### PR TITLE
fix(ubuntu): Configure arm64 to use archive.ubuntu.com

### DIFF
--- a/config/cloud.cfg.tmpl
+++ b/config/cloud.cfg.tmpl
@@ -359,7 +359,7 @@ system_info:
         security: https://deb.debian.org/debian-security
 {% elif variant in ["ubuntu", "unknown"] %}
   package_mirrors:
-    - arches: [i386, amd64]
+    - arches: [arm64, i386, amd64]
       failsafe:
         primary: http://archive.ubuntu.com/ubuntu
         security: http://security.ubuntu.com/ubuntu
@@ -369,7 +369,7 @@ system_info:
           - http://%(availability_zone)s.clouds.archive.ubuntu.com/ubuntu/
           - http://%(region)s.clouds.archive.ubuntu.com/ubuntu/
         security: []
-    - arches: [arm64, armel, armhf]
+    - arches: [armel, armhf]
       failsafe:
         primary: http://ports.ubuntu.com/ubuntu-ports
         security: http://ports.ubuntu.com/ubuntu-ports


### PR DESCRIPTION
Note: I have not *added* unit tests, as the test suite still passes (on my local machine). Also, no documentation changes appear to be necessary (this is purely an infrastructure configuration change).

- [x] I have signed the CLA: https://ubuntu.com/legal/contributors
- [x] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [x] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [x] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e doc``.


## Proposed Commit Message
```
fix(ubuntu): Configure arm64 to use archive.ubuntu.com

Fixes GH-6825
LP: #2147101
```

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
