### PR TITLE
test: fix test_schema when the schema validation takes longer

### DIFF
--- a/tests/unittests/config/test_schema.py
+++ b/tests/unittests/config/test_schema.py
@@ -451,8 +451,8 @@ class TestValidateCloudConfigSchema:
         """When strict is False validate_cloudconfig_schema emits warnings."""
         schema = {"properties": {"p1": {"type": "string"}}}
         validate_cloudconfig_schema({"p1": -1}, schema=schema, strict=False)
-        assert (
-            caplog.record_tuples and len(caplog.record_tuples) == 1
+        assert caplog.record_tuples and (
+            len(caplog.record_tuples) == 1 or len(caplog.record_tuples) == 2
         ), caplog.record_tuples
         [(module, log_level, log_msg)] = caplog.record_tuples
         assert "cloudinit.config.schema" == module


### PR DESCRIPTION
When the schema validation takes more than 0.01 seconds, a log is emitted: `Validating schema took 0.070 seconds`

When this happens, the tuple length is 2 and not one and the test fails with the following:

```
def test_validateconfig_schema_non_strict_emits_warnings(self, caplog):
        """When strict is False validate_cloudconfig_schema emits warnings."""
        schema = {"properties": {"p1": {"type": "string"}}}
        validate_cloudconfig_schema({"p1": -1}, schema=schema, strict=False)
>       assert (
            caplog.record_tuples and len(caplog.record_tuples) == 1
        ), caplog.record_tuples
E       AssertionError: [('cloudinit.config.schema', 30, "cloud-config failed schema validation!
E         p1: -1 is not of type 'string'"), ('cloudinit.performance', 10, 'Validating schema took 0.070 seconds')]
E       assert ([('cloudinit.config.schema', 30, "cloud-config failed schema validation!\np1: -1 is not of type 'string'"), ('cloudinit.performance', 10, 'Validating schema took 0.070 seconds')] and 2 == 1)
E        +  where [('cloudinit.config.schema', 30, "cloud-config failed schema validation!\np1: -1 is not of type 'string'"), ('cloudinit.performance', 10, 'Validating schema took 0.070 seconds')] = <_pytest.logging.LogCaptureFixture object at 0xffffb27f9250>.record_tuples
E        +  and   2 = len([('cloudinit.config.schema', 30, "cloud-config failed schema validation!\np1: -1 is not of type 'string'"), ('cloudinit.performance', 10, 'Validating schema took 0.070 seconds')])
E        +    where [('cloudinit.config.schema', 30, "cloud-config failed schema validation!\np1: -1 is not of type 'string'"), ('cloudinit.performance', 10, 'Validating schema took 0.070 seconds')] = <_pytest.logging.LogCaptureFixture object at 0xffffb27f9250>.record_tuples

tests/unittests/config/test_schema.py:454: AssertionError
```
Fix it by checking if the length of the tuple is either one or two, not just one.

## Proposed Commit Message
    When the schema validation takes more than 0.01 seconds, a log is emitted:
    "Validating schema took 0.070 seconds"
    
    When this happens, the tuple length is 2 and not one and the test fails with
    the following:
    
    def test_validateconfig_schema_non_strict_emits_warnings(self, caplog):
            """When strict is False validate_cloudconfig_schema emits warnings."""
            schema = {"properties": {"p1": {"type": "string"}}}
            validate_cloudconfig_schema({"p1": -1}, schema=schema, strict=False)
    >       assert (
                caplog.record_tuples and len(caplog.record_tuples) == 1
            ), caplog.record_tuples
    E       AssertionError: [('cloudinit.config.schema', 30,
                               "cloud-config failed schema validation!
    E         p1: -1 is not of type 'string'"), ('cloudinit.performance', 10,
                                      'Validating schema took 0.070 seconds')]
    
    Fix it by checking if the length of the tuple is either one or two,
    not just one.


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
