### PR TITLE
feat(opennebula): support ETHx_METRIC for default route priority

### DIFF
--- a/cloudinit/sources/DataSourceOpenNebula.py
+++ b/cloudinit/sources/DataSourceOpenNebula.py
@@ -228,6 +228,9 @@ class OpenNebulaNetwork:
     def get_mask(self, dev: str) -> str:
         return self.get_field(dev, "mask", "255.255.255.0")
 
+    def get_metric(self, dev: str) -> Optional[str]:
+        return self.get_field(dev, "metric")
+
     @overload
     def get_field(self, dev: str, name: str) -> Optional[str]: ...
     @overload
@@ -285,9 +288,21 @@ class OpenNebulaNetwork:
                 )
 
             # Set IPv4 default gateway
+            # When a metric is specified, emit an explicit route so the metric
+            # can be attached to it. Otherwise use the simpler gateway4 key.
             gateway = self.get_gateway(c_dev)
+            metric: Optional[str] = self.get_metric(c_dev)
             if gateway:
-                devconf["gateway4"] = gateway
+                if metric is not None:
+                    devconf.setdefault("routes", []).append(
+                        {
+                            "to": "default",
+                            "via": gateway,
+                            "metric": int(metric),
+                        }
+                    )
+                else:
+                    devconf["gateway4"] = gateway
 
             # Set IPv6 default gateway
             gateway6 = self.get_gateway6(c_dev)

--- a/cloudinit/sources/DataSourceOpenNebula.py
+++ b/cloudinit/sources/DataSourceOpenNebula.py
@@ -327,13 +327,23 @@ class OpenNebulaNetwork:
             # can be attached to it. Otherwise use the simpler gateway4 key.
             gateway = self.get_gateway(c_dev)
             metric: Optional[str] = self.get_metric(c_dev)
+            metric_int: Optional[int] = None
+            if metric is not None:
+                try:
+                    metric_int = int(metric)
+                except ValueError:
+                    LOG.warning(
+                        "Ignoring unparseable %s_METRIC: %r",
+                        c_dev.upper(),
+                        metric,
+                    )
             if gateway:
-                if metric is not None:
+                if metric_int is not None:
                     devconf.setdefault("routes", []).append(
                         {
                             "to": "default",
                             "via": gateway,
-                            "metric": int(metric),
+                            "metric": metric_int,
                         }
                     )
                 else:

--- a/cloudinit/sources/DataSourceOpenNebula.py
+++ b/cloudinit/sources/DataSourceOpenNebula.py
@@ -263,6 +263,9 @@ class OpenNebulaNetwork:
                 )
         return routes
 
+    def get_metric(self, dev: str) -> Optional[str]:
+        return self.get_field(dev, "metric")
+
     @overload
     def get_field(self, dev: str, name: str) -> Optional[str]: ...
     @overload
@@ -320,9 +323,21 @@ class OpenNebulaNetwork:
                 )
 
             # Set IPv4 default gateway
+            # When a metric is specified, emit an explicit route so the metric
+            # can be attached to it. Otherwise use the simpler gateway4 key.
             gateway = self.get_gateway(c_dev)
+            metric: Optional[str] = self.get_metric(c_dev)
             if gateway:
-                devconf["gateway4"] = gateway
+                if metric is not None:
+                    devconf.setdefault("routes", []).append(
+                        {
+                            "to": "default",
+                            "via": gateway,
+                            "metric": int(metric),
+                        }
+                    )
+                else:
+                    devconf["gateway4"] = gateway
 
             # Set IPv6 default gateway
             gateway6 = self.get_gateway6(c_dev)
@@ -342,7 +357,7 @@ class OpenNebulaNetwork:
             # Set static routes
             extra_routes: List[Dict[str, str]] = self.get_routes(c_dev)
             if extra_routes:
-                devconf["routes"] = extra_routes
+                devconf.setdefault("routes", []).extend(extra_routes)
 
             ethernets[dev] = devconf
 

--- a/doc/rtd/reference/datasources/opennebula.rst
+++ b/doc/rtd/reference/datasources/opennebula.rst
@@ -68,12 +68,19 @@ the OpenNebula documentation.
     ETH<x>_DNS
     ETH<x>_SEARCH_DOMAIN
     ETH<x>_MTU
+    ETH<x>_METRIC
     ETH<x>_IP6
     ETH<x>_IP6_ULA
     ETH<x>_IP6_PREFIX_LENGTH
     ETH<x>_IP6_GATEWAY
 
 Static `network configuration`_.
+
+When ``ETH<x>_METRIC`` is set, the default gateway is expressed as an explicit
+route with that metric value rather than the simple ``gateway4`` key. This
+allows correct route priority on multi-homed VMs. For example, setting
+``ETH0_METRIC=0`` and ``ETH1_METRIC=1`` makes interface 0 the preferred
+default route.
 
 ::
 

--- a/doc/rtd/reference/datasources/opennebula.rst
+++ b/doc/rtd/reference/datasources/opennebula.rst
@@ -69,6 +69,7 @@ the OpenNebula documentation.
     ETH<x>_DNS
     ETH<x>_SEARCH_DOMAIN
     ETH<x>_MTU
+    ETH<x>_METRIC
     ETH<x>_IP6
     ETH<x>_IP6_ULA
     ETH<x>_IP6_PREFIX_LENGTH
@@ -86,6 +87,12 @@ duplicate entries across both levels are suppressed.
 ``NETWORK via GATEWAY``. For example::
 
     ETH0_ROUTES="10.0.0.0/8 via 192.168.1.1, 172.16.0.0/12 via 192.168.1.254"
+
+When ``ETH<x>_METRIC`` is set, the default gateway is expressed as an explicit
+route with that metric value rather than the simple ``gateway4`` key. This
+allows correct route priority on multi-homed VMs. For example, setting
+``ETH0_METRIC=0`` and ``ETH1_METRIC=1`` makes interface 0 the preferred
+default route.
 
 ::
 

--- a/tests/unittests/sources/test_opennebula.py
+++ b/tests/unittests/sources/test_opennebula.py
@@ -975,6 +975,114 @@ class TestOpenNebulaNetwork:
 
         assert expected == net.gen_conf()
 
+    # ------------------------------------------------------------------ #
+    # ETHx_METRIC                                                          #
+    # ------------------------------------------------------------------ #
+
+    def test_get_metric_absent(self):
+        """get_metric returns None when ETHx_METRIC is not set."""
+        net = ds.OpenNebulaNetwork({}, mock.Mock())
+        assert net.get_metric("eth0") is None
+
+    def test_get_metric_set(self):
+        """get_metric returns the value string when ETHx_METRIC is set."""
+        net = ds.OpenNebulaNetwork({"ETH0_METRIC": "1"}, mock.Mock())
+        assert net.get_metric("eth0") == "1"
+
+    def test_get_metric_zero(self):
+        """get_metric returns '0' when ETHx_METRIC is explicitly zero."""
+        net = ds.OpenNebulaNetwork({"ETH0_METRIC": "0"}, mock.Mock())
+        assert net.get_metric("eth0") == "0"
+
+    @mock.patch(DS_PATH + ".get_physical_nics_by_mac")
+    def test_gen_conf_metric_replaces_gateway4(self, m_get_phys_by_mac):
+        """When metric is set, gateway is emitted as an explicit route."""
+        context = {
+            "ETH0_MAC": MACADDR,
+            "ETH0_IP": PUBLIC_IP,
+            "ETH0_GATEWAY": "10.0.0.1",
+            "ETH0_METRIC": "100",
+        }
+        m_get_phys_by_mac.return_value = {MACADDR: "eth0"}
+        net = ds.OpenNebulaNetwork(context, mock.Mock())
+        conf = net.gen_conf()
+        eth0 = conf["ethernets"]["eth0"]
+        assert "gateway4" not in eth0
+        expected_route = {"to": "default", "via": "10.0.0.1", "metric": 100}
+        assert expected_route in eth0["routes"]
+
+    @mock.patch(DS_PATH + ".get_physical_nics_by_mac")
+    def test_gen_conf_metric_zero(self, m_get_phys_by_mac):
+        """Metric value '0' is emitted as integer 0 in the route."""
+        context = {
+            "ETH0_MAC": MACADDR,
+            "ETH0_IP": PUBLIC_IP,
+            "ETH0_GATEWAY": "10.0.0.1",
+            "ETH0_METRIC": "0",
+        }
+        m_get_phys_by_mac.return_value = {MACADDR: "eth0"}
+        net = ds.OpenNebulaNetwork(context, mock.Mock())
+        conf = net.gen_conf()
+        eth0 = conf["ethernets"]["eth0"]
+        assert "gateway4" not in eth0
+        expected_route = {"to": "default", "via": "10.0.0.1", "metric": 0}
+        assert expected_route in eth0["routes"]
+
+    @mock.patch(DS_PATH + ".get_physical_nics_by_mac")
+    def test_gen_conf_no_metric_uses_gateway4(self, m_get_phys_by_mac):
+        """Without ETHx_METRIC the gateway4 key is used (no regression)."""
+        context = {
+            "ETH0_MAC": MACADDR,
+            "ETH0_IP": PUBLIC_IP,
+            "ETH0_GATEWAY": "10.0.0.1",
+        }
+        m_get_phys_by_mac.return_value = {MACADDR: "eth0"}
+        net = ds.OpenNebulaNetwork(context, mock.Mock())
+        conf = net.gen_conf()
+        eth0 = conf["ethernets"]["eth0"]
+        assert eth0["gateway4"] == "10.0.0.1"
+        assert "routes" not in eth0
+
+    @mock.patch(DS_PATH + ".get_physical_nics_by_mac")
+    def test_gen_conf_metric_without_gateway(self, m_get_phys_by_mac):
+        """Metric set but no gateway: no routes list, no gateway4 key."""
+        context = {
+            "ETH0_MAC": MACADDR,
+            "ETH0_IP": PUBLIC_IP,
+            "ETH0_METRIC": "10",
+        }
+        m_get_phys_by_mac.return_value = {MACADDR: "eth0"}
+        net = ds.OpenNebulaNetwork(context, mock.Mock())
+        conf = net.gen_conf()
+        eth0 = conf["ethernets"]["eth0"]
+        assert "gateway4" not in eth0
+        assert "routes" not in eth0
+
+    @mock.patch(DS_PATH + ".get_physical_nics_by_mac")
+    def test_gen_conf_multi_nic_different_metrics(self, m_get_phys_by_mac):
+        """Each NIC gets its own metric in its own explicit route."""
+        MAC_1 = "02:00:0a:12:01:01"
+        MAC_2 = "02:00:0a:12:01:02"
+        context = {
+            "ETH0_MAC": MAC_1,
+            "ETH0_IP": "10.0.0.5",
+            "ETH0_GATEWAY": "10.0.0.1",
+            "ETH0_METRIC": "0",
+            "ETH1_MAC": MAC_2,
+            "ETH1_IP": "185.70.43.5",
+            "ETH1_GATEWAY": "185.70.43.1",
+            "ETH1_METRIC": "1",
+        }
+        m_get_phys_by_mac.return_value = {MAC_1: "eth0", MAC_2: "eth1"}
+        net = ds.OpenNebulaNetwork(context, mock.Mock())
+        conf = net.gen_conf()
+        assert {"to": "default", "via": "10.0.0.1", "metric": 0} in (
+            conf["ethernets"]["eth0"]["routes"]
+        )
+        assert {"to": "default", "via": "185.70.43.1", "metric": 1} in (
+            conf["ethernets"]["eth1"]["routes"]
+        )
+
 
 class TestParseShellConfig:
     @pytest.mark.allow_subp_for("bash", "sh")

--- a/tests/unittests/sources/test_opennebula.py
+++ b/tests/unittests/sources/test_opennebula.py
@@ -1140,6 +1140,134 @@ class TestOpenNebulaNetwork:
         conf = net.gen_conf()
         assert "routes" not in conf["ethernets"]["eth0"]
 
+    # ------------------------------------------------------------------ #
+    # ETHx_METRIC                                                          #
+    # ------------------------------------------------------------------ #
+
+    def test_get_metric_absent(self):
+        """get_metric returns None when ETHx_METRIC is not set."""
+        net = ds.OpenNebulaNetwork({}, mock.Mock())
+        assert net.get_metric("eth0") is None
+
+    def test_get_metric_set(self):
+        """get_metric returns the value string when ETHx_METRIC is set."""
+        net = ds.OpenNebulaNetwork({"ETH0_METRIC": "1"}, mock.Mock())
+        assert net.get_metric("eth0") == "1"
+
+    def test_get_metric_zero(self):
+        """get_metric returns '0' when ETHx_METRIC is explicitly zero."""
+        net = ds.OpenNebulaNetwork({"ETH0_METRIC": "0"}, mock.Mock())
+        assert net.get_metric("eth0") == "0"
+
+    @mock.patch(DS_PATH + ".get_physical_nics_by_mac")
+    def test_gen_conf_metric_replaces_gateway4(self, m_get_phys_by_mac):
+        """When metric is set, gateway is emitted as an explicit route."""
+        context = {
+            "ETH0_MAC": MACADDR,
+            "ETH0_IP": PUBLIC_IP,
+            "ETH0_GATEWAY": "10.0.0.1",
+            "ETH0_METRIC": "100",
+        }
+        m_get_phys_by_mac.return_value = {MACADDR: "eth0"}
+        net = ds.OpenNebulaNetwork(context, mock.Mock())
+        conf = net.gen_conf()
+        eth0 = conf["ethernets"]["eth0"]
+        assert "gateway4" not in eth0
+        expected_route = {"to": "default", "via": "10.0.0.1", "metric": 100}
+        assert expected_route in eth0["routes"]
+
+    @mock.patch(DS_PATH + ".get_physical_nics_by_mac")
+    def test_gen_conf_metric_zero(self, m_get_phys_by_mac):
+        """Metric value '0' is emitted as integer 0 in the route."""
+        context = {
+            "ETH0_MAC": MACADDR,
+            "ETH0_IP": PUBLIC_IP,
+            "ETH0_GATEWAY": "10.0.0.1",
+            "ETH0_METRIC": "0",
+        }
+        m_get_phys_by_mac.return_value = {MACADDR: "eth0"}
+        net = ds.OpenNebulaNetwork(context, mock.Mock())
+        conf = net.gen_conf()
+        eth0 = conf["ethernets"]["eth0"]
+        assert "gateway4" not in eth0
+        expected_route = {"to": "default", "via": "10.0.0.1", "metric": 0}
+        assert expected_route in eth0["routes"]
+
+    @mock.patch(DS_PATH + ".get_physical_nics_by_mac")
+    def test_gen_conf_no_metric_uses_gateway4(self, m_get_phys_by_mac):
+        """Without ETHx_METRIC the gateway4 key is used (no regression)."""
+        context = {
+            "ETH0_MAC": MACADDR,
+            "ETH0_IP": PUBLIC_IP,
+            "ETH0_GATEWAY": "10.0.0.1",
+        }
+        m_get_phys_by_mac.return_value = {MACADDR: "eth0"}
+        net = ds.OpenNebulaNetwork(context, mock.Mock())
+        conf = net.gen_conf()
+        eth0 = conf["ethernets"]["eth0"]
+        assert eth0["gateway4"] == "10.0.0.1"
+        assert "routes" not in eth0
+
+    @mock.patch(DS_PATH + ".get_physical_nics_by_mac")
+    def test_gen_conf_metric_without_gateway(self, m_get_phys_by_mac):
+        """Metric set but no gateway: no routes list, no gateway4 key."""
+        context = {
+            "ETH0_MAC": MACADDR,
+            "ETH0_IP": PUBLIC_IP,
+            "ETH0_METRIC": "10",
+        }
+        m_get_phys_by_mac.return_value = {MACADDR: "eth0"}
+        net = ds.OpenNebulaNetwork(context, mock.Mock())
+        conf = net.gen_conf()
+        eth0 = conf["ethernets"]["eth0"]
+        assert "gateway4" not in eth0
+        assert "routes" not in eth0
+
+    @mock.patch(DS_PATH + ".get_physical_nics_by_mac")
+    def test_gen_conf_metric_and_routes_both_present(self, m_get_phys_by_mac):
+        """METRIC and ROUTES both set: default and static routes coexist."""
+        context = {
+            "ETH0_MAC": MACADDR,
+            "ETH0_IP": PUBLIC_IP,
+            "ETH0_GATEWAY": "10.0.0.1",
+            "ETH0_METRIC": "100",
+            "ETH0_ROUTES": "192.168.1.0/24 via 10.0.0.254",
+        }
+        m_get_phys_by_mac.return_value = {MACADDR: "eth0"}
+        net = ds.OpenNebulaNetwork(context, mock.Mock())
+        conf = net.gen_conf()
+        routes = conf["ethernets"]["eth0"]["routes"]
+        assert {"to": "default", "via": "10.0.0.1", "metric": 100} in routes
+        assert {
+            "to": "192.168.1.0/24",
+            "via": "10.0.0.254",
+        } in routes
+
+    @mock.patch(DS_PATH + ".get_physical_nics_by_mac")
+    def test_gen_conf_multi_nic_different_metrics(self, m_get_phys_by_mac):
+        """Each NIC gets its own metric in its own explicit route."""
+        MAC_1 = "02:00:0a:12:01:01"
+        MAC_2 = "02:00:0a:12:01:02"
+        context = {
+            "ETH0_MAC": MAC_1,
+            "ETH0_IP": "10.0.0.5",
+            "ETH0_GATEWAY": "10.0.0.1",
+            "ETH0_METRIC": "0",
+            "ETH1_MAC": MAC_2,
+            "ETH1_IP": "185.70.43.5",
+            "ETH1_GATEWAY": "185.70.43.1",
+            "ETH1_METRIC": "1",
+        }
+        m_get_phys_by_mac.return_value = {MAC_1: "eth0", MAC_2: "eth1"}
+        net = ds.OpenNebulaNetwork(context, mock.Mock())
+        conf = net.gen_conf()
+        assert {"to": "default", "via": "10.0.0.1", "metric": 0} in (
+            conf["ethernets"]["eth0"]["routes"]
+        )
+        assert {"to": "default", "via": "185.70.43.1", "metric": 1} in (
+            conf["ethernets"]["eth1"]["routes"]
+        )
+
 
 class TestParseShellConfig:
     @pytest.mark.allow_subp_for("bash", "sh")

--- a/tests/unittests/sources/test_opennebula.py
+++ b/tests/unittests/sources/test_opennebula.py
@@ -1,6 +1,7 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 # pylint: disable=attribute-defined-outside-init
 
+import logging
 import os
 import pwd
 from unittest import mock
@@ -1207,6 +1208,28 @@ class TestOpenNebulaNetwork:
         eth0 = conf["ethernets"]["eth0"]
         assert eth0["gateway4"] == "10.0.0.1"
         assert "routes" not in eth0
+
+    @mock.patch(DS_PATH + ".get_physical_nics_by_mac")
+    def test_gen_conf_unparseable_metric_falls_back_to_gateway4(
+        self, m_get_phys_by_mac, caplog
+    ):
+        """Non-integer ETHx_METRIC is ignored with a warning, falling back
+        to gateway4 instead of aborting config generation."""
+        context = {
+            "ETH0_MAC": MACADDR,
+            "ETH0_IP": PUBLIC_IP,
+            "ETH0_GATEWAY": "10.0.0.1",
+            "ETH0_METRIC": "not-a-number",
+        }
+        m_get_phys_by_mac.return_value = {MACADDR: "eth0"}
+        net = ds.OpenNebulaNetwork(context, mock.Mock())
+        conf = net.gen_conf()
+        eth0 = conf["ethernets"]["eth0"]
+        assert eth0["gateway4"] == "10.0.0.1"
+        assert "routes" not in eth0
+        warnings = [r for r in caplog.record_tuples if r[1] == logging.WARNING]
+        assert len(warnings) == 1
+        assert "ETH0_METRIC" in warnings[0][2]
 
     @mock.patch(DS_PATH + ".get_physical_nics_by_mac")
     def test_gen_conf_metric_without_gateway(self, m_get_phys_by_mac):


### PR DESCRIPTION
## Proposed Commit Message

```
feat(opennebula): support ETHx_METRIC for default route priority

Add `get_metric()` to `OpenNebulaNetwork` and use it in `gen_conf()`.
When `ETHx_METRIC` is set, the default gateway is emitted as an explicit
Netplan v2 `routes:` entry with the metric attached, rather than the
simpler `gateway4:` key. When the variable is absent the existing
`gateway4:` behaviour is preserved.

This allows correct route priority on multi-homed VMs: setting
`ETH0_METRIC=0` and `ETH1_METRIC=1` ensures interface 0 is the
preferred default route.
```

## Additional Context

The OpenNebula `context-linux` package (one-apps) supports `ETHx_METRIC`
to set the route metric for the default gateway on each interface.
Without this, multi-homed VMs (common in OpenNebula deployments using
tools like netbox-network-config) have no way to express route priority
and the kernel picks an arbitrary default route.

The fix is minimal: when `ETHx_METRIC` is present the `gateway4:` key is
replaced by an explicit `routes:` entry carrying the metric. When the
variable is absent behaviour is identical to before.

## Test Steps

On a multi-homed OpenNebula VM, add to the VM template context:

```
ETH0_GATEWAY="10.0.0.1"
ETH0_METRIC="0"
ETH1_GATEWAY="185.70.43.1"
ETH1_METRIC="1"
```

After boot, verify route priorities:

```sh
ip route show
# expected: default via 10.0.0.1 dev eth0 metric 0
#           default via 185.70.43.1 dev eth1 metric 1
```

Also verify that a VM with no `ETHx_METRIC` set continues to produce
`gateway4:` in its Netplan config without any change in behaviour.

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)