### PR TITLE
fix(net): do not resolve IPs when netloc contains a port

### DIFF
--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -1298,7 +1298,7 @@ def is_resolvable(url) -> bool:
 
     # Early return for IP addresses - no DNS resolution needed
     with suppress(ValueError):
-        if net.is_ip_address(parsed_url.netloc.strip("[]")):
+        if net.is_ip_address(name):
             return True
     try:
         hostname_result = socket.getaddrinfo(name, None)

--- a/tests/unittests/test_util.py
+++ b/tests/unittests/test_util.py
@@ -3185,6 +3185,8 @@ class TestResolvable:
         """
         assert util.is_resolvable("http://169.254.169.254/") is True
         assert util.is_resolvable("http://[fd00:ec2::254]/") is True
+        assert util.is_resolvable("http://169.254.169.254:80") is True
+        assert util.is_resolvable("http://[fd00:ec2::254]:80/") is True
         assert not m_getaddr.called
 
     @mock.patch.object(util.net, "is_ip_address")
@@ -3206,6 +3208,7 @@ class TestResolvable:
         m_getaddr.side_effect = mock_getaddrinfo
 
         assert util.is_resolvable("http://example.com/") is True
+        assert util.is_resolvable("http://example.com/:80") is True
         assert m_getaddr.called
 
         assert m_getaddr.call_args_list[0] == mock.call("example.com", None)


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [x] I have signed the CLA: https://ubuntu.com/legal/contributors
- [x] I have included a comprehensive commit message using the guide below
- [x] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [x] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [x] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e doc``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix(util): include port-stripped hostname in IP fast-path check

The existing IP fast-path optimization only checked parsed_url.netloc,
which includes port information. This meant IP URLs with ports (e.g.
http://169.254.169.254:80) did not benefit from the optimization and
still triggered DNS resolution.

This improves the existing logic by using parsed_url.hostname, which
correctly excludes port information while preserving IP detection.

Fixes #6557
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
Tested with:
tox -e py3

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
