### PR TITLE
fix: increase raspberry pi usb timeout

### DIFF
--- a/cloudinit/config/cc_raspberry_pi.py
+++ b/cloudinit/config/cc_raspberry_pi.py
@@ -63,7 +63,7 @@ def configure_usb_gadget(enable: bool) -> bool:
                 "-f",
             ],
             capture=False,
-            timeout=15,
+            timeout=30,
         )
 
         return True

--- a/tests/unittests/config/test_cc_raspberry_pi.py
+++ b/tests/unittests/config/test_cc_raspberry_pi.py
@@ -113,7 +113,7 @@ class TestRaspberryPiMethods:
         with mock.patch("os.path.exists", return_value=True):
             cc_rpi.configure_usb_gadget(True)
         m_subp.assert_called_once_with(
-            [RPI_USB_GADGET_SCRIPT, "on", "-f"], capture=False, timeout=15
+            [RPI_USB_GADGET_SCRIPT, "on", "-f"], capture=False, timeout=30
         )
 
     @mock.patch("cloudinit.subp.subp")
@@ -152,7 +152,7 @@ class TestRaspberryPiMethods:
 
         # Subprocess should have been invoked once
         m_subp.assert_called_once_with(
-            [RPI_USB_GADGET_SCRIPT, "on", "-f"], capture=False, timeout=15
+            [RPI_USB_GADGET_SCRIPT, "on", "-f"], capture=False, timeout=30
         )
 
         # Error log should contain failure message


### PR DESCRIPTION
Running on `rpi-usb-gadget` on a Raspberry Pi Zero 2 W takes more than 15 seconds.

Even running it manually on a settled system it longer than the allowed timeout:

```
$ time sudo /usr/bin/rpi-usb-gadget on
Turning on USB Gadget mode
Reboot to apply changes

real    0m19.209s
user    0m0.032s
sys     0m0.040s
```

On cloud-init first boot it results in a failure:

```
$ sudo cat /var/log/cloud-init.log
2025-12-04 14:51:44,868 - cc_raspberry_pi.py[DEBUG]: Enable rpi-usb-gadget mode: True
2025-12-04 14:51:44,877 - subp.py[DEBUG]: Running command ['/usr/bin/rpi-usb-gadget', 'on', '-f'] with allowed return codes [0] (shell=False, capture=False)
2025-12-04 14:51:59,914 - performance.py[DEBUG]: Running ['/usr/bin/rpi-usb-gadget', 'on', '-f'] took 15.014 seconds
2025-12-04 14:51:59,952 - handlers.py[DEBUG]: finish: modules-config/config-raspberry_pi: FAIL: running config-raspberry_pi with frequency once-per-instance
2025-12-04 14:51:59,955 - log_util.py[WARNING]: Running module raspberry_pi (<module 'cloudinit.config.cc_raspberry_pi' from '/usr/lib/python3/dist-packages/cloudinit/config/cc_raspberry_pi.py'>) failed
2025-12-04 14:51:59,964 - log_util.py[DEBUG]: Running module raspberry_pi (<module 'cloudinit.config.cc_raspberry_pi' from '/usr/lib/python3/dist-packages/cloudinit/config/cc_raspberry_pi.py'>) failed
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/cloudinit/config/modules.py", line 297, in _run_modules
    ran, _r = cc.run(
              ~~~~~~^
        run_name, mod.handle, func_args, freq=freq
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/usr/lib/python3/dist-packages/cloudinit/cloud.py", line 71, in run
    return self._runners.run(name, functor, args, freq, clear_on_fail)
           ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/cloudinit/helpers.py", line 156, in run
    results = functor(**args)
  File "/usr/lib/python3/dist-packages/cloudinit/config/cc_raspberry_pi.py", line 210, in handle
    want_reboot |= configure_usb_gadget(enable)
                   ~~~~~~~~~~~~~~~~~~~~^^^^^^^^
  File "/usr/lib/python3/dist-packages/cloudinit/config/cc_raspberry_pi.py", line 53, in configure_usb_gadget
    subp.subp(
    ~~~~~~~~~^
        [
        ^
    ...<5 lines>...
        timeout=15,
        ^^^^^^^^^^^
    )
    ^
  File "/usr/lib/python3/dist-packages/cloudinit/subp.py", line 272, in subp
    out, err = sp.communicate(data, timeout=timeout)
               ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/subprocess.py", line 1222, in communicate
    stdout, stderr = self._communicate(input, endtime, timeout)
                     ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/subprocess.py", line 2154, in _communicate
    self.wait(timeout=self._remaining_time(endtime))
    ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/subprocess.py", line 1280, in wait
    return self._wait(timeout=timeout)
           ~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/subprocess.py", line 2058, in _wait
    raise TimeoutExpired(self.args, timeout)
subprocess.TimeoutExpired: Command '[b'/usr/bin/rpi-usb-gadget', b'on', b'-f']' timed out after 15 seconds
```

Fixes: raspberrypi/rpi-imager#1403