### PR TITLE
feat(opennebula): support global SEARCH_DOMAIN for all interfaces

### DIFF
--- a/cloudinit/sources/DataSourceOpenNebula.py
+++ b/cloudinit/sources/DataSourceOpenNebula.py
@@ -190,6 +190,9 @@ class OpenNebulaNetwork:
         if dns:
             nameservers["addresses"] = dns
         search_domain = self.get_field(dev, "search_domain", "").split()
+        for domain in self.context.get("SEARCH_DOMAIN", "").split():
+            if domain not in search_domain:
+                search_domain.append(domain)
         if search_domain:
             nameservers["search"] = search_domain
         return nameservers

--- a/cloudinit/sources/DataSourceOpenNebula.py
+++ b/cloudinit/sources/DataSourceOpenNebula.py
@@ -185,11 +185,22 @@ class OpenNebulaNetwork:
 
     def get_nameservers(self, dev: str) -> Dict[str, List[str]]:
         nameservers: Dict[str, List[str]] = {}
-        dns = self.get_field(dev, "dns", "").split()
-        dns.extend(self.context.get("DNS", "").split())
+        dns: List[str] = []
+        for server in (
+            self.get_field(dev, "dns", "").split()
+            + self.context.get("DNS", "").split()
+        ):
+            if server not in dns:
+                dns.append(server)
         if dns:
             nameservers["addresses"] = dns
-        search_domain = self.get_field(dev, "search_domain", "").split()
+        search_domain: List[str] = []
+        for domain in (
+            self.get_field(dev, "search_domain", "").split()
+            + self.context.get("SEARCH_DOMAIN", "").split()
+        ):
+            if domain not in search_domain:
+                search_domain.append(domain)
         if search_domain:
             nameservers["search"] = search_domain
         return nameservers

--- a/doc/rtd/reference/datasources/opennebula.rst
+++ b/doc/rtd/reference/datasources/opennebula.rst
@@ -59,6 +59,7 @@ the OpenNebula documentation.
 ::
 
     DNS
+    SEARCH_DOMAIN
     ETH<x>_IP
     ETH<x>_NETWORK
     ETH<x>_MASK
@@ -73,7 +74,9 @@ the OpenNebula documentation.
     ETH<x>_IP6_PREFIX_LENGTH
     ETH<x>_IP6_GATEWAY
 
-Static `network configuration`_.
+Static `network configuration`_. ``DNS`` and ``SEARCH_DOMAIN`` are global
+fallbacks applied to every interface. Per-interface ``ETH<x>_DNS`` and
+``ETH<x>_SEARCH_DOMAIN`` take precedence; duplicate entries are suppressed.
 
 ::
 

--- a/doc/rtd/reference/datasources/opennebula.rst
+++ b/doc/rtd/reference/datasources/opennebula.rst
@@ -59,6 +59,7 @@ the OpenNebula documentation.
 ::
 
     DNS
+    SEARCH_DOMAIN
     ETH<x>_IP
     ETH<x>_NETWORK
     ETH<x>_MASK
@@ -74,7 +75,12 @@ the OpenNebula documentation.
     ETH<x>_IP6_GATEWAY
     ETH<x>_ROUTES
 
-Static `network configuration`_.
+Static `network configuration`_. ``DNS`` and ``SEARCH_DOMAIN`` are global
+values applied to every interface. Per-interface ``ETH<x>_DNS`` and
+``ETH<x>_SEARCH_DOMAIN`` (defined in `context-linux`_) take precedence;
+duplicate entries across both levels are suppressed.
+
+.. _context-linux: https://github.com/OpenNebula/one-apps/blob/v7.0.0/context-linux/src/etc/one-context.d/loc-10-network.d/functions#L463-L466
 
 ``ETH<x>_ROUTES`` is a comma-separated list of static routes in the form
 ``NETWORK via GATEWAY``. For example::

--- a/tests/unittests/sources/test_opennebula.py
+++ b/tests/unittests/sources/test_opennebula.py
@@ -975,6 +975,83 @@ class TestOpenNebulaNetwork:
 
         assert expected == net.gen_conf()
 
+    def test_get_nameservers_global_search_domain(self):
+        """Global SEARCH_DOMAIN is appended to the search list."""
+        context = {
+            "SEARCH_DOMAIN": "global.example.com global.example.org",
+        }
+        net = ds.OpenNebulaNetwork(context, mock.Mock())
+        val = net.get_nameservers("eth0")
+        assert val["search"] == ["global.example.com", "global.example.org"]
+
+    def test_get_nameservers_global_and_per_interface_search_domain(self):
+        """Per-interface and global SEARCH_DOMAIN are merged."""
+        context = {
+            "ETH0_SEARCH_DOMAIN": "iface.example.com",
+            "SEARCH_DOMAIN": "global.example.com",
+        }
+        net = ds.OpenNebulaNetwork(context, mock.Mock())
+        val = net.get_nameservers("eth0")
+        assert val["search"] == ["iface.example.com", "global.example.com"]
+
+    def test_get_nameservers_no_global_search_domain_no_regression(self):
+        """Absent global SEARCH_DOMAIN does not break existing behaviour."""
+        context = {
+            "ETH0_SEARCH_DOMAIN": "iface.example.com",
+        }
+        net = ds.OpenNebulaNetwork(context, mock.Mock())
+        val = net.get_nameservers("eth0")
+        assert val["search"] == ["iface.example.com"]
+
+    def test_get_nameservers_global_search_domain_not_duplicated(self):
+        """Same domain in per-interface and global appears only once."""
+        context = {
+            "ETH0_SEARCH_DOMAIN": "shared.example.com",
+            "SEARCH_DOMAIN": "shared.example.com extra.example.com",
+        }
+        net = ds.OpenNebulaNetwork(context, mock.Mock())
+        val = net.get_nameservers("eth0")
+        assert val["search"].count("shared.example.com") == 1
+
+    @mock.patch(DS_PATH + ".get_physical_nics_by_mac")
+    def test_gen_conf_global_search_domain(self, m_get_phys_by_mac):
+        """gen_conf includes global SEARCH_DOMAIN in nameservers.search."""
+        context = {
+            "ETH0_MAC": MACADDR,
+            "SEARCH_DOMAIN": "global.example.com",
+        }
+        for nic in self.system_nics:
+            m_get_phys_by_mac.return_value = {MACADDR: nic}
+            net = ds.OpenNebulaNetwork(context, mock.Mock())
+            conf = net.gen_conf()
+            assert conf["ethernets"][nic]["nameservers"]["search"] == [
+                "global.example.com"
+            ]
+
+    @mock.patch(DS_PATH + ".get_physical_nics_by_mac")
+    def test_gen_conf_global_search_domain_multiple_nics(
+        self, m_get_phys_by_mac
+    ):
+        """Global SEARCH_DOMAIN appears on every NIC."""
+        MAC_1 = "02:00:0a:12:01:01"
+        MAC_2 = "02:00:0a:12:01:02"
+        context = {
+            "ETH0_MAC": MAC_1,
+            "ETH1_MAC": MAC_2,
+            "SEARCH_DOMAIN": "global.example.com",
+        }
+        net = ds.OpenNebulaNetwork(
+            context,
+            mock.Mock(),
+            system_nics_by_mac={MAC_1: "eth0", MAC_2: "eth1"},
+        )
+        conf = net.gen_conf()
+        for nic in ("eth0", "eth1"):
+            assert (
+                "global.example.com"
+                in conf["ethernets"][nic]["nameservers"]["search"]
+            )
+
 
 class TestParseShellConfig:
     @pytest.mark.allow_subp_for("bash", "sh")

--- a/tests/unittests/sources/test_opennebula.py
+++ b/tests/unittests/sources/test_opennebula.py
@@ -975,6 +975,84 @@ class TestOpenNebulaNetwork:
 
         assert expected == net.gen_conf()
 
+    @pytest.mark.parametrize(
+        "context,expected_search",
+        [
+            pytest.param(
+                {"SEARCH_DOMAIN": "global.example.com global.example.org"},
+                ["global.example.com", "global.example.org"],
+                id="global_only",
+            ),
+            pytest.param(
+                {
+                    "ETH0_SEARCH_DOMAIN": "iface.example.com",
+                    "SEARCH_DOMAIN": "global.example.com",
+                },
+                ["iface.example.com", "global.example.com"],
+                id="per_interface_and_global",
+            ),
+            pytest.param(
+                {"ETH0_SEARCH_DOMAIN": "iface.example.com"},
+                ["iface.example.com"],
+                id="per_interface_only",
+            ),
+            pytest.param(
+                {
+                    "ETH0_SEARCH_DOMAIN": "shared.example.com",
+                    # extra precedes shared in global; shared must still come
+                    # first because per-interface ordering takes precedence
+                    "SEARCH_DOMAIN": "extra.example.com shared.example.com",
+                },
+                ["shared.example.com", "extra.example.com"],
+                id="dedup_iface_order_preferred",
+            ),
+        ],
+    )
+    def test_get_nameservers_search_domain(self, context, expected_search):
+        """get_nameservers merges and deduplicates SEARCH_DOMAIN correctly."""
+        net = ds.OpenNebulaNetwork(context, mock.Mock())
+        val = net.get_nameservers("eth0")
+        assert val["search"] == expected_search
+
+    @mock.patch(DS_PATH + ".get_physical_nics_by_mac")
+    def test_gen_conf_global_search_domain(self, m_get_phys_by_mac):
+        """gen_conf includes global SEARCH_DOMAIN in nameservers.search."""
+        context = {
+            "ETH0_MAC": MACADDR,
+            "SEARCH_DOMAIN": "global.example.com",
+        }
+        for nic in self.system_nics:
+            m_get_phys_by_mac.return_value = {MACADDR: nic}
+            net = ds.OpenNebulaNetwork(context, mock.Mock())
+            conf = net.gen_conf()
+            assert conf["ethernets"][nic]["nameservers"]["search"] == [
+                "global.example.com"
+            ]
+
+    @mock.patch(DS_PATH + ".get_physical_nics_by_mac")
+    def test_gen_conf_global_search_domain_multiple_nics(
+        self, m_get_phys_by_mac
+    ):
+        """Global SEARCH_DOMAIN appears on every NIC."""
+        MAC_1 = "02:00:0a:12:01:01"
+        MAC_2 = "02:00:0a:12:01:02"
+        context = {
+            "ETH0_MAC": MAC_1,
+            "ETH1_MAC": MAC_2,
+            "SEARCH_DOMAIN": "global.example.com",
+        }
+        net = ds.OpenNebulaNetwork(
+            context,
+            mock.Mock(),
+            system_nics_by_mac={MAC_1: "eth0", MAC_2: "eth1"},
+        )
+        conf = net.gen_conf()
+        for nic in ("eth0", "eth1"):
+            assert (
+                "global.example.com"
+                in conf["ethernets"][nic]["nameservers"]["search"]
+            )
+
     # ------------------------------------------------------------------ #
     # ETHx_ROUTES                                                          #
     # ------------------------------------------------------------------ #


### PR DESCRIPTION
## Proposed Commit Message

```
feat(opennebula): support global SEARCH_DOMAIN for all interfaces

netbox-network-config sets a global SEARCH_DOMAIN context variable
(never per-interface ETHx_SEARCH_DOMAIN). The existing get_nameservers()
already handled the global DNS key but silently ignored SEARCH_DOMAIN,
leaving VMs with no DNS search domain configured.

Extend get_nameservers() to append entries from the global SEARCH_DOMAIN
key, matching the existing pattern for global DNS. Per-interface
ETHx_SEARCH_DOMAIN entries take precedence and duplicates are suppressed.
```

## Additional Context

Part of a series bringing cloud-init's OpenNebula datasource to feature
parity with the context-linux package from one-apps.

The global `DNS` key was already handled by `get_nameservers()` (line 179
of `DataSourceOpenNebula.py`). `SEARCH_DOMAIN` is its natural counterpart
and follows the exact same pattern.

## Test Steps

In an OpenNebula VM context, set:

```sh
SEARCH_DOMAIN="example.com example.org"
```

After boot, verify `/etc/resolv.conf` (or systemd-resolved config) contains
`search example.com example.org`.

Also verify that setting both `ETH0_SEARCH_DOMAIN="iface.example.com"` and
`SEARCH_DOMAIN="global.example.com"` results in both domains present without
duplication.

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)