### PR TITLE
feat(opennebula): support ETHx_ALIASn_IP/MASK for anycast addresses

### DIFF
--- a/cloudinit/sources/DataSourceOpenNebula.py
+++ b/cloudinit/sources/DataSourceOpenNebula.py
@@ -233,6 +233,28 @@ class OpenNebulaNetwork:
         # allow empty string to return the default.
         return default if val in (None, "") else val
 
+    def get_alias_addresses(self, c_dev, mac):
+        """Return list of alias IP/prefix strings for context device c_dev.
+
+        Scans context for ETHx_ALIASn_IP / ETHx_ALIASn_MASK keys, where x
+        matches c_dev (e.g. 'ETH0').  Missing MASK defaults to /32.
+        Stops at the first gap in the alias index sequence.
+        """
+        aliases = []
+        prefix = c_dev.upper() + "_ALIAS"
+        idx = 0
+        while True:
+            ip_key = "%s%d_IP" % (prefix, idx)
+            ip = self.context.get(ip_key)
+            if not ip:
+                break
+            mask_key = "%s%d_MASK" % (prefix, idx)
+            mask = self.context.get(mask_key) or "255.255.255.255"
+            net_prefix = str(net.ipv4_mask_to_net_prefix(mask))
+            aliases.append("%s/%s" % (ip, net_prefix))
+            idx += 1
+        return aliases
+
     def gen_conf(self):
         netconf = {}
         netconf["version"] = 2
@@ -256,6 +278,11 @@ class OpenNebulaNetwork:
             mask = self.get_mask(c_dev)
             prefix = str(net.ipv4_mask_to_net_prefix(mask))
             devconf["addresses"].append(self.get_ip(c_dev, mac) + "/" + prefix)
+
+            # Set alias (anycast) IPv4 addresses
+            alias_addresses = self.get_alias_addresses(c_dev, mac)
+            if alias_addresses:
+                devconf["addresses"].extend(alias_addresses)
 
             # Set IPv6 Global and ULA address
             addresses6 = self.get_ip6(c_dev)

--- a/doc/rtd/reference/datasources/opennebula.rst
+++ b/doc/rtd/reference/datasources/opennebula.rst
@@ -77,6 +77,16 @@ Static `network configuration`_.
 
 ::
 
+    ETH<x>_ALIAS<n>_IP
+    ETH<x>_ALIAS<n>_MASK
+
+Additional (anycast) IPv4 addresses for interface ``ETH<x>``. Aliases are
+numbered from 0 (e.g. ``ETH0_ALIAS0_IP``, ``ETH0_ALIAS1_IP``, …). The
+``MASK`` field defaults to ``255.255.255.255`` (``/32``) when absent. All
+alias addresses are added to the interface alongside the primary address.
+
+::
+
     SET_HOSTNAME
     HOSTNAME
 

--- a/tests/unittests/sources/test_opennebula.py
+++ b/tests/unittests/sources/test_opennebula.py
@@ -986,6 +986,118 @@ class TestOpenNebulaNetwork:
 
         assert expected == net.gen_conf()
 
+    @mock.patch(DS_PATH + ".get_physical_nics_by_mac")
+    def test_get_alias_addresses_single(self, m_get_phys_by_mac):
+        """Single alias on ETH0 produces one extra address."""
+        context = {
+            "ETH0_MAC": MACADDR,
+            "ETH0_ALIAS0_IP": "192.168.1.10",
+            "ETH0_ALIAS0_MASK": "255.255.255.0",
+        }
+        m_get_phys_by_mac.return_value = {MACADDR: "eth0"}
+        net = ds.OpenNebulaNetwork(context, mock.Mock())
+        aliases = net.get_alias_addresses("ETH0", MACADDR)
+        assert aliases == ["192.168.1.10/24"]
+
+    @mock.patch(DS_PATH + ".get_physical_nics_by_mac")
+    def test_get_alias_addresses_multiple(self, m_get_phys_by_mac):
+        """Multiple aliases on same interface are all returned."""
+        context = {
+            "ETH0_MAC": MACADDR,
+            "ETH0_ALIAS0_IP": "192.168.1.10",
+            "ETH0_ALIAS0_MASK": "255.255.255.0",
+            "ETH0_ALIAS1_IP": "192.168.1.11",
+            "ETH0_ALIAS1_MASK": "255.255.255.0",
+            "ETH0_ALIAS2_IP": "192.168.1.12",
+            "ETH0_ALIAS2_MASK": "255.255.255.0",
+        }
+        m_get_phys_by_mac.return_value = {MACADDR: "eth0"}
+        net = ds.OpenNebulaNetwork(context, mock.Mock())
+        aliases = net.get_alias_addresses("ETH0", MACADDR)
+        assert aliases == [
+            "192.168.1.10/24",
+            "192.168.1.11/24",
+            "192.168.1.12/24",
+        ]
+
+    @mock.patch(DS_PATH + ".get_physical_nics_by_mac")
+    def test_get_alias_addresses_none(self, m_get_phys_by_mac):
+        """No alias variables → empty list."""
+        context = {"ETH0_MAC": MACADDR}
+        m_get_phys_by_mac.return_value = {MACADDR: "eth0"}
+        net = ds.OpenNebulaNetwork(context, mock.Mock())
+        aliases = net.get_alias_addresses("ETH0", MACADDR)
+        assert aliases == []
+
+    @mock.patch(DS_PATH + ".get_physical_nics_by_mac")
+    def test_get_alias_addresses_default_mask(self, m_get_phys_by_mac):
+        """Alias without MASK uses default /32."""
+        context = {
+            "ETH0_MAC": MACADDR,
+            "ETH0_ALIAS0_IP": "10.0.0.5",
+        }
+        m_get_phys_by_mac.return_value = {MACADDR: "eth0"}
+        net = ds.OpenNebulaNetwork(context, mock.Mock())
+        aliases = net.get_alias_addresses("ETH0", MACADDR)
+        assert aliases == ["10.0.0.5/32"]
+
+    @mock.patch(DS_PATH + ".get_physical_nics_by_mac")
+    def test_gen_conf_aliases_in_addresses(self, m_get_phys_by_mac):
+        """gen_conf includes alias IPs in addresses list."""
+        context = {
+            "ETH0_MAC": MACADDR,
+            "ETH0_IP": PUBLIC_IP,
+            "ETH0_MASK": "255.255.255.0",
+            "ETH0_ALIAS0_IP": "192.168.1.10",
+            "ETH0_ALIAS0_MASK": "255.255.255.0",
+            "ETH0_ALIAS1_IP": "192.168.1.11",
+            "ETH0_ALIAS1_MASK": "255.255.255.0",
+        }
+        for nic in self.system_nics:
+            m_get_phys_by_mac.return_value = {MACADDR: nic}
+            net = ds.OpenNebulaNetwork(context, mock.Mock())
+            conf = net.gen_conf()
+            addresses = conf["ethernets"][nic]["addresses"]
+            assert PUBLIC_IP + "/24" in addresses
+            assert "192.168.1.10/24" in addresses
+            assert "192.168.1.11/24" in addresses
+
+    @mock.patch(DS_PATH + ".get_physical_nics_by_mac")
+    def test_gen_conf_no_aliases_unchanged(self, m_get_phys_by_mac):
+        """gen_conf without aliases produces same output as before."""
+        context = {
+            "ETH0_MAC": MACADDR,
+            "ETH0_IP": PUBLIC_IP,
+            "ETH0_MASK": "255.255.255.0",
+        }
+        for nic in self.system_nics:
+            m_get_phys_by_mac.return_value = {MACADDR: nic}
+            net = ds.OpenNebulaNetwork(context, mock.Mock())
+            conf = net.gen_conf()
+            assert conf["ethernets"][nic]["addresses"] == [PUBLIC_IP + "/24"]
+
+    @mock.patch(DS_PATH + ".get_physical_nics_by_mac")
+    def test_gen_conf_aliases_on_second_nic(self, m_get_phys_by_mac):
+        """Aliases on a second NIC do not bleed into the first."""
+        MAC_1 = "02:00:0a:12:01:01"
+        MAC_2 = "02:00:0a:12:01:02"
+        context = {
+            "ETH0_MAC": MAC_1,
+            "ETH0_IP": "10.0.0.1",
+            "ETH1_MAC": MAC_2,
+            "ETH1_IP": "10.0.1.1",
+            "ETH1_ALIAS0_IP": "10.0.1.100",
+            "ETH1_ALIAS0_MASK": "255.255.255.0",
+        }
+        net = ds.OpenNebulaNetwork(
+            context,
+            mock.Mock(),
+            system_nics_by_mac={MAC_1: "eth0", MAC_2: "eth1"},
+        )
+        conf = net.gen_conf()
+        assert conf["ethernets"]["eth0"]["addresses"] == ["10.0.0.1/24"]
+        assert "10.0.1.100/24" in conf["ethernets"]["eth1"]["addresses"]
+
 
 class TestParseShellConfig:
     @pytest.mark.allow_subp_for("bash", "sh")


### PR DESCRIPTION
## Proposed Commit Message

```
feat(opennebula): support ETHx_ALIASn_IP/MASK for anycast addresses

OpenNebula's context-linux package supports per-NIC alias addresses
(ETHx_ALIAS0_IP, ETHx_ALIAS1_IP, ...) used for anycast IPs. Network
configuration generators such as netbox-network-config emit these
variables, which cloud-init previously ignored, leaving anycast
addresses unconfigured on the VM.

Add get_alias_addresses() to OpenNebulaNetwork and wire it into
gen_conf() so alias addresses appear in the Netplan v2 addresses:
list alongside the primary address. Missing MASK defaults to
255.255.255.255 (/32).
```

## Additional Context

Part of a series bringing cloud-init's OpenNebula datasource to
feature parity with the context-linux package from one-apps.

## Test Steps

In an OpenNebula VM context, set:

```sh
ETH0_IP="10.0.0.1"
ETH0_ALIAS0_IP="192.168.1.10"
ETH0_ALIAS0_MASK="255.255.255.0"
ETH0_ALIAS1_IP="192.168.1.11"
ETH0_ALIAS1_MASK="255.255.255.0"
```

After boot, verify `ip addr show` lists `192.168.1.10/24` and
`192.168.1.11/24` on the interface alongside `10.0.0.1`.

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)