### PR TITLE
fix(netplan): handle ipv6_slaac separately from dhcp6

### DIFF
--- a/cloudinit/net/netplan.py
+++ b/cloudinit/net/netplan.py
@@ -120,7 +120,10 @@ def _extract_addresses(config: dict, entry: dict, ifname, features: Callable):
                 dhcp_override["route-metric"] = sn_metric
                 entry.update({dhcp_override_key: dhcp_override})
         elif sn_type in IPV6_DYNAMIC_TYPES:
-            entry.update({"dhcp6": True})
+            if sn_type == "ipv6_slaac":
+                entry.update({"accept-ra": True})
+            else:
+                entry.update({"dhcp6": True})
             if sn_metric is not None:
                 # Add metric to DHCP6 override if specified in the subnet```
                 dhcp_override = entry.get("dhcp6-overrides", {})

--- a/tests/unittests/net/network_configs.py
+++ b/tests/unittests/net/network_configs.py
@@ -1669,7 +1669,7 @@ NETWORK_CONFIGS = {
                 version: 2
                 ethernets:
                     iface0:
-                        dhcp6: true
+                        accept-ra: true
         """
         ).rstrip(" "),
         "yaml": textwrap.dedent(


### PR DESCRIPTION
The netplan renderer treats `ipv6_slaac` subnet type identically to `dhcp6`, generating `dhcp6: true` in the netplan config. This causes VMs to acquire DHCPv6 addresses in addition to SLAAC addresses, which is not the expected behavior for SLAAC.

Root cause: all `IPV6_DYNAMIC_TYPES` (which includes `ipv6_slaac`, `dhcp6`, `ipv6_dhcpv6-stateless`, and `ipv6_dhcpv6-stateful`) share a single code path that unconditionally sets `dhcp6: True`.

The other renderers (eni, sysconfig, NetworkManager) each handle `ipv6_slaac` as a distinct case:
- **eni**: sets `iface inet6 auto` with `dhcp 0`
- **sysconfig**: has a dedicated `elif` branch for `ipv6_slaac`
- **NetworkManager**: maps `ipv6_slaac` to method `auto` (distinct from DHCPv6)

This change makes the netplan renderer consistent: for `ipv6_slaac` subnets it now emits `accept-ra: true` instead of `dhcp6: true`. The netplan renderer already has plumbing for `accept-ra` at line 201 of `netplan.py`.

Fixes #6847