### PR TITLE
feat(opennebula): support ETHx_ROUTES static routes in network config

### DIFF
--- a/cloudinit/sources/DataSourceOpenNebula.py
+++ b/cloudinit/sources/DataSourceOpenNebula.py
@@ -228,6 +228,28 @@ class OpenNebulaNetwork:
     def get_mask(self, dev: str) -> str:
         return self.get_field(dev, "mask", "255.255.255.0")
 
+    def get_routes(self, dev: str) -> List[Dict[str, str]]:
+        """Parse ETHx_ROUTES into a list of Netplan route dicts.
+
+        Expected format: "NETWORK via GATEWAY[, NETWORK via GATEWAY, ...]"
+        e.g. "10.0.0.0/8 via 192.168.1.1, 192.168.100.0/24 via 10.0.0.1"
+        Returns an empty list when the variable is absent or empty.
+        """
+        raw = self.get_field(dev, "routes", "")
+        routes: List[Dict[str, str]] = []
+        for entry in raw.split(","):
+            entry = entry.strip()
+            if not entry:
+                continue
+            parts = entry.split()
+            if len(parts) == 3 and parts[1].lower() == "via":
+                routes.append({"to": parts[0], "via": parts[2]})
+            else:
+                LOG.warning(
+                    "Unparseable ETHx_ROUTES entry for %s: %r", dev, entry
+                )
+        return routes
+
     @overload
     def get_field(self, dev: str, name: str) -> Optional[str]: ...
     @overload
@@ -303,6 +325,11 @@ class OpenNebulaNetwork:
             mtu = self.get_mtu(c_dev)
             if mtu:
                 devconf["mtu"] = mtu
+
+            # Set static routes
+            extra_routes: List[Dict[str, str]] = self.get_routes(c_dev)
+            if extra_routes:
+                devconf["routes"] = extra_routes
 
             ethernets[dev] = devconf
 

--- a/cloudinit/sources/DataSourceOpenNebula.py
+++ b/cloudinit/sources/DataSourceOpenNebula.py
@@ -228,6 +228,30 @@ class OpenNebulaNetwork:
     def get_mask(self, dev: str) -> str:
         return self.get_field(dev, "mask", "255.255.255.0")
 
+    def get_routes(self, dev: str) -> List[Dict[str, str]]:
+        """Parse ETHx_ROUTES into a list of Netplan route dicts.
+
+        Expected format: "NETWORK via GATEWAY[, NETWORK via GATEWAY, ...]"
+        e.g. "10.0.0.0/8 via 192.168.1.1, 192.168.100.0/24 via 10.0.0.1"
+        Returns an empty list when the variable is absent or empty.
+        """
+        routes: List[Dict[str, str]] = []
+        for entry in self.get_field(dev, "routes", "").split(","):
+            entry = entry.strip()
+            if not entry:
+                continue
+            m = re.match(
+                r"\s*(?P<route_to>\S+)\s+via\s+(?P<route_via>\S+)\s*$",
+                entry,
+            )
+            if m:
+                routes.append({"to": m["route_to"], "via": m["route_via"]})
+            else:
+                LOG.warning(
+                    "Unparseable ETHx_ROUTES entry for %s: %r", dev, entry
+                )
+        return routes
+
     @overload
     def get_field(self, dev: str, name: str) -> Optional[str]: ...
     @overload
@@ -303,6 +327,11 @@ class OpenNebulaNetwork:
             mtu = self.get_mtu(c_dev)
             if mtu:
                 devconf["mtu"] = mtu
+
+            # Set static routes
+            extra_routes: List[Dict[str, str]] = self.get_routes(c_dev)
+            if extra_routes:
+                devconf["routes"] = extra_routes
 
             ethernets[dev] = devconf
 

--- a/doc/rtd/reference/datasources/opennebula.rst
+++ b/doc/rtd/reference/datasources/opennebula.rst
@@ -72,8 +72,14 @@ the OpenNebula documentation.
     ETH<x>_IP6_ULA
     ETH<x>_IP6_PREFIX_LENGTH
     ETH<x>_IP6_GATEWAY
+    ETH<x>_ROUTES
 
 Static `network configuration`_.
+
+``ETH<x>_ROUTES`` is a comma-separated list of static routes in the form
+``NETWORK via GATEWAY``. For example::
+
+    ETH0_ROUTES="10.0.0.0/8 via 192.168.1.1, 172.16.0.0/12 via 192.168.1.254"
 
 ::
 

--- a/doc/rtd/reference/datasources/opennebula.rst
+++ b/doc/rtd/reference/datasources/opennebula.rst
@@ -72,8 +72,14 @@ the OpenNebula documentation.
     ETH<x>_IP6_ULA
     ETH<x>_IP6_PREFIX_LENGTH
     ETH<x>_IP6_GATEWAY
+    ETH<x>_ROUTES
 
 Static `network configuration`_.
+
+``ETH<x>_ROUTES`` is a comma-separated list of static routes in the form
+``NETWORK via GATEWAY``. For example::
+
+    ETH0_ROUTES="10.0.0.0/8 via 192.168.1.1, 172.16.0.0/12 via 192.168.1.254"
 
 ::
 
@@ -146,5 +152,5 @@ Example VM's context section
 .. _OpenNebula: http://opennebula.org/
 .. _contextualization overview: http://opennebula.org/documentation:documentation:context_overview
 .. _contextualizing VMs: http://opennebula.org/documentation:documentation:cong
-.. _network configuration: https://docs.opennebula.io/
+.. _network configuration: https://docs.opennebula.io/7.2/product/operation_references/configuration_references/template/#context-section
 .. _iso9660: https://en.wikipedia.org/wiki/ISO_9660

--- a/tests/unittests/sources/test_opennebula.py
+++ b/tests/unittests/sources/test_opennebula.py
@@ -975,6 +975,87 @@ class TestOpenNebulaNetwork:
 
         assert expected == net.gen_conf()
 
+    # ------------------------------------------------------------------ #
+    # ETHx_ROUTES                                                          #
+    # ------------------------------------------------------------------ #
+
+    def test_get_routes_absent(self):
+        """get_routes returns empty list when ETHx_ROUTES is not set."""
+        net = ds.OpenNebulaNetwork({}, mock.Mock())
+        assert net.get_routes("eth0") == []
+
+    def test_get_routes_empty_string(self):
+        """get_routes returns empty list when ETHx_ROUTES is empty string."""
+        net = ds.OpenNebulaNetwork({"ETH0_ROUTES": ""}, mock.Mock())
+        assert net.get_routes("eth0") == []
+
+    def test_get_routes_single(self):
+        """get_routes parses a single 'NETWORK via GATEWAY' entry."""
+        net = ds.OpenNebulaNetwork(
+            {"ETH0_ROUTES": "10.0.0.0/8 via 192.168.1.1"}, mock.Mock()
+        )
+        assert net.get_routes("eth0") == [
+            {"to": "10.0.0.0/8", "via": "192.168.1.1"}
+        ]
+
+    def test_get_routes_multiple(self):
+        """get_routes parses multiple comma-separated entries."""
+        net = ds.OpenNebulaNetwork(
+            {
+                "ETH0_ROUTES": (
+                    "10.0.0.0/8 via 192.168.1.1,"
+                    " 172.16.0.0/12 via 192.168.1.254"
+                )
+            },
+            mock.Mock(),
+        )
+        assert net.get_routes("eth0") == [
+            {"to": "10.0.0.0/8", "via": "192.168.1.1"},
+            {"to": "172.16.0.0/12", "via": "192.168.1.254"},
+        ]
+
+    def test_get_routes_malformed_entry_skipped(self):
+        """get_routes silently skips entries it cannot parse."""
+        net = ds.OpenNebulaNetwork(
+            {"ETH0_ROUTES": "bad-entry, 10.0.0.0/8 via 192.168.1.1"},
+            mock.Mock(),
+        )
+        assert net.get_routes("eth0") == [
+            {"to": "10.0.0.0/8", "via": "192.168.1.1"}
+        ]
+
+    @mock.patch(DS_PATH + ".get_physical_nics_by_mac")
+    def test_gen_conf_routes(self, m_get_phys_by_mac):
+        """Routes from ETHx_ROUTES appear in gen_conf() output."""
+        self.maxDiff = None
+        context = {
+            "ETH0_MAC": "02:00:0a:12:01:01",
+            "ETH0_IP": "10.0.0.5",
+            "ETH0_MASK": "255.255.255.0",
+            "ETH0_GATEWAY": "10.0.0.1",
+            "ETH0_ROUTES": (
+                "192.168.0.0/16 via 10.0.0.1, 172.16.0.0/12 via 10.0.0.1"
+            ),
+        }
+        for nic in self.system_nics:
+            m_get_phys_by_mac.return_value = {MACADDR: nic}
+            net = ds.OpenNebulaNetwork(context, mock.Mock())
+            conf = net.gen_conf()
+            routes = conf["ethernets"][nic].get("routes", [])
+            assert {"to": "192.168.0.0/16", "via": "10.0.0.1"} in routes
+            assert {"to": "172.16.0.0/12", "via": "10.0.0.1"} in routes
+
+    @mock.patch(DS_PATH + ".get_physical_nics_by_mac")
+    def test_gen_conf_no_routes_key_when_absent(self, m_get_phys_by_mac):
+        """gen_conf() does not emit 'routes' key when ETHx_ROUTES is unset."""
+        context = {
+            "ETH0_MAC": "02:00:0a:12:01:01",
+        }
+        m_get_phys_by_mac.return_value = {MACADDR: "eth0"}
+        net = ds.OpenNebulaNetwork(context, mock.Mock())
+        conf = net.gen_conf()
+        assert "routes" not in conf["ethernets"]["eth0"]
+
 
 class TestParseShellConfig:
     @pytest.mark.allow_subp_for("bash", "sh")

--- a/tests/unittests/sources/test_opennebula.py
+++ b/tests/unittests/sources/test_opennebula.py
@@ -975,6 +975,76 @@ class TestOpenNebulaNetwork:
 
         assert expected == net.gen_conf()
 
+    # ------------------------------------------------------------------ #
+    # ETHx_ROUTES                                                          #
+    # ------------------------------------------------------------------ #
+
+    @pytest.mark.parametrize(
+        "context,expected",
+        [
+            pytest.param({}, [], id="absent"),
+            pytest.param({"ETH0_ROUTES": ""}, [], id="empty_string"),
+            pytest.param(
+                {"ETH0_ROUTES": "10.0.0.0/8 via 192.168.1.1"},
+                [{"to": "10.0.0.0/8", "via": "192.168.1.1"}],
+                id="single_entry",
+            ),
+            pytest.param(
+                {
+                    "ETH0_ROUTES": (
+                        "10.0.0.0/8 via 192.168.1.1,"
+                        " 172.16.0.0/12 via 192.168.1.254"
+                    )
+                },
+                [
+                    {"to": "10.0.0.0/8", "via": "192.168.1.1"},
+                    {"to": "172.16.0.0/12", "via": "192.168.1.254"},
+                ],
+                id="multiple_comma_separated_entries",
+            ),
+            pytest.param(
+                {"ETH0_ROUTES": "bad-entry, 10.0.0.0/8 via 192.168.1.1"},
+                [{"to": "10.0.0.0/8", "via": "192.168.1.1"}],
+                id="malformed_entry_skipped",
+            ),
+        ],
+    )
+    def test_get_routes(self, context, expected):
+        net = ds.OpenNebulaNetwork(context, mock.Mock())
+        assert net.get_routes("eth0") == expected
+
+    @mock.patch(DS_PATH + ".get_physical_nics_by_mac")
+    def test_gen_conf_routes(self, m_get_phys_by_mac):
+        """Routes from ETHx_ROUTES appear in gen_conf() output."""
+        self.maxDiff = None
+        context = {
+            "ETH0_MAC": "02:00:0a:12:01:01",
+            "ETH0_IP": "10.0.0.5",
+            "ETH0_MASK": "255.255.255.0",
+            "ETH0_GATEWAY": "10.0.0.1",
+            "ETH0_ROUTES": (
+                "192.168.0.0/16 via 10.0.0.1, 172.16.0.0/12 via 10.0.0.1"
+            ),
+        }
+        for nic in self.system_nics:
+            m_get_phys_by_mac.return_value = {MACADDR: nic}
+            net = ds.OpenNebulaNetwork(context, mock.Mock())
+            conf = net.gen_conf()
+            routes = conf["ethernets"][nic].get("routes", [])
+            assert {"to": "192.168.0.0/16", "via": "10.0.0.1"} in routes
+            assert {"to": "172.16.0.0/12", "via": "10.0.0.1"} in routes
+
+    @mock.patch(DS_PATH + ".get_physical_nics_by_mac")
+    def test_gen_conf_no_routes_key_when_absent(self, m_get_phys_by_mac):
+        """gen_conf() does not emit 'routes' key when ETHx_ROUTES is unset."""
+        context = {
+            "ETH0_MAC": "02:00:0a:12:01:01",
+        }
+        m_get_phys_by_mac.return_value = {MACADDR: "eth0"}
+        net = ds.OpenNebulaNetwork(context, mock.Mock())
+        conf = net.gen_conf()
+        assert "routes" not in conf["ethernets"]["eth0"]
+
 
 class TestParseShellConfig:
     @pytest.mark.allow_subp_for("bash", "sh")


### PR DESCRIPTION
## Proposed Commit Message

```
feat(opennebula): support ETHx_ROUTES static routes in network config

Add `get_routes()` to `OpenNebulaNetwork` to parse the `ETHx_ROUTES`
context variable (format: "NETWORK via GATEWAY, ...") and emit the
resulting routes into the Netplan v2 `routes:` list in `gen_conf()`.

Malformed entries are skipped with a warning. No `routes` key is
emitted when the variable is absent or empty, preserving backward
compatibility.
```

## Additional Context

The OpenNebula `context-linux` package (one-apps) supports `ETHx_ROUTES`
to configure static routes per interface. cloud-init's OpenNebula
datasource was silently ignoring this variable, meaning any static
routes defined in the VM template were never applied.

## Test Steps

On an OpenNebula VM, add to the VM template context section:

```
ETH0_ROUTES="10.0.0.0/8 via 192.168.1.1, 172.16.0.0/12 via 192.168.1.254"
```

After boot, verify the routes were applied:

```sh
ip route show
# expected: routes to 10.0.0.0/8 and 172.16.0.0/12 via 192.168.1.x
```

Also verify that a VM with no `ETHx_ROUTES` set continues to boot and
configure networking without any change in behaviour.

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)