### PR TITLE
fix(CloudStack): Ensure primary_nic Defined Before Attempting DHCP

### DIFF
--- a/cloudinit/sources/DataSourceCloudStack.py
+++ b/cloudinit/sources/DataSourceCloudStack.py
@@ -198,6 +198,7 @@ class DataSourceCloudStack(sources.DataSource):
 
     def _get_data(self):
         seed_ret = {}
+        primary_nic = None
         if util.read_optional_seed(seed_ret, base=(self.seed_dir + "/")):
             self.userdata_raw = seed_ret["user-data"]
             self.metadata = seed_ret["meta-data"]


### PR DESCRIPTION
Ensure that primary_nic is always assigned a value due since there is always a possibility that it can be dereferenced when logging a failure to obtain DHCP

Signed-off-by: Bryan Fraschetti \<bryan.fraschetti@canonical.com\>

Fixes: GH-6838