### PR TITLE
fix: pass force=True to update_package_sources

### DIFF
--- a/cloudinit/config/cc_package_update_upgrade_install.py
+++ b/cloudinit/config/cc_package_update_upgrade_install.py
@@ -75,7 +75,7 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     errors = []
     if update or upgrade:
         try:
-            cloud.distro.update_package_sources()
+            cloud.distro.update_package_sources(force=True)
         except Exception as e:
             util.logexc(LOG, "Package update failed")
             errors.append(e)

--- a/cloudinit/distros/aosc.py
+++ b/cloudinit/distros/aosc.py
@@ -9,7 +9,7 @@ from cloudinit import distros, helpers, subp, util
 from cloudinit.distros import PackageList
 from cloudinit.distros.parsers.hostname import HostnameConf
 from cloudinit.distros.parsers.sys_conf import SysConf
-from cloudinit.settings import PER_INSTANCE
+from cloudinit.settings import PER_ALWAYS, PER_INSTANCE
 
 LOG = logging.getLogger(__name__)
 
@@ -112,7 +112,7 @@ class Distro(distros.Distro):
             "update-sources",
             self.package_command,
             "refresh",
-            freq=PER_INSTANCE,
+            freq=PER_ALWAYS if force else PER_INSTANCE,
         )
 
 

--- a/tests/unittests/config/test_cc_package_update_upgrade_install.py
+++ b/tests/unittests/config/test_cc_package_update_upgrade_install.py
@@ -288,6 +288,43 @@ class TestMultiplePackageManagers:
         )
 
 
+class TestPackageUpdateForce:
+    def test_package_update_calls_update_sources_with_force(
+        self, common_mocks
+    ):
+        """update_package_sources must be called with force=True when
+        package_update is configured, so the semaphore is bypassed."""
+        cloud = get_cloud("ubuntu")
+        cfg = {"package_update": True}
+        handle("", cfg, cloud, [])
+        cloud.distro.update_package_sources.assert_called_once_with(force=True)
+
+    def test_package_upgrade_calls_update_sources_with_force(
+        self, common_mocks, mocker
+    ):
+        """update_package_sources must be called with force=True when
+        package_upgrade is configured, so the semaphore is bypassed."""
+        mocker.patch("cloudinit.subp.subp", return_value=SubpResult("{}", ""))
+        cloud = get_cloud("ubuntu")
+        cfg = {"package_upgrade": True}
+        handle("", cfg, cloud, [])
+        cloud.distro.update_package_sources.assert_called_once_with(force=True)
+
+    def test_no_update_sources_when_no_update_or_upgrade(self, common_mocks):
+        """update_package_sources should not be called when neither
+        package_update nor package_upgrade is set."""
+
+        def _subp(*args, **kwargs):
+            if args and "apt-cache" in args[0]:
+                return SubpResult("git\n", None)
+
+        cloud = get_cloud("ubuntu")
+        cfg = {"packages": ["git"]}
+        with mock.patch("cloudinit.subp.subp", side_effect=_subp):
+            handle("", cfg, cloud, [])
+        cloud.distro.update_package_sources.assert_not_called()
+
+
 class TestPackageUpdateUpgradeSchema:
     @pytest.mark.parametrize(
         "config, error_msg",


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [x] I have signed the CLA: https://ubuntu.com/legal/contributors
- [x] I have included a comprehensive commit message using the guide below
- [x] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [x] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [x] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e doc``.
-->


## Proposed Commit Message
fix: pass `force=True` to `update_package_sources` in `cc_package_update_upgrade_install`

When `package_update` or `package_upgrade` is set, `apt-get update` was being
skipped on re-runs because `update_package_sources` had a hardcoded
`PER_INSTANCE` semaphore. Pass `force=True` so the package cache is always
refreshed when the module is configured to update packages.

Also fix `aosc.py` which accepted the force parameter but silently ignored
it by hardcoding `freq=PER_INSTANCE`.

Fixes GH-3218
LP: #1785225

## Test Steps

```bash
tox -e py3 -- tests/unittests/config/test_cc_package_update_upgrade_install.py -vv
```
Verified that `update_package_sources` is called with `force=True` when `package_update` or `package_upgrade` is configured, and not called at all when neither is set.

## Merge type

- [x] Squash merge using "Proposed Commit Message"

