### PR TITLE
fix(net): add NET_ADDR_STOLEN exceptions for r8152

### DIFF
--- a/cloudinit/net/__init__.py
+++ b/cloudinit/net/__init__.py
@@ -968,10 +968,13 @@ def get_interfaces_by_mac_on_openbsd() -> dict:
 def get_interfaces_by_mac_on_linux() -> dict:
     """Build a dictionary of tuples {mac: name}.
 
-    Bridges and any devices that have a 'stolen' mac are excluded."""
+    Bridges and any devices that have a non-unique 'stolen' mac are
+    excluded."""
     ret: dict = {}
 
-    for name, mac, driver, _devid in get_interfaces():
+    for name, mac, driver, _devid in get_interfaces(
+        filter_without_own_mac=False
+    ):
         if mac in ret:
             # This is intended to be a short-term fix of LP: #1997922
             # Long term, we should better handle configuration of virtual
@@ -986,6 +989,45 @@ def get_interfaces_by_mac_on_linux() -> dict:
                     name,
                     ret[mac],
                     driver,
+                )
+                continue
+
+            stored_is_real = interface_has_own_mac(ret[mac])
+            current_is_real = interface_has_own_mac(name)
+            if not stored_is_real and current_is_real:
+                LOG.debug(
+                    "Replacing mac '%s' mapping from '%s' to '%s' "
+                    "because '%s' is a real device and '%s' stole its mac.",
+                    mac,
+                    ret[mac],
+                    name,
+                    name,
+                    ret[mac],
+                )
+                ret[mac] = name
+                continue
+            elif stored_is_real and not current_is_real:
+                LOG.debug(
+                    "Keeping mac '%s' mapping to '%s' instead of '%s' "
+                    "because '%s' is a real device and '%s' stole its mac.",
+                    mac,
+                    ret[mac],
+                    name,
+                    ret[mac],
+                    name,
+                )
+                continue
+            elif not stored_is_real and not current_is_real:
+                # We should probably anticipate having a real device if we have
+                # two devices with the same mac and both are stolen, but for
+                # now just log and keep the first one we found.
+                LOG.debug(
+                    "Both '%s' and '%s' have mac '%s', but both are stolen "
+                    "mac. Keeping the first mapping to '%s'.",
+                    name,
+                    ret[mac],
+                    mac,
+                    ret[mac],
                 )
                 continue
 

--- a/cloudinit/net/__init__.py
+++ b/cloudinit/net/__init__.py
@@ -968,10 +968,19 @@ def get_interfaces_by_mac_on_openbsd() -> dict:
 def get_interfaces_by_mac_on_linux() -> dict:
     """Build a dictionary of tuples {mac: name}.
 
-    Bridges and any devices that have a 'stolen' mac are excluded."""
+    Bridges and devices that have a 'stolen' mac are excluded,
+    with exception of r8152."""
     ret: dict = {}
 
-    for name, mac, driver, _devid in get_interfaces():
+    for name, mac, driver, _devid in get_interfaces(
+        filter_without_own_mac=False
+    ):
+        # Filter out interfaces that don't have their own MAC address, except
+        # for r8152: it reports NET_ADDR_STOLEN when using pass-thru MAC
+        # address. See https://github.com/canonical/cloud-init/issues/6110
+        if not interface_has_own_mac(name) and driver != "r8152":
+            continue
+
         if mac in ret:
             # This is intended to be a short-term fix of LP: #1997922
             # Long term, we should better handle configuration of virtual
@@ -987,6 +996,34 @@ def get_interfaces_by_mac_on_linux() -> dict:
                     ret[mac],
                     driver,
                 )
+                continue
+
+            # In case of Dell hardware, all Dell USB Ethernet interfaces (Dock,
+            # builtin USB NICs for laptops) will be assigned MAC address +1
+            # from the onboard NIC.  If there are multiple USB Ethernet
+            # interfaces, they will all use the same +1 MAC address. When it
+            # happens, tiebreak by preferring the interface that is connected,
+            # otherwise prefer the one that's lexically smaller.
+            if driver == "r8152":
+                # Prefer the connected interface (has carrier).  If both or
+                # neither are connected, fall back to a deterministic choice
+                # (the lexically smallest name) so the result is stable
+                # across enumeration order.
+                carrier = bool(read_sys_net_int(name, "carrier"))
+                stored_carrier = bool(read_sys_net_int(ret[mac], "carrier"))
+                if carrier > stored_carrier or (
+                    carrier == stored_carrier and name < ret[mac]
+                ):
+                    LOG.debug(
+                        "Replacing mac '%s' mapping from '%s' to '%s' "
+                        "(carrier: %s -> %s).",
+                        mac,
+                        ret[mac],
+                        name,
+                        stored_carrier,
+                        carrier,
+                    )
+                    ret[mac] = name
                 continue
 
             msg = "duplicate mac found! both '%s' and '%s' have mac '%s'." % (

--- a/tests/unittests/sources/test_azure.py
+++ b/tests/unittests/sources/test_azure.py
@@ -2212,7 +2212,7 @@ scbus-1 on xpt0 bus 0
         dsrc.get_data()
 
         distro.networking.get_interfaces_by_mac()
-        m_net_get_interfaces.assert_called_with()
+        m_net_get_interfaces.assert_called_with(filter_without_own_mac=False)
 
     @mock.patch(
         "cloudinit.sources.helpers.azure.OpenSSLManager.parse_certificates"

--- a/tests/unittests/sources/test_azure.py
+++ b/tests/unittests/sources/test_azure.py
@@ -2322,7 +2322,7 @@ scbus-1 on xpt0 bus 0
         dsrc.get_data()
 
         distro.networking.get_interfaces_by_mac()
-        m_net_get_interfaces.assert_called_with()
+        m_net_get_interfaces.assert_called_with(filter_without_own_mac=False)
 
     @mock.patch(
         "cloudinit.sources.helpers.azure.OpenSSLManager.parse_certificates"

--- a/tests/unittests/test_net.py
+++ b/tests/unittests/test_net.py
@@ -5657,6 +5657,28 @@ class TestGetInterfacesByMac:
         }
         assert expected == result
 
+    def test_real_device_preferred_over_stolen_mac(self, mocks):
+        """When a real device and a stolen-mac device share the same MAC,
+        the real device should win regardless of enumeration order."""
+        shared_mac = "aa:aa:aa:aa:aa:ff"
+        self.data["macs"]["real0"] = shared_mac
+        self.data["macs"]["stolen0"] = shared_mac
+        self.data["devices"].update({"real0", "stolen0"})
+        self.data["own_macs"].append("real0")
+        # stolen0 is intentionally NOT added to own_macs
+        ret = net.get_interfaces_by_mac()
+        assert ret[shared_mac] == "real0"
+
+    def test_stolen_mac_only_device_is_included(self, mocks):
+        """A device with a stolen MAC should still appear in the map when
+        it is the only device with that MAC address."""
+        stolen_mac = "aa:aa:aa:aa:aa:dd"
+        self.data["macs"]["stolen_only"] = stolen_mac
+        self.data["devices"].add("stolen_only")
+        # stolen_only is intentionally NOT added to own_macs
+        ret = net.get_interfaces_by_mac()
+        assert ret[stolen_mac] == "stolen_only"
+
 
 @pytest.mark.parametrize("driver", ("mscc_felix", "fsl_enetc", "qmi_wwan"))
 @mock.patch("cloudinit.net.get_sys_class_path")

--- a/tests/unittests/test_net.py
+++ b/tests/unittests/test_net.py
@@ -5645,6 +5645,75 @@ class TestGetInterfacesByMac:
         }
         assert expected == result
 
+    def test_r8152_passthru_mac_is_included(self, mocks):
+        """An onboard NIC keeps its own MAC while a r8152 dock/USB NIC is
+        assigned a pass-thru (stolen) MAC of [onboard]+1.  The two do not
+        collide, so both must be enumerated.  See GH-6110."""
+        onboard_mac = "aa:aa:aa:aa:aa:10"
+        passthru_mac = "aa:aa:aa:aa:aa:11"  # [onboard_mac] + 1
+        self.data["macs"]["onboard0"] = onboard_mac
+        self.data["macs"]["usb0"] = passthru_mac
+        self.data["devices"].update({"onboard0", "usb0"})
+        self.data["own_macs"].append("onboard0")
+        self.data["drivers"]["usb0"] = "r8152"
+        # usb0 uses a pass-thru MAC and is intentionally NOT in own_macs
+        ret = net.get_interfaces_by_mac()
+        assert ret[onboard_mac] == "onboard0"
+        assert ret[passthru_mac] == "usb0"
+
+    def test_non_r8152_stolen_mac_is_excluded(self, mocks):
+        """A stolen MAC from any driver other than r8152 keeps the previous
+        behaviour and is excluded from the mapping."""
+        stolen_mac = "aa:aa:aa:aa:aa:20"
+        self.data["macs"]["inherit0"] = stolen_mac
+        self.data["devices"].add("inherit0")
+        self.data["drivers"]["inherit0"] = "some_virt_driver"
+        # inherit0 has a stolen mac (intentionally NOT in own_macs)
+        ret = net.get_interfaces_by_mac()
+        assert stolen_mac not in ret
+
+    def test_r8152_duplicate_passthru_macs_prefer_connected(self, mocks):
+        """Multiple Dell USB NICs are all assigned the same [mac]+1 pass-thru
+        address.  When they collide, prefer the interface that is connected
+        (has carrier), regardless of enumeration order."""
+        dup_mac = "aa:aa:aa:aa:aa:30"
+        self.data["macs"]["usb0"] = dup_mac
+        self.data["macs"]["usb1"] = dup_mac
+        self.data["drivers"]["usb0"] = "r8152"
+        self.data["drivers"]["usb1"] = "r8152"
+        # Enumerate the connected NIC (usb1) FIRST, and make it lexically
+        # greater, so a lexical tiebreak alone would wrongly pick usb0.
+        # The connected NIC must still win.
+        self.data["devices"] = ["usb1", "usb0"]
+        carrier = {"usb0": 0, "usb1": 1}
+        with mock.patch(
+            "cloudinit.net.read_sys_net_int",
+            side_effect=lambda name, field: carrier.get(name),
+        ):
+            ret = net.get_interfaces_by_mac()
+        assert ret[dup_mac] == "usb1"
+
+    def test_r8152_duplicate_passthru_macs_none_connected_prefers_lexical(
+        self, mocks
+    ):
+        """When multiple r8152 pass-thru NICs share a MAC and none are
+        connected, fall back to a deterministic choice (the lexically smallest
+        name) so the result is stable across enumeration order."""
+        dup_mac = "aa:aa:aa:aa:aa:31"
+        self.data["macs"]["usb2"] = dup_mac
+        self.data["macs"]["usb1"] = dup_mac
+        self.data["drivers"]["usb2"] = "r8152"
+        self.data["drivers"]["usb1"] = "r8152"
+        # Enumerate the lexically-greater NIC (usb2) first to prove the choice
+        # does not depend on order; neither is connected.
+        self.data["devices"] = ["usb2", "usb1"]
+        with mock.patch(
+            "cloudinit.net.read_sys_net_int",
+            side_effect=lambda name, field: 0,
+        ):
+            ret = net.get_interfaces_by_mac()
+        assert ret[dup_mac] == "usb1"
+
 
 @pytest.mark.parametrize("driver", ("mscc_felix", "fsl_enetc", "qmi_wwan"))
 @mock.patch("cloudinit.net.get_sys_class_path")


### PR DESCRIPTION
Fixes #6110

## Proposed Commit Message
```
fix(net): add NET_ADDR_STOLEN exceptions for r8152

A recent kernel commit began using NET_ADDR_STOLEN in /sys/class/net/<iface>/
addr_assign_type for interfaces using MAC passthrough in the r8152 USB NIC
driver.

This will allow r8152 with MAC pass-through to be listed in
`get_interfaces_by_mac_on_linux` function.

Fixes: GH-6110
```

## Test Steps
* Find devices where the system can assign a MAC address to the external device. e.g. Dell laptop with a Dell dock with MAC passthrough enabled, or Dell laptop with an additional USB PHY interface with MAC passthrough.
* Ensure two interfaces have similar MACs but not the same.
* Use cloud-init to provision the system.


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
