### PR TITLE
fix(cloudstack): get domain name and vr information from network manager leases

### DIFF
--- a/cloudinit/net/dhcp.py
+++ b/cloudinit/net/dhcp.py
@@ -29,6 +29,7 @@ NETWORKD_LEASES_DIR = "/run/systemd/netif/leases"
 DHCLIENT_FALLBACK_LEASE_DIR = "/var/lib/dhclient"
 # Match something.lease or something.leases
 DHCLIENT_FALLBACK_LEASE_REGEX = r".+\.leases?$"
+NMCLI = "nmcli"
 UDHCPC_SCRIPT = """#!/bin/sh
 log() {
     echo "udhcpc[$PPID]" "$interface: $2"
@@ -145,6 +146,80 @@ def networkd_get_option_from_leases(keyname, leases_d=None):
         if data.get(keyname):
             return data[keyname]
     return None
+
+
+def run_nmcli(nmcli_opts: List[str]) -> str:
+    nmcli_path = subp.which(NMCLI)
+    if not nmcli_path:
+        raise NoDHCPLeaseMissingDhclientError()
+
+    command = [nmcli_path] + nmcli_opts
+    try:
+        out, _ = subp.subp(
+            command,
+        )
+    except subp.ProcessExecutionError as error:
+        LOG.debug(
+            "nmcli command exited with code: %s stderr: %r stdout: %r",
+            error.exit_code,
+            error.stderr,
+            error.stdout,
+        )
+        raise NoDHCPLeaseError from error
+    return out
+
+
+def network_manager_load_leases(device: str) -> Dict[str, str]:
+    """Return a dictionary of lease options obtained from NM cli"""
+
+    opts = ["--fields", "DHCP4", "device", "show", device]
+    nmcli_out = run_nmcli(opts)
+
+    content = []
+    for line in nmcli_out.splitlines():
+        line = line.partition(":")[2].strip()
+        content.append(line)
+
+    return dict(configobj.ConfigObj(content, list_values=False))
+
+
+def find_correct_device_nmcli() -> Optional[str]:
+    """Return the lease value for
+    the first connected device as returned by 'nmcli'"""
+
+    device_list_opts = ["--terse", "device"]
+    nmcli_out = run_nmcli(device_list_opts)
+
+    for line in nmcli_out.splitlines():
+        if line == "":
+            continue
+        try:
+            dev_name, _, state, _ = line.split(":", 3)
+        except ValueError:
+            LOG.warning(
+                "Unexpected nmcli format: expected 4 colon-delimited"
+                " values, found %s",
+                line,
+            )
+            continue
+
+        # skip devices that are not connected
+        if state != "connected":
+            continue
+        # skip loopback
+        if dev_name == "lo":
+            continue
+        return dev_name
+    return None
+
+
+def network_manager_get_option_from_leases(keyname: str) -> Optional[str]:
+    leases = None
+    dev = find_correct_device_nmcli()
+    if dev:
+        leases = network_manager_load_leases(dev)
+
+    return leases.get(keyname) if leases else None
 
 
 class DhcpClient(abc.ABC):

--- a/cloudinit/sources/DataSourceCloudStack.py
+++ b/cloudinit/sources/DataSourceCloudStack.py
@@ -90,6 +90,7 @@ class DataSourceCloudStack(sources.DataSource):
         """Try obtaining a "domain-name" DHCP lease parameter:
         - From systemd-networkd lease (case-insensitive)
         - From ISC dhclient
+        - From network manager dhcp client
         - From dhcpcd (ephemeral)
         - Return empty string if not found (non-fatal)
         """
@@ -113,7 +114,19 @@ class DataSourceCloudStack(sources.DataSource):
 
         LOG.debug(
             "Could not obtain FQDN from ISC dhclient leases. Falling back to "
-            "%s",
+            "Network Manager leases"
+        )
+        with suppress(
+            dhcp.NoDHCPLeaseMissingDhclientError, dhcp.NoDHCPLeaseError
+        ):
+            domain_name = dhcp.network_manager_get_option_from_leases(
+                "domain_name"
+            )
+            if domain_name:
+                return domain_name.strip()
+
+        LOG.debug(
+            "Could not obtain FQDN from NM leases. Falling back to %s",
             self.distro.dhcp_client.client_name,
         )
         try:

--- a/cloudinit/sources/DataSourceCloudStack.py
+++ b/cloudinit/sources/DataSourceCloudStack.py
@@ -351,6 +351,15 @@ def get_vr_address(distro):
             LOG.debug("Found SERVER_ADDRESS '%s' via dhclient", latest_address)
             return latest_address
 
+    # try network manager DHCP lease information
+    with suppress(dhcp.NoDHCPLeaseMissingDhclientError, dhcp.NoDHCPLeaseError):
+        latest_address = dhcp.network_manager_get_option_from_leases(
+            "dhcp_server_identifier"
+        )
+        if latest_address:
+            LOG.debug("Found SERVER_ADDRESS '%s' via nmcli", latest_address)
+            return latest_address
+
     with suppress(FileNotFoundError):
         latest_lease = distro.dhcp_client.get_newest_lease(
             distro.fallback_interface

--- a/tests/unittests/net/test_dhcp.py
+++ b/tests/unittests/net/test_dhcp.py
@@ -20,8 +20,11 @@ from cloudinit.net.dhcp import (
     NoDHCPLeaseInterfaceError,
     NoDHCPLeaseMissingDhclientError,
     Udhcpc,
+    find_correct_device_nmcli,
     maybe_perform_dhcp_discovery,
+    network_manager_load_leases,
     networkd_load_leases,
+    run_nmcli,
 )
 from cloudinit.net.ephemeral import EphemeralDHCPv4
 from cloudinit.subp import SubpResult
@@ -1392,3 +1395,84 @@ class TestMaybePerformDhcpDiscovery:
         with pytest.raises(NoDHCPLeaseInterfaceError):
             distro = mock.Mock(fallback_interface=None)
             maybe_perform_dhcp_discovery(distro, None)
+
+
+class TestNMDhcpLeases:
+    def test_find_correct_connected_device_first_match(self):
+        with mock.patch(
+            "cloudinit.net.dhcp.run_nmcli",
+            return_value=dedent(
+                """
+                   ens150:ethernet:unavailable:
+                   p2p-dev-wlp:wifi-p2p:disconnected:
+                   ens160:ethernet:connected:Wired connection 2
+                   ens256:ethernet:connected:Wired connection 3
+                   lo:loopback:connected (externally):lo
+                """
+            ),
+        ):
+            ret = find_correct_device_nmcli()
+        assert ret == "ens160"
+
+    def test_network_manager_load_leases(self):
+        expected_return = {
+            "broadcast_address": "172.16.127.255",
+            "dhcp_client_identifier": "01:00:0c:29:bf:c5:56",
+            "dhcp_lease_time": "1800",
+            "dhcp_server_identifier": "172.16.127.254",
+        }
+        with mock.patch(
+            "cloudinit.net.dhcp.run_nmcli",
+            return_value=dedent(
+                """
+                DHCP4.OPTION[1]: broadcast_address = 172.16.127.255
+                DHCP4.OPTION[2]: dhcp_client_identifier = 01:00:0c:29:bf:c5:56
+                DHCP4.OPTION[3]: dhcp_lease_time = 1800
+                DHCP4.OPTION[4]: dhcp_server_identifier = 172.16.127.254
+                """
+            ),
+        ):
+            ret = network_manager_load_leases("ens10")
+            assert ret == expected_return
+
+    @mock.patch("cloudinit.net.dhcp.subp.which", return_value="/usr/bin/nmcli")
+    @mock.patch("cloudinit.net.dhcp.subp.subp")
+    def test_run_nmcli(self, m_subp, m_which):
+        expected_return = dedent(
+            """
+                DHCP4.OPTION[1]: broadcast_address = 172.16.127.255
+                DHCP4.OPTION[2]: dhcp_client_identifier = 01:00:0c:29:bf:c5:56
+                DHCP4.OPTION[3]: dhcp_lease_time = 1800
+                DHCP4.OPTION[4]: dhcp_server_identifier = 172.16.127.254
+                """
+        )
+        m_subp.return_value = (expected_return, "")
+        ret = run_nmcli(["show"])
+        assert ret == expected_return
+
+    @mock.patch("cloudinit.net.dhcp.subp.which", return_value=None)
+    def test_run_nmcli_missing_nmcli(self, m_which):
+        """verify that absence of nmcli binary can result in
+        raising NoDHCPLeaseMissingDhclientError"""
+
+        with pytest.raises(NoDHCPLeaseMissingDhclientError):
+            run_nmcli(["show"])
+
+    @mock.patch("cloudinit.net.dhcp.subp.which", return_value="/usr/bin/nmcli")
+    @mock.patch("cloudinit.net.dhcp.subp.subp")
+    def test_run_nmcli_subp_err(self, m_subp, m_which):
+        """verify that when subp.ProcessExecutionError is raised while
+        running nmcli, it results in run_nmcli raising NoDHCPLeaseError"""
+
+        m_subp.side_effect = subp.ProcessExecutionError(exit_code=-5)
+
+        with pytest.raises(NoDHCPLeaseError):
+            run_nmcli(["--fields", "all", "device", "show"])
+
+        m_subp.assert_has_calls(
+            [
+                mock.call(
+                    ["/usr/bin/nmcli", "--fields", "all", "device", "show"],
+                ),
+            ]
+        )

--- a/tests/unittests/sources/test_cloudstack.py
+++ b/tests/unittests/sources/test_cloudstack.py
@@ -108,6 +108,10 @@ class TestCloudStackHostname:
             DHCP_MOD_PATH + ".networkd_get_option_from_leases",
             get_networkd_domain,
         )
+        mocker.patch(
+            MOD_PATH + ".dhcp.IscDhclient.get_newest_lease_file_from_distro",
+            return_value=True,
+        )
 
         with patch(
             MOD_PATH + ".util.load_text_file",

--- a/tests/unittests/sources/test_cloudstack.py
+++ b/tests/unittests/sources/test_cloudstack.py
@@ -67,6 +67,7 @@ class TestCloudStackHostname:
         self.hostname = "vm-hostname"
         self.networkd_domainname = "networkd.local"
         self.isc_dhclient_domainname = "dhclient.local"
+        self.nm_domainname = "nm.local"
 
         get_hostname_parent = mock.MagicMock(
             return_value=DataSourceHostname(self.hostname, True)
@@ -145,6 +146,201 @@ class TestCloudStackHostname:
             result = cloudstack_ds._get_domainname()
         assert self.isc_dhclient_domainname == result
 
+    def test_get_domainname_network_manager(self, cloudstack_ds, mocker):
+        """
+        Test if DataSourceCloudStack._get_domainname()
+        gets domain name from nmcli lease information
+        """
+        nmcliop = f"DHCP4.OPTION[5]:        domain_name = {self.nm_domainname}"
+        get_networkd_domain = mock.MagicMock(return_value=None)
+        mocker.patch(
+            DHCP_MOD_PATH + ".networkd_get_option_from_leases",
+            get_networkd_domain,
+        )
+        mocker.patch(
+            MOD_PATH + ".dhcp.IscDhclient.get_newest_lease_file_from_distro",
+            return_value=True,
+        )
+
+        mocker.patch(
+            MOD_PATH + ".util.load_text_file",
+            return_value=None,
+        )
+
+        mocker.patch(
+            DHCP_MOD_PATH + ".find_correct_device_nmcli",
+            return_value="ens120",
+        )
+
+        with patch(
+            DHCP_MOD_PATH + ".run_nmcli",
+            return_value=dedent(
+                """
+     DHCP4.OPTION[1]:          broadcast_address = 172.16.127.255
+     DHCP4.OPTION[2]:          dhcp_client_identifier = 01:00:0c:29:bf:c5:56
+     DHCP4.OPTION[3]:          dhcp_lease_time = 1800
+     DHCP4.OPTION[4]:          dhcp_server_identifier = 172.16.127.254
+     """
+                + nmcliop
+                + """
+     DHCP4.OPTION[6]:          domain_name_servers = 172.16.127.2
+     DHCP4.OPTION[7]:          expiry = 1775029195
+     DHCP4.OPTION[8]:          ip_address = 172.16.127.135
+     DHCP4.OPTION[9]:          next_server = 172.16.127.254
+     """
+            ),
+        ):
+            result = cloudstack_ds._get_domainname()
+        assert self.nm_domainname == result
+
+    def test_get_domainname_nm_multi_conn_nic(self, cloudstack_ds, mocker):
+        """
+        Test if DataSourceCloudStack._get_domainname()
+        can handle multi connected nic environments.
+        """
+        domain_name = f"{self.nm_domainname}"
+        get_networkd_domain = mock.MagicMock(return_value=None)
+        mocker.patch(
+            DHCP_MOD_PATH + ".networkd_get_option_from_leases",
+            get_networkd_domain,
+        )
+        mocker.patch(
+            MOD_PATH + ".dhcp.IscDhclient.get_newest_lease_file_from_distro",
+            return_value=True,
+        )
+
+        mocker.patch(
+            MOD_PATH + ".util.load_text_file",
+            return_value=None,
+        )
+
+        mocker.patch(
+            DHCP_MOD_PATH + ".run_nmcli",
+            return_value=dedent(
+                """
+                   ens160:ethernet:connected:Wired connection 1
+                   ens256:ethernet:connected:Wired connection 2
+                   lo:loopback:connected (externally):lo
+                """
+            ),
+        )
+
+        with patch(
+            DHCP_MOD_PATH + ".network_manager_load_leases",
+            return_value={"domain_name": domain_name},
+        ):
+            result = cloudstack_ds._get_domainname()
+        assert self.nm_domainname == result
+
+    def test_get_domainname_nm_single_conn_nic(self, cloudstack_ds, mocker):
+        """
+        Test if DataSourceCloudStack._get_domainname()
+        can handle one connected nic environments.
+        """
+        domain_name = f"{self.nm_domainname}"
+        get_networkd_domain = mock.MagicMock(return_value=None)
+        mocker.patch(
+            DHCP_MOD_PATH + ".networkd_get_option_from_leases",
+            get_networkd_domain,
+        )
+        mocker.patch(
+            MOD_PATH + ".dhcp.IscDhclient.get_newest_lease_file_from_distro",
+            return_value=True,
+        )
+
+        mocker.patch(
+            MOD_PATH + ".util.load_text_file",
+            return_value=None,
+        )
+
+        mocker.patch(
+            DHCP_MOD_PATH + ".run_nmcli",
+            return_value=dedent(
+                """
+                   ens160:ethernet:connected:Wired connection 1
+                   lo:loopback:connected (externally):lo
+                   ens256:ethernet:unavailable:
+                """
+            ),
+        )
+
+        with patch(
+            DHCP_MOD_PATH + ".network_manager_load_leases",
+            return_value={"domain_name": domain_name},
+        ):
+            result = cloudstack_ds._get_domainname()
+        assert self.nm_domainname == result
+
+    def test_get_domainname_nm_no_conn_nic(
+        self, cloudstack_ds, mocker, caplog
+    ):
+        """
+        Test if DataSourceCloudStack._get_domainname()
+        can handle one connected nic environments.
+        """
+        get_networkd_domain = mock.MagicMock(return_value=None)
+        mocker.patch(
+            DHCP_MOD_PATH + ".networkd_get_option_from_leases",
+            get_networkd_domain,
+        )
+        mocker.patch(
+            MOD_PATH + ".dhcp.IscDhclient.get_newest_lease_file_from_distro",
+            return_value=True,
+        )
+
+        mocker.patch(
+            MOD_PATH + ".util.load_text_file",
+            return_value=None,
+        )
+
+        mocker.patch(
+            DHCP_MOD_PATH + ".run_nmcli",
+            return_value=dedent(
+                """
+                   lo:loopback:connected (externally):lo
+                   ens256:ethernet:unavailable:
+                """
+            ),
+        )
+
+        result = cloudstack_ds._get_domainname()
+        assert "Could not obtain FQDN from NM leases" in caplog.text
+        assert (
+            "No domain name found in any DHCP lease; returning empty"
+            in caplog.text
+        )
+        assert result == ""
+
+    def test_get_domainname_nm_nodhcp_lease_err(
+        self, cloudstack_ds, mocker, caplog
+    ):
+        """
+        Test if DataSourceCloudStack._get_domainname()
+        can handle NoDHCPLeaseError.
+        """
+        get_networkd_domain = mock.MagicMock(return_value=None)
+        mocker.patch(
+            DHCP_MOD_PATH + ".networkd_get_option_from_leases",
+            get_networkd_domain,
+        )
+        mocker.patch(
+            MOD_PATH + ".dhcp.IscDhclient.get_newest_lease_file_from_distro",
+            return_value=True,
+        )
+
+        mocker.patch(
+            MOD_PATH + ".util.load_text_file",
+            return_value=None,
+        )
+
+        mocker.patch(
+            DHCP_MOD_PATH + ".network_manager_get_option_from_leases",
+            side_effect=NoDHCPLeaseError,
+        )
+
+        cloudstack_ds._get_domainname()
+        assert "Could not obtain FQDN from NM leases" in caplog.text
+
     def test_get_hostname_non_fqdn(self, cloudstack_ds):
         """
         Test get_hostname() method implementation
@@ -188,6 +384,12 @@ class TestCloudStackHostname:
         mocker.patch(
             DHCP_MOD_PATH + ".networkd_get_option_from_leases",
             get_networkd_domain,
+        )
+
+        get_nm_domain = mock.MagicMock(return_value=None)
+        mocker.patch(
+            DHCP_MOD_PATH + ".network_manager_get_option_from_leases",
+            get_nm_domain,
         )
 
         mocker.patch(

--- a/tests/unittests/sources/test_cloudstack.py
+++ b/tests/unittests/sources/test_cloudstack.py
@@ -492,9 +492,17 @@ class TestGetDataServer:
     MOD_PATH + ".dhcp.networkd_get_option_from_leases",
     return_value="10.1.37.132",
 )
+@mock.patch(
+    MOD_PATH + ".dhcp.network_manager_get_option_from_leases",
+    return_value="10.1.37.135",
+)
 class TestGetVrAddress:
     def test_get_vr_addr_from_dns(
-        self, m_networkd_option_from_leases, m_get_data_server, caplog
+        self,
+        m_nm_get_option_from_leases,
+        m_networkd_option_from_leases,
+        m_get_data_server,
+        caplog,
     ):
         """cloud-init first obtains data-server if resolved by DNS"""
         assert "10.1.37.131" == get_vr_address(MockDistro())
@@ -505,7 +513,12 @@ class TestGetVrAddress:
         assert 0 == m_networkd_option_from_leases.call_count
 
     def test_get_vr_addr_from_networkd_leases(
-        self, m_networkd_option_from_leases, m_get_data_server, mocker, caplog
+        self,
+        m_nm_get_option_from_leases,
+        m_networkd_option_from_leases,
+        m_get_data_server,
+        mocker,
+        caplog,
     ):
         """When no DNS for data-server use networkd dhcp-server-identifier"""
         mocker.patch(MOD_PATH + ".get_data_server", return_value=None)
@@ -515,6 +528,36 @@ class TestGetVrAddress:
             in caplog.text
         )
         m_networkd_option_from_leases.assert_called_once_with("SERVER_ADDRESS")
+
+    def test_get_vr_addr_from_network_manager_leases(
+        self,
+        m_nm_get_option_from_leases,
+        m_networkd_option_from_leases,
+        m_get_data_server,
+        mocker,
+        caplog,
+    ):
+        """When no DNS for data-server or networkd or IscDhclient,
+        use dhcp_server_identifier from network manager lease"""
+        mocker.patch(MOD_PATH + ".get_data_server", return_value=None)
+        mocker.patch(
+            MOD_PATH + ".dhcp.networkd_get_option_from_leases",
+            return_value=None,
+        )
+        mocker.patch(
+            DHCP_MOD_PATH + ".IscDhclient.get_newest_lease",
+            return_value=None,
+        )
+        assert "10.1.37.135" == get_vr_address(MockDistro())
+        m_which = mocker.patch(
+            "cloudinit.net.dhcp.subp.which",
+            return_value=None,
+        )
+        assert "10.1.37.135" == get_vr_address(MockDistro())
+        m_which.assert_called_once_with("dhclient")
+        m_nm_get_option_from_leases.assert_called_with(
+            "dhcp_server_identifier"
+        )
 
 
 @pytest.mark.usefixtures("dhclient_exists")
@@ -536,6 +579,10 @@ class TestCloudStackPasswordFetching:
                 "expire": "5 2017/07/28 07:08:15",
                 "dhcp-server-identifier": "168.63.129.16",
             },
+        )
+        mocker.patch(
+            DHCP_MOD_PATH + ".network_manager_get_option_from_leases",
+            return_value=None,
         )
         get_newest_lease_file_from_distro = mock.MagicMock(return_value=None)
         mocker.patch(
@@ -702,11 +749,11 @@ class TestDataSourceCloudStackLocal:
         MOD_PATH + ".EphemeralIPNetwork",
         autospec=True,
     )
-    @mock.patch(MOD_PATH + ".net.find_fallback_nic")
-    # @mock.patch(MOD_PATH + ".get_vr_address", return_value="10.1.37.131")
+    @mock.patch(MOD_PATH + ".net.find_fallback_nic", return_value="enp0s1")
+    @mock.patch(MOD_PATH + ".get_vr_address", return_value="10.1.37.131")
     def test_local_datasource_success(
         self,
-        # m_get_vr_address,
+        m_get_vr_address,
         m_find_fallback_nic,
         m_dhcp,
         m_wait_for_mds,
@@ -720,7 +767,6 @@ class TestDataSourceCloudStackLocal:
             {}, distro, helpers.Paths({"run_dir": tmpdir})
         )
 
-        m_find_fallback_nic.return_value = "enp0s1"
         m_dhcp.return_value.__enter__.side_effect = (None,)
         m_wait_for_mds.return_value = (True,)
         m_get_userdata.return_value = "ud"


### PR DESCRIPTION
This is a series of four independent commits.
The first commit adds helper functions in dhcp module to get dhcp lease information from network manager.
The second commit fixes a mock leak in existing cloudstack unit test code.
The third commit adds ability in cloud stack code trying to get domain name use network manager leases as well (in addition to trying networtkd and isa dhclient as it does today already).
The fourth commit adds support in cloud stack code to get VR information from network manager lease information.

This change has been tested by our (Red Hat) customer. After the change, we see logs of this type:
```
2026-04-04 15:19:54,813 - DataSourceCloudStack.py[DEBUG]: FQDN requested
2026-04-04 15:19:54,813 - DataSourceCloudStack.py[DEBUG]: Try obtaining domain name from networkd leases
2026-04-04 15:19:54,813 - DataSourceCloudStack.py[DEBUG]: Could not obtain FQDN from networkd leases. Falling back to ISC dhclient
2026-04-04 15:19:54,813 - DataSourceCloudStack.py[DEBUG]: Could not obtain FQDN from ISC dhclient leases. Falling back to Network Manager leases
2026-04-04 15:19:54,814 - subp.py[DEBUG]: Running command ['/usr/bin/nmcli', '-f', 'DHCP4', 'd', 'show'] with allowed return codes [0] (shell=False, capture=True)
2026-04-04 15:19:54,827 - performance.py[DEBUG]: Running ['/usr/bin/nmcli', '-f', 'DHCP4', 'd', 'show'] took 0.014 seconds
2026-04-04 15:19:54,828 - DataSourceCloudStack.py[DEBUG]: Obtained the following FQDN: foo.bar.baz.com
2026-04-04 15:19:54,828 - xxx[DEBUG]: XYZ hostname: foo.bar.baz.com
``` 


## Proposed Commit Message
Commit 1:

    feat(dhcp): Add network manager lease parsing capability
    
    DHCP leases can be directly obtained from network manager through appropriate
    command to the network manager cli. Add a couple of helper functions to get
    the lease information from network manager.
    
    In a subsequent patch, we will use the helper function from cloud stack
    datasource to get the lease information from network manager.

Commit 2:

    test: fix test_get_domainname_isc_dhclient mock leak
    
    Without mocking out dhcp.IscDhclient.get_newest_lease_file_from_distro, the
    functions on some platforms returns None. This means
    get_key_from_latest_lease() bails out early without calling parse_leases()
    to parse the lease file. Fix it.

Commit 3:

    fix(cloudstack): get domain name information from network manager leases

    Red Hat uses network manager as the supported dhcp client. If network manager
    cli is available, we should try to get domain name information directly from
    the network manager leases before asking distro specific dhcp client
    (dhcpcd by default).

Commit 4:

    fix(cloudstack): get vr information from network manager leases (#6829)
    
    Red Hat distributions uses network manager to manage DHCP leases. This change
    adds support for obtaining vr address information from DHCP leases maintained
    by network manager.
 
## Merge type

- [] Squash merge using "Proposed Commit Message"
- [x] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
