### PR TITLE
test: fix test_get_domainname_isc_dhclient mock leak

### DIFF
--- a/tests/unittests/sources/test_cloudstack.py
+++ b/tests/unittests/sources/test_cloudstack.py
@@ -108,6 +108,10 @@ class TestCloudStackHostname:
             DHCP_MOD_PATH + ".networkd_get_option_from_leases",
             get_networkd_domain,
         )
+        mocker.patch(
+            MOD_PATH + ".dhcp.IscDhclient.get_newest_lease_file_from_distro",
+            return_value=True,
+        )
 
         with patch(
             MOD_PATH + ".util.load_text_file",


### PR DESCRIPTION

## Proposed Commit Message
Without mocking out `dhcp.IscDhclient.get_newest_lease_file_from_distro`, this function on some platforms returns `None` as it is not able to find the lease files on the host. This means `get_key_from_latest_lease()` bails out early without calling `parse_leases()` to parse the lease file. Fix it.
## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
