### PR TITLE
feat(opennebula): support ETHx_VLAN_ID for 802.1Q VLAN interfaces

### DIFF
--- a/cloudinit/sources/DataSourceOpenNebula.py
+++ b/cloudinit/sources/DataSourceOpenNebula.py
@@ -255,9 +255,8 @@ class OpenNebulaNetwork:
         return default if val in (None, "") else val
 
     def gen_conf(self) -> Dict[str, Any]:
-        netconf: Dict[str, Any] = {"version": 2, "ethernets": {}}
+        netconf: Dict[str, Any] = {"version": 2, "ethernets": {}, "vlans": {}}
 
-        ethernets: Dict[str, Dict[str, Any]] = {}
         for mac, dev in self.ifaces.items():
             mac = mac.lower()
 
@@ -265,10 +264,18 @@ class OpenNebulaNetwork:
             # dev stores the current system name.
             c_dev = self.context_devname.get(mac, dev)
 
-            devconf: Dict[str, Any] = {}
+            vlan_id: Optional[str] = self.get_field(c_dev, "vlan_id")
+            devconf: Dict[str, Any]
 
-            # Set MAC address
-            devconf["match"] = {"macaddress": mac}
+            if vlan_id:
+                # Parent: just bring it up, no IP configuration
+                netconf["ethernets"][dev] = {"match": {"macaddress": mac}}
+                # VLAN sub-interface carries the actual IP config
+                target_name = "%s.%s" % (dev, vlan_id)
+                devconf = {"id": int(vlan_id), "link": dev}
+            else:
+                target_name = dev
+                devconf = {"match": {"macaddress": mac}}
 
             # Set IPv4 address
             devconf["addresses"] = []
@@ -304,9 +311,15 @@ class OpenNebulaNetwork:
             if mtu:
                 devconf["mtu"] = mtu
 
-            ethernets[dev] = devconf
+            if vlan_id:
+                netconf["vlans"][target_name] = devconf
+            else:
+                netconf["ethernets"][target_name] = devconf
 
-        netconf["ethernets"] = ethernets
+        # Remove empty top-level sections
+        if not netconf["vlans"]:
+            del netconf["vlans"]
+
         return netconf
 
 

--- a/cloudinit/sources/DataSourceOpenNebula.py
+++ b/cloudinit/sources/DataSourceOpenNebula.py
@@ -279,9 +279,8 @@ class OpenNebulaNetwork:
         return default if val in (None, "") else val
 
     def gen_conf(self) -> Dict[str, Any]:
-        netconf: Dict[str, Any] = {"version": 2, "ethernets": {}}
+        netconf: Dict[str, Any] = {"version": 2, "ethernets": {}, "vlans": {}}
 
-        ethernets: Dict[str, Dict[str, Any]] = {}
         for mac, dev in self.ifaces.items():
             mac = mac.lower()
 
@@ -289,10 +288,18 @@ class OpenNebulaNetwork:
             # dev stores the current system name.
             c_dev = self.context_devname.get(mac, dev)
 
-            devconf: Dict[str, Any] = {}
+            vlan_id: Optional[str] = self.get_field(c_dev, "vlan_id")
+            devconf: Dict[str, Any]
 
-            # Set MAC address
-            devconf["match"] = {"macaddress": mac}
+            if vlan_id:
+                # Parent: just bring it up, no IP configuration
+                netconf["ethernets"][dev] = {"match": {"macaddress": mac}}
+                # VLAN sub-interface carries the actual IP config
+                target_name = "%s.%s" % (dev, vlan_id)
+                devconf = {"id": int(vlan_id), "link": dev}
+            else:
+                target_name = dev
+                devconf = {"match": {"macaddress": mac}}
 
             # Set IPv4 address
             devconf["addresses"] = []
@@ -333,9 +340,15 @@ class OpenNebulaNetwork:
             if extra_routes:
                 devconf["routes"] = extra_routes
 
-            ethernets[dev] = devconf
+            if vlan_id:
+                netconf["vlans"][target_name] = devconf
+            else:
+                netconf["ethernets"][target_name] = devconf
 
-        netconf["ethernets"] = ethernets
+        # Remove empty top-level sections
+        if not netconf["vlans"]:
+            del netconf["vlans"]
+
         return netconf
 
 

--- a/doc/rtd/reference/datasources/opennebula.rst
+++ b/doc/rtd/reference/datasources/opennebula.rst
@@ -68,12 +68,18 @@ the OpenNebula documentation.
     ETH<x>_DNS
     ETH<x>_SEARCH_DOMAIN
     ETH<x>_MTU
+    ETH<x>_VLAN_ID
     ETH<x>_IP6
     ETH<x>_IP6_ULA
     ETH<x>_IP6_PREFIX_LENGTH
     ETH<x>_IP6_GATEWAY
 
 Static `network configuration`_.
+
+When ``ETH<x>_VLAN_ID`` is set, ``cloud-init`` creates an 802.1Q VLAN
+sub-interface named ``<dev>.<VLAN_ID>`` (e.g. ``eth0.100``) and assigns
+all IP configuration to that sub-interface. The parent interface is
+brought up with no address.
 
 ::
 

--- a/doc/rtd/reference/datasources/opennebula.rst
+++ b/doc/rtd/reference/datasources/opennebula.rst
@@ -68,6 +68,7 @@ the OpenNebula documentation.
     ETH<x>_DNS
     ETH<x>_SEARCH_DOMAIN
     ETH<x>_MTU
+    ETH<x>_VLAN_ID
     ETH<x>_IP6
     ETH<x>_IP6_ULA
     ETH<x>_IP6_PREFIX_LENGTH
@@ -75,6 +76,11 @@ the OpenNebula documentation.
     ETH<x>_ROUTES
 
 Static `network configuration`_.
+
+When ``ETH<x>_VLAN_ID`` is set, ``cloud-init`` creates an 802.1Q VLAN
+sub-interface named ``<dev>.<VLAN_ID>`` (e.g. ``eth0.100``) and assigns
+all IP configuration to that sub-interface. The parent interface is
+brought up with no address.
 
 ``ETH<x>_ROUTES`` is a comma-separated list of static routes in the form
 ``NETWORK via GATEWAY``. For example::

--- a/tests/unittests/sources/test_opennebula.py
+++ b/tests/unittests/sources/test_opennebula.py
@@ -975,6 +975,83 @@ class TestOpenNebulaNetwork:
 
         assert expected == net.gen_conf()
 
+    # --- ETHx_VLAN_ID tests ---
+
+    @mock.patch(DS_PATH + ".get_physical_nics_by_mac")
+    def test_gen_conf_vlan_id(self, m_get_phys_by_mac):
+        """VLAN_ID set → vlans: section; parent has no addresses."""
+        context = {
+            "ETH0_MAC": MACADDR,
+            "ETH0_IP": PUBLIC_IP,
+            "ETH0_MASK": "255.255.255.0",
+            "ETH0_VLAN_ID": "100",
+        }
+        for nic in self.system_nics:
+            m_get_phys_by_mac.return_value = {MACADDR: nic}
+            net = ds.OpenNebulaNetwork(context, mock.Mock())
+            conf = net.gen_conf()
+            # Parent ethernet: just MAC match, no addresses
+            assert nic in conf["ethernets"]
+            assert "addresses" not in conf["ethernets"][nic]
+            # VLAN child carries the IP config
+            vlan_name = "%s.100" % nic
+            assert "vlans" in conf
+            assert vlan_name in conf["vlans"]
+            vlan = conf["vlans"][vlan_name]
+            assert vlan["id"] == 100
+            assert vlan["link"] == nic
+            assert PUBLIC_IP + "/24" in vlan["addresses"]
+
+    @mock.patch(DS_PATH + ".get_physical_nics_by_mac")
+    def test_gen_conf_no_vlan_no_vlans_key(self, m_get_phys_by_mac):
+        """Without VLAN_ID the output has no 'vlans' key."""
+        context = {"ETH0_MAC": MACADDR}
+        for nic in self.system_nics:
+            m_get_phys_by_mac.return_value = {MACADDR: nic}
+            net = ds.OpenNebulaNetwork(context, mock.Mock())
+            conf = net.gen_conf()
+            assert "vlans" not in conf
+
+    @mock.patch(DS_PATH + ".get_physical_nics_by_mac")
+    def test_gen_conf_vlan_with_gateway(self, m_get_phys_by_mac):
+        """Gateway on a VLAN interface ends up in the vlans entry."""
+        context = {
+            "ETH0_MAC": MACADDR,
+            "ETH0_IP": PUBLIC_IP,
+            "ETH0_GATEWAY": "10.0.0.1",
+            "ETH0_VLAN_ID": "200",
+        }
+        m_get_phys_by_mac.return_value = {MACADDR: "eth0"}
+        net = ds.OpenNebulaNetwork(context, mock.Mock())
+        conf = net.gen_conf()
+        vlan = conf["vlans"]["eth0.200"]
+        assert vlan.get("gateway4") == "10.0.0.1"
+        assert "gateway4" not in conf["ethernets"]["eth0"]
+
+    @mock.patch(DS_PATH + ".get_physical_nics_by_mac")
+    def test_gen_conf_vlan_mixed_nics(self, m_get_phys_by_mac):
+        """One NIC with VLAN, one without: only one vlans entry."""
+        MAC_1 = "02:00:0a:12:01:01"
+        MAC_2 = "02:00:0a:12:01:02"
+        context = {
+            "ETH0_MAC": MAC_1,
+            "ETH0_IP": "10.0.0.1",
+            "ETH0_VLAN_ID": "10",
+            "ETH1_MAC": MAC_2,
+            "ETH1_IP": "10.0.1.1",
+        }
+        net = ds.OpenNebulaNetwork(
+            context,
+            mock.Mock(),
+            system_nics_by_mac={MAC_1: "eth0", MAC_2: "eth1"},
+        )
+        conf = net.gen_conf()
+        assert "vlans" in conf
+        assert "eth0.10" in conf["vlans"]
+        assert "eth1" in conf["ethernets"]
+        assert "addresses" in conf["ethernets"]["eth1"]
+        assert "addresses" not in conf["ethernets"]["eth0"]
+
 
 class TestParseShellConfig:
     @pytest.mark.allow_subp_for("bash", "sh")

--- a/tests/unittests/sources/test_opennebula.py
+++ b/tests/unittests/sources/test_opennebula.py
@@ -975,6 +975,83 @@ class TestOpenNebulaNetwork:
 
         assert expected == net.gen_conf()
 
+    # --- ETHx_VLAN_ID tests ---
+
+    @mock.patch(DS_PATH + ".get_physical_nics_by_mac")
+    def test_gen_conf_vlan_id(self, m_get_phys_by_mac):
+        """VLAN_ID set → vlans: section; parent has no addresses."""
+        context = {
+            "ETH0_MAC": MACADDR,
+            "ETH0_IP": PUBLIC_IP,
+            "ETH0_MASK": "255.255.255.0",
+            "ETH0_VLAN_ID": "100",
+        }
+        for nic in self.system_nics:
+            m_get_phys_by_mac.return_value = {MACADDR: nic}
+            net = ds.OpenNebulaNetwork(context, mock.Mock())
+            conf = net.gen_conf()
+            # Parent ethernet: just MAC match, no addresses
+            assert nic in conf["ethernets"]
+            assert "addresses" not in conf["ethernets"][nic]
+            # VLAN child carries the IP config
+            vlan_name = "%s.100" % nic
+            assert "vlans" in conf
+            assert vlan_name in conf["vlans"]
+            vlan = conf["vlans"][vlan_name]
+            assert vlan["id"] == 100
+            assert vlan["link"] == nic
+            assert PUBLIC_IP + "/24" in vlan["addresses"]
+
+    @mock.patch(DS_PATH + ".get_physical_nics_by_mac")
+    def test_gen_conf_no_vlan_no_vlans_key(self, m_get_phys_by_mac):
+        """Without VLAN_ID the output has no 'vlans' key."""
+        context = {"ETH0_MAC": MACADDR}
+        for nic in self.system_nics:
+            m_get_phys_by_mac.return_value = {MACADDR: nic}
+            net = ds.OpenNebulaNetwork(context, mock.Mock())
+            conf = net.gen_conf()
+            assert "vlans" not in conf
+
+    @mock.patch(DS_PATH + ".get_physical_nics_by_mac")
+    def test_gen_conf_vlan_with_gateway(self, m_get_phys_by_mac):
+        """Gateway on a VLAN interface ends up in the vlans entry."""
+        context = {
+            "ETH0_MAC": MACADDR,
+            "ETH0_IP": PUBLIC_IP,
+            "ETH0_GATEWAY": "10.0.0.1",
+            "ETH0_VLAN_ID": "200",
+        }
+        m_get_phys_by_mac.return_value = {MACADDR: "eth0"}
+        net = ds.OpenNebulaNetwork(context, mock.Mock())
+        conf = net.gen_conf()
+        vlan = conf["vlans"]["eth0.200"]
+        assert vlan.get("gateway4") == "10.0.0.1"
+        assert "gateway4" not in conf["ethernets"]["eth0"]
+
+    @mock.patch(DS_PATH + ".get_physical_nics_by_mac")
+    def test_gen_conf_vlan_mixed_nics(self, m_get_phys_by_mac):
+        """One NIC with VLAN, one without: only one vlans entry."""
+        MAC_1 = "02:00:0a:12:01:01"
+        MAC_2 = "02:00:0a:12:01:02"
+        context = {
+            "ETH0_MAC": MAC_1,
+            "ETH0_IP": "10.0.0.1",
+            "ETH0_VLAN_ID": "10",
+            "ETH1_MAC": MAC_2,
+            "ETH1_IP": "10.0.1.1",
+        }
+        net = ds.OpenNebulaNetwork(
+            context,
+            mock.Mock(),
+            system_nics_by_mac={MAC_1: "eth0", MAC_2: "eth1"},
+        )
+        conf = net.gen_conf()
+        assert "vlans" in conf
+        assert "eth0.10" in conf["vlans"]
+        assert "eth1" in conf["ethernets"]
+        assert "addresses" in conf["ethernets"]["eth1"]
+        assert "addresses" not in conf["ethernets"]["eth0"]
+
     # ------------------------------------------------------------------ #
     # ETHx_ROUTES                                                          #
     # ------------------------------------------------------------------ #


### PR DESCRIPTION
## Proposed Commit Message

```
feat(opennebula): support ETHx_VLAN_ID for 802.1Q VLAN interfaces

When ETHx_VLAN_ID is set, context-linux creates a VLAN sub-interface
(e.g. eth0.100) and assigns IP config to it. cloud-init ignored this
variable entirely.

Restructure gen_conf() to check for VLAN_ID per interface: when set,
emit a bare parent entry in ethernets: (MAC match only) and place all
IP configuration in a vlans: entry named <dev>.<id>. The vlans: key
is omitted from the output when no VLANs are configured.
```

## Additional Context

Part of a series bringing cloud-init's OpenNebula datasource to feature
parity with the context-linux package from one-apps.

The Netplan v2 `vlans:` stanza requires `id:` (integer) and `link:` (parent
device name). All other configuration keys (addresses, gateway4, nameservers,
etc.) are placed on the VLAN entry, not the parent.

## Test Steps

In an OpenNebula VM context, set:

```sh
ETH0_IP="10.0.0.1"
ETH0_MASK="255.255.255.0"
ETH0_VLAN_ID="100"
```

After boot, verify `ip link show` includes `eth0.100` and `ip addr show eth0.100`
shows `10.0.0.1/24`. The parent `eth0` should have no address.

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)