### PR TITLE
feat: owasp security event logging for user, password, and shutdown

### DIFF
--- a/cloudinit/distros/__init__.py
+++ b/cloudinit/distros/__init__.py
@@ -659,6 +659,14 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
     def get_default_user(self):
         return self.get_option("default_user")
 
+    def _get_elevated_roles(self, **kwargs: Dict[str, Any]) -> List[str]:
+        elevated_roles = []
+        if kwargs.get("sudo"):
+            elevated_roles.append("sudo")
+        if kwargs.get("doas"):
+            elevated_roles.append("doas")
+        return elevated_roles
+
     def add_user(self, name, **kwargs) -> bool:
         """
         Add a user to the system using standard GNU tools

--- a/cloudinit/distros/__init__.py
+++ b/cloudinit/distros/__init__.py
@@ -10,6 +10,7 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
 import abc
+import functools
 import logging
 import os
 import re
@@ -52,6 +53,11 @@ from cloudinit.distros.package_management.utils import known_package_managers
 from cloudinit.distros.parsers import hosts
 from cloudinit.features import ALLOW_EC2_MIRRORS_ON_NON_AWS_INSTANCE_TYPES
 from cloudinit.lifecycle import log_with_downgradable_level
+from cloudinit.log.security_event_log import (
+    OWASPEventLevel,
+    OWASPEventType,
+    log_security_event,
+)
 from cloudinit.net import activators, dhcp, renderers
 from cloudinit.net.netops import NetOps
 from cloudinit.net.network_state import parse_net_config_data
@@ -121,6 +127,97 @@ PackageList = Union[
     List[Union[str, List[str]]],
     List[Union[str, List[str], Mapping]],
 ]
+
+
+def sec_log_user_created(func):
+    """A decorator to log a user creation event and group attributes."""
+
+    @functools.wraps(func)
+    def decorator(
+        self, name: str, *args, groups: Optional[List[str]] = None, **kwargs
+    ):
+        if not name:
+            raise RuntimeError(
+                "sec_log_user_created requires positional param name or kwarg"
+            )
+        params = [name]
+        groups_msg = ""
+        if groups is None:
+            groups = []
+        all_groups = groups + _get_elevated_roles(**kwargs)
+        if all_groups:
+            groups_suffix = ",".join(all_groups)
+            groups_msg = f" in groups: {groups_suffix}"
+            params.append(f"groups:{groups_suffix}")
+
+        response = func(self, name, groups=groups, *args, **kwargs)
+        log_security_event(
+            event_type=OWASPEventType.USER_CREATED,
+            level=OWASPEventLevel.INFO,
+            description=f"User '{name}' was created{groups_msg}",
+            event_params=params,
+        )
+        return response
+
+    return decorator
+
+
+def sec_log_password_changed_batch(func):
+    @functools.wraps(func)
+    def decorator(self, plist_in: List[Tuple[str, str]], *args, **kwargs):
+        response = func(self, plist_in, *args, **kwargs)
+        for userid, _ in plist_in:
+            log_security_event(
+                event_type=OWASPEventType.AUTHN_PASSWORD_CHANGE,
+                level=OWASPEventLevel.INFO,
+                description=f"Password changed for user '{userid}'",
+                event_params=[userid],
+            )
+        return response
+
+    return decorator
+
+
+def sec_log_password_changed(func):
+    """A decorator logging a password change event."""
+
+    @functools.wraps(func)
+    def decorator(self, user: str, *args, **kwargs):
+        response = func(self, user, *args, **kwargs)
+        log_security_event(
+            event_type=OWASPEventType.AUTHN_PASSWORD_CHANGE,
+            level=OWASPEventLevel.INFO,
+            description=f"Password changed for user '{user}'",
+            event_params=[user],
+        )
+        return response
+
+    return decorator
+
+
+def sec_log_system_shutdown(func):
+    """A decorator logging a system shutdown event."""
+
+    @functools.wraps(func)
+    def decorator(cls, mode: str, delay: str, message):
+        if mode == "reboot":
+            event_type = OWASPEventType.SYS_RESTART
+            description = "System restart initiated"
+        else:
+            event_type = OWASPEventType.SYS_SHUTDOWN
+            description = "System shutdown initiated"
+        if message:
+            description += f": {message}"
+
+        log_security_event(
+            event_type=event_type,
+            level=OWASPEventLevel.INFO,
+            description=description,
+            additional_data={"delay": delay, "mode": mode},
+        )
+        return func(cls, mode=mode, delay=delay, message=message)
+
+    return decorator
 
 
 class PackageInstallerError(Exception):
@@ -658,14 +755,6 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
 
     def get_default_user(self):
         return self.get_option("default_user")
-
-    def _get_elevated_roles(self, **kwargs: Dict[str, Any]) -> List[str]:
-        elevated_roles = []
-        if kwargs.get("sudo"):
-            elevated_roles.append("sudo")
-        if kwargs.get("doas"):
-            elevated_roles.append("doas")
-        return elevated_roles
 
     def add_user(self, name, **kwargs) -> bool:
         """
@@ -1605,6 +1694,21 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
         It is called during cloud-init's network stage if it was determined
         that network connectivity is necessary in cloud-init's network stage.
         """
+
+
+def _get_elevated_roles(
+    *,
+    sudo: Optional[str] = None,
+    doas: Optional[List[str]] = None,
+    **kwargs,
+) -> List[str]:
+    """Return a list of elevated roles provided as keyword arguments."""
+    elevated_roles = []
+    if sudo:
+        elevated_roles.append("sudo")
+    if doas:
+        elevated_roles.append("doas")
+    return elevated_roles
 
 
 def _apply_hostname_transformations_to_url(url: str, transformations: list):

--- a/cloudinit/log/loggers.py
+++ b/cloudinit/log/loggers.py
@@ -114,7 +114,7 @@ def setup_security_logging(
     handler.setFormatter(SecurityFormatter())
     handler.addFilter(SecurityOnlyFilter())
     handler.setLevel(SECURITY)
-    logging.getLogger().addHandler(handler)
+    root.addHandler(handler)
 
 
 def flush_loggers(root):
@@ -189,6 +189,8 @@ def setup_logging(cfg=None):
 
             # Attempt to load its config.
             logging.config.fileConfig(log_cfg)
+            for h in root_logger.handlers:
+                h.addFilter(NoSecurityFilter())
             setup_security_logging(root_logger)
 
             # Configure warning exporter after loading logging configuration

--- a/cloudinit/log/loggers.py
+++ b/cloudinit/log/loggers.py
@@ -11,6 +11,7 @@
 import collections.abc  # pylint: disable=import-error
 import copy
 import io
+import json
 import logging
 import logging.config
 import logging.handlers
@@ -22,6 +23,8 @@ from contextlib import suppress
 from typing import DefaultDict
 
 DEFAULT_LOG_FORMAT = "%(asctime)s - %(filename)s[%(levelname)s]: %(message)s"
+SECURITY_LOG_FORMAT = "%(message)s"
+SECURITY = logging.WARNING - 5
 DEPRECATED = 35
 TRACE = logging.DEBUG - 5
 
@@ -41,6 +44,49 @@ class CustomLoggerType(logging.Logger):
     def deprecated(self, *args, **kwargs):
         pass
 
+    def security(self, *args, **kwargs):
+        pass
+
+
+SECURITY_LOG_FILE = "/var/log/cloud-init-security.log"
+
+
+class SecurityOnlyFilter(logging.Filter):
+    """Pass only SECURITY level records."""
+
+    def filter(self, record):
+        return record.levelno == SECURITY
+
+
+class NoSecurityFilter(logging.Filter):
+    """Block SECURITY level records from non-security handlers."""
+
+    def filter(self, record):
+        return record.levelno != SECURITY
+
+
+class SecurityFormatter(logging.Formatter):
+    """Inject a 'datetime' field (UTC ISO-8601) into SECURITY JSON messages."""
+
+    # Provide ISO-8601 millisecond details and TZ info in datetime value.
+    default_time_format = "%Y-%m-%dT%H:%M:%S"
+    default_msec_format = "%s.%03d+00:00"
+
+    def format(self, record: logging.LogRecord) -> str:
+        # Use record.msg instead of getMessage which formats dict to JSON
+        if not isinstance(record.msg, dict):
+            raise ValueError(
+                f"SECURITY logs expected dict but found: {record.msg}"
+            )
+        # Produce compressed JSON lines with separators to avoid whitespace.
+        return json.dumps(
+            {
+                **record.msg,
+                "datetime": self.formatTime(record),
+            },
+            separators=(",", ":"),
+        )
+
 
 def setup_basic_logging(level=logging.DEBUG, formatter=None):
     formatter = formatter or logging.Formatter(DEFAULT_LOG_FORMAT)
@@ -48,8 +94,27 @@ def setup_basic_logging(level=logging.DEBUG, formatter=None):
     console = logging.StreamHandler(sys.stderr)
     console.setFormatter(formatter)
     console.setLevel(level)
+    console.addFilter(NoSecurityFilter())
     root.addHandler(console)
     root.setLevel(level)
+
+
+def setup_security_logging(
+    root: logging.Logger, log_file: str = SECURITY_LOG_FILE
+) -> None:
+    """Attach a FileHandler routing SECURITY records to log_file if absent."""
+    for h in root.handlers:
+        if isinstance(h, logging.FileHandler) and h.baseFilename == log_file:
+            return  # handler already attached
+
+    try:
+        handler = logging.FileHandler(log_file)
+    except OSError:
+        return
+    handler.setFormatter(SecurityFormatter())
+    handler.addFilter(SecurityOnlyFilter())
+    handler.setLevel(SECURITY)
+    logging.getLogger().addHandler(handler)
 
 
 def flush_loggers(root):
@@ -63,7 +128,7 @@ def flush_loggers(root):
 
 
 def define_extra_loggers() -> None:
-    """Add DEPRECATED and TRACE log levels to the logging module."""
+    """Add SECURITY, DEPRECATED and TRACE log levels to the logging module."""
 
     def new_logger(level):
         def log_at_level(self, message, *args, **kwargs):
@@ -72,8 +137,10 @@ def define_extra_loggers() -> None:
 
         return log_at_level
 
+    logging.addLevelName(SECURITY, "SECURITY")
     logging.addLevelName(DEPRECATED, "DEPRECATED")
     logging.addLevelName(TRACE, "TRACE")
+    setattr(logging.Logger, "security", new_logger(SECURITY))
     setattr(logging.Logger, "deprecated", new_logger(DEPRECATED))
     setattr(logging.Logger, "trace", new_logger(TRACE))
 
@@ -122,6 +189,7 @@ def setup_logging(cfg=None):
 
             # Attempt to load its config.
             logging.config.fileConfig(log_cfg)
+            setup_security_logging(root_logger)
 
             # Configure warning exporter after loading logging configuration
             root_logger.addHandler(exporter)
@@ -216,7 +284,10 @@ def configure_root_logger():
     # add handler only to the root logger
     handler = LogExporter()
     handler.setLevel(logging.WARN)
-    logging.getLogger().addHandler(handler)
+    handler.addFilter(NoSecurityFilter())
+    root_logger = logging.getLogger()
+    root_logger.addHandler(handler)
+    setup_security_logging(root_logger)
 
     # LogRecord allows us to report more useful information than __init__.py
     logging.setLogRecordFactory(CloudInitLogRecord)

--- a/cloudinit/log/loggers.py
+++ b/cloudinit/log/loggers.py
@@ -104,7 +104,7 @@ def setup_security_logging(
 ) -> None:
     """Attach a FileHandler routing SECURITY records to log_file if absent."""
     for h in root.handlers:
-        if isinstance(h, logging.FileHandler) and h.baseFilename == log_file:
+        if getattr(h, "baseFilename", None) == log_file:
             return  # handler already attached
 
     try:

--- a/cloudinit/log/loggers.py
+++ b/cloudinit/log/loggers.py
@@ -54,14 +54,14 @@ SECURITY_LOG_FILE = "/var/log/cloud-init-security.log"
 class SecurityOnlyFilter(logging.Filter):
     """Pass only SECURITY level records."""
 
-    def filter(self, record):
+    def filter(self, record) -> bool:
         return record.levelno == SECURITY
 
 
 class NoSecurityFilter(logging.Filter):
     """Block SECURITY level records from non-security handlers."""
 
-    def filter(self, record):
+    def filter(self, record) -> bool:
         return record.levelno != SECURITY
 
 

--- a/cloudinit/log/security_event_log.py
+++ b/cloudinit/log/security_event_log.py
@@ -1,0 +1,189 @@
+# This file is part of cloud-init. See LICENSE file for license information.
+
+"""
+OWASP-formatted Security Event Logging for cloud-init.
+
+This module provides security event logging following the OWASP Logging
+Vocabulary Cheat Sheet:
+https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/Logging_Vocabulary_Cheat_Sheet.md
+
+Security events are logged in JSON Lines format with standardized fields:
+- datetime: ISO 8601 timestamp with UTC offset
+- appid: Application identifier (canonical.cloud-init)
+- type: "security"
+- event: Event type with optional parameters (e.g., user_created:root,ubuntu)
+- level: INFO, WARN, or CRITICAL
+- description: Human-readable summary
+- host_ip: Optional IP address, included when network information is available.
+"""
+
+import functools
+import logging
+from enum import Enum
+from typing import Any, Dict, List, Optional, Tuple
+
+from cloudinit import util
+from cloudinit.log import loggers
+
+LOG = logging.getLogger(__name__)
+
+# Hard-coded application identifier
+APP_ID = "canonical.cloud-init"
+
+
+class OWASPEventLevel(Enum):
+    """OWASP log levels."""
+
+    INFO = "INFO"
+    WARN = "WARN"
+    CRITICAL = "CRITICAL"
+
+
+class OWASPEventType(Enum):
+    """OWASP security event types."""
+
+    # Authentication events [AUTHN]
+    AUTHN_PASSWORD_CHANGE = "authn_password_change"
+
+    # System events [SYS]
+    SYS_SHUTDOWN = "sys_shutdown"
+    SYS_RESTART = "sys_restart"
+
+    # User management events [USER]
+    USER_CREATED = "user_created"
+    # TODO(USER_UPDATED = "user_updated")
+
+
+def _log_security_event(
+    event_type: OWASPEventType,
+    level: OWASPEventLevel,
+    description: str,
+    event_params: Optional[List[str]] = None,
+    additional_data: Optional[Dict[str, Any]] = None,
+) -> None:
+    """
+    Log a security event in OWASP format.
+
+    :param event_type: Type of security event.
+    :param level: OWASP Log level (INFO, WARN, CRITICAL).
+    :param description: Human-readable description of the event.
+    :param event_params: Parameters to include in the event string.
+    :param additional_data: Additional context-specific data.
+    """
+    # cloud-init is the default primary 'actor' for any system change operation
+    if event_params:
+        event_params.insert(0, "cloud-init")
+    else:
+        event_params = ["cloud-init"]
+
+    event_str = event_type.value
+    if event_params:
+        event_str += ":" + ",".join(event_params)
+    event = {
+        "appid": APP_ID,
+        "type": "security",
+        "event": event_str,
+        "level": str(level.value),
+        "description": description,
+        "hostname": util.get_hostname(),
+    }
+    if additional_data:
+        # Merge additional non-empty data but don't overwrite core fields
+        for key, value in additional_data.items():
+            if key not in event and value:
+                event[key] = value
+
+    LOG.log(loggers.SECURITY, event)
+
+
+def sec_log_user_created(func):
+    """A decorator to log a user creation event and group attributes."""
+
+    @functools.wraps(func)
+    def decorator(
+        self, name: str, *args, groups: Optional[List[str]] = None, **kwargs
+    ):
+        if not name:
+            raise RuntimeError(
+                "sec_log_user_created requires positional param name or kwarg"
+            )
+        params = [name]
+        groups_msg = ""
+        if groups is None:
+            groups = []
+        all_groups = groups + self._get_elevated_roles(**kwargs)
+        if all_groups:
+            groups_suffix = ",".join(all_groups)
+            groups_msg = f" in groups: {groups_suffix}"
+            params.append(f"groups:{groups_suffix}")
+
+        response = func(self, name, groups=groups, *args, **kwargs)
+        # User creation operation did not raise an Exception
+        _log_security_event(
+            event_type=OWASPEventType.USER_CREATED,
+            # Treat INFO level as this is prescribed provisioning at launch
+            level=OWASPEventLevel.INFO,
+            description=f"User '{name}' was created{groups_msg}",
+            event_params=params,
+        )
+        return response
+
+    return decorator
+
+
+def sec_log_password_changed_batch(func):
+    @functools.wraps(func)
+    def decorator(self, plist_in: List[Tuple[str, str]], *args, **kwargs):
+        response = func(self, plist_in, *args, **kwargs)
+        for userid, _ in plist_in:
+            _log_security_event(
+                event_type=OWASPEventType.AUTHN_PASSWORD_CHANGE,
+                level=OWASPEventLevel.INFO,
+                description=f"Password changed for user '{userid}'",
+                event_params=[userid],
+            )
+        return response
+
+    return decorator
+
+
+def sec_log_password_changed(func):
+    """A decorator logging a password change event."""
+
+    @functools.wraps(func)
+    def decorator(self, user: str, *args, **kwargs):
+        response = func(self, user, *args, **kwargs)
+        _log_security_event(
+            event_type=OWASPEventType.AUTHN_PASSWORD_CHANGE,
+            level=OWASPEventLevel.INFO,
+            description=f"Password changed for user '{user}'",
+            event_params=[user],
+        )
+        return response
+
+    return decorator
+
+
+def sec_log_system_shutdown(func):
+    """A decorator logging a system shutdown event."""
+
+    @functools.wraps(func)
+    def decorator(cls, mode: str, delay: str, message):
+        if mode == "reboot":
+            event_type = OWASPEventType.SYS_RESTART
+            description = "System restart initiated"
+        else:
+            event_type = OWASPEventType.SYS_SHUTDOWN
+            description = "System shutdown initiated"
+        if message:
+            description += f": {message}"
+
+        _log_security_event(
+            event_type=event_type,
+            level=OWASPEventLevel.INFO,
+            description=description,
+            additional_data={"delay": delay, "mode": mode},
+        )
+        return func(cls, mode=mode, delay=delay, message=message)
+
+    return decorator

--- a/cloudinit/log/security_event_log.py
+++ b/cloudinit/log/security_event_log.py
@@ -14,13 +14,12 @@ Security events are logged in JSON Lines format with standardized fields:
 - event: Event type with optional parameters (e.g., user_created:root,ubuntu)
 - level: INFO, WARN, or CRITICAL
 - description: Human-readable summary
-- host_ip: Optional IP address, included when network information is available.
+- hostname: System hostname
 """
 
-import functools
 import logging
 from enum import Enum
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional
 
 from cloudinit import util
 from cloudinit.log import loggers
@@ -54,7 +53,7 @@ class OWASPEventType(Enum):
     # TODO(USER_UPDATED = "user_updated")
 
 
-def _log_security_event(
+def log_security_event(
     event_type: OWASPEventType,
     level: OWASPEventLevel,
     description: str,
@@ -71,14 +70,10 @@ def _log_security_event(
     :param additional_data: Additional context-specific data.
     """
     # cloud-init is the default primary 'actor' for any system change operation
+    params = ["cloud-init"]
     if event_params:
-        event_params.insert(0, "cloud-init")
-    else:
-        event_params = ["cloud-init"]
-
-    event_str = event_type.value
-    if event_params:
-        event_str += ":" + ",".join(event_params)
+        params.extend(event_params)
+    event_str = f"{event_type.value}:{','.join(params)}"
     event = {
         "appid": APP_ID,
         "type": "security",
@@ -89,101 +84,7 @@ def _log_security_event(
     }
     if additional_data:
         # Merge additional non-empty data but don't overwrite core fields
-        for key, value in additional_data.items():
-            if key not in event and value:
-                event[key] = value
-
+        event.update(
+            {k: v for k, v in additional_data.items() if v and k not in event}
+        )
     LOG.log(loggers.SECURITY, event)
-
-
-def sec_log_user_created(func):
-    """A decorator to log a user creation event and group attributes."""
-
-    @functools.wraps(func)
-    def decorator(
-        self, name: str, *args, groups: Optional[List[str]] = None, **kwargs
-    ):
-        if not name:
-            raise RuntimeError(
-                "sec_log_user_created requires positional param name or kwarg"
-            )
-        params = [name]
-        groups_msg = ""
-        if groups is None:
-            groups = []
-        all_groups = groups + self._get_elevated_roles(**kwargs)
-        if all_groups:
-            groups_suffix = ",".join(all_groups)
-            groups_msg = f" in groups: {groups_suffix}"
-            params.append(f"groups:{groups_suffix}")
-
-        response = func(self, name, groups=groups, *args, **kwargs)
-        # User creation operation did not raise an Exception
-        _log_security_event(
-            event_type=OWASPEventType.USER_CREATED,
-            # Treat INFO level as this is prescribed provisioning at launch
-            level=OWASPEventLevel.INFO,
-            description=f"User '{name}' was created{groups_msg}",
-            event_params=params,
-        )
-        return response
-
-    return decorator
-
-
-def sec_log_password_changed_batch(func):
-    @functools.wraps(func)
-    def decorator(self, plist_in: List[Tuple[str, str]], *args, **kwargs):
-        response = func(self, plist_in, *args, **kwargs)
-        for userid, _ in plist_in:
-            _log_security_event(
-                event_type=OWASPEventType.AUTHN_PASSWORD_CHANGE,
-                level=OWASPEventLevel.INFO,
-                description=f"Password changed for user '{userid}'",
-                event_params=[userid],
-            )
-        return response
-
-    return decorator
-
-
-def sec_log_password_changed(func):
-    """A decorator logging a password change event."""
-
-    @functools.wraps(func)
-    def decorator(self, user: str, *args, **kwargs):
-        response = func(self, user, *args, **kwargs)
-        _log_security_event(
-            event_type=OWASPEventType.AUTHN_PASSWORD_CHANGE,
-            level=OWASPEventLevel.INFO,
-            description=f"Password changed for user '{user}'",
-            event_params=[user],
-        )
-        return response
-
-    return decorator
-
-
-def sec_log_system_shutdown(func):
-    """A decorator logging a system shutdown event."""
-
-    @functools.wraps(func)
-    def decorator(cls, mode: str, delay: str, message):
-        if mode == "reboot":
-            event_type = OWASPEventType.SYS_RESTART
-            description = "System restart initiated"
-        else:
-            event_type = OWASPEventType.SYS_SHUTDOWN
-            description = "System shutdown initiated"
-        if message:
-            description += f": {message}"
-
-        _log_security_event(
-            event_type=event_type,
-            level=OWASPEventLevel.INFO,
-            description=description,
-            additional_data={"delay": delay, "mode": mode},
-        )
-        return func(cls, mode=mode, delay=delay, message=message)
-
-    return decorator

--- a/tests/unittests/distros/test__init__.py
+++ b/tests/unittests/distros/test__init__.py
@@ -603,7 +603,7 @@ class TestDHCP:
 
 
 class TestGetElevatedRoles:
-    """Tests for Distro._get_elevated_roles."""
+    """Tests for get_elevated_roles."""
 
     @pytest.mark.parametrize(
         "kwargs,expected",
@@ -624,5 +624,4 @@ class TestGetElevatedRoles:
         ],
     )
     def test_get_elevated_roles(self, kwargs, expected):
-        distro = Distro("ubuntu", {}, None)
-        assert distro._get_elevated_roles(**kwargs) == expected
+        assert distros._get_elevated_roles(**kwargs) == expected

--- a/tests/unittests/distros/test__init__.py
+++ b/tests/unittests/distros/test__init__.py
@@ -600,3 +600,29 @@ class TestDHCP:
         distro = Distro("", {}, {})
         distro._cfg = config
         assert isinstance(distro.dhcp_client, chosen_client)
+
+
+class TestGetElevatedRoles:
+    """Tests for Distro._get_elevated_roles."""
+
+    @pytest.mark.parametrize(
+        "kwargs,expected",
+        [
+            pytest.param({}, [], id="no_kwargs_returns_empty"),
+            pytest.param({"sudo": True}, ["sudo"], id="sudo_only"),
+            pytest.param({"doas": True}, ["doas"], id="doas_only"),
+            pytest.param(
+                {"sudo": True, "doas": True},
+                ["sudo", "doas"],
+                id="sudo_and_doas",
+            ),
+            pytest.param({"sudo": False}, [], id="falsy_sudo_excluded"),
+            pytest.param({"doas": False}, [], id="falsy_doas_excluded"),
+            pytest.param(
+                {"shell": "/bin/bash"}, [], id="unrelated_kwargs_ignored"
+            ),
+        ],
+    )
+    def test_get_elevated_roles(self, kwargs, expected):
+        distro = Distro("ubuntu", {}, None)
+        assert distro._get_elevated_roles(**kwargs) == expected

--- a/tests/unittests/test_log.py
+++ b/tests/unittests/test_log.py
@@ -225,12 +225,15 @@ class TestSecurityLogs:
         ]
         assert len(security_handlers) == 1
 
-    def test_setup_security_logging_oserror_is_silent(self, tmp_path):
-        """setup_security_logging silent return on unwriatable log."""
-        unwritable = "/root/cannot-create-this-security.log"
+    def test_setup_security_logging_oserror_is_silent(self, mocker):
+        """setup_security_logging silent return on unwritable log."""
+        mocker.patch(
+            "cloudinit.log.loggers.logging.FileHandler",
+            side_effect=OSError("Permission denied"),
+        )
         root = logging.getLogger()
         handlers_before = list(root.handlers)
-        loggers.setup_security_logging(root=root, log_file=unwritable)
+        loggers.setup_security_logging(root=root, log_file="/any/path")
         # No new handler should have been attached.
         assert root.handlers == handlers_before
 

--- a/tests/unittests/test_log.py
+++ b/tests/unittests/test_log.py
@@ -4,6 +4,7 @@
 
 import datetime
 import io
+import json
 import logging
 import time
 from typing import cast
@@ -97,6 +98,13 @@ class TestDeprecatedLogs:
         assert "TRACE" == caplog.records[0].levelname
         assert "trace message" in caplog.text
 
+    def test_security_log_level(self, caplog):
+        logger = cast(loggers.CustomLoggerType, logging.getLogger())
+        logger.setLevel(logging.NOTSET)
+        logger.security("security message")
+        assert "SECURITY" == caplog.records[0].levelname
+        assert "security message" in caplog.text
+
     @pytest.mark.parametrize(
         "expected_log_level, deprecation_info_boundary",
         (
@@ -165,8 +173,114 @@ class TestDeprecatedLogs:
         assert 2 == len(caplog.records)
 
 
-def test_logger_prints_to_stderr(capsys):
+def test_logger_prints_to_stderr(capsys, caplog):
     message = "to stdout"
     loggers.setup_basic_logging()
     logging.getLogger().warning(message)
     assert message in capsys.readouterr().err
+
+
+class TestSecurityLogs:
+    def test_logger_prints_security_as_json_lines(
+        self, tmp_path, capsys, caplog
+    ):
+        """Security logs accepts dict as payload and logs JSON lines."""
+        log_file = tmp_path / "cloud-init-output.log"
+        loggers.setup_basic_logging()
+        root = cast(loggers.CustomLoggerType, logging.getLogger())
+        loggers.setup_security_logging(root=root, log_file=str(log_file))
+        message = {"key": "value"}  # Security logs expect python dict
+        root.security(message)
+        logged_event = json.loads(log_file.read_text())
+        assert logged_event.pop("datetime"), "Missing expected datetime in log"
+        assert logged_event == message
+        # SECURITY level logs are not reflected to stderr
+        assert "" == capsys.readouterr().err
+
+    def test_logger_requires_dict_payload(self, tmp_path, capsys):
+        """Security logs will error when payload message is not a dict.
+
+        Future-proofing additional call-sites from calling
+        LOG.security("non-dict payload")
+        """
+        log_file = tmp_path / "cloud-init-output.log"
+        loggers.setup_basic_logging()
+        root = cast(loggers.CustomLoggerType, logging.getLogger())
+        loggers.setup_security_logging(root=root, log_file=str(log_file))
+        root.security("some non-dict payload")
+        # Invalid security payloads are not logged and don't crash cloud-init.
+        assert "" == log_file.read_text()
+
+    def test_setup_security_logging_idempotent(self, tmp_path):
+        """Multiple setup_security_logging calls do not duplicate handlers."""
+        log_file = str(tmp_path / "sec.log")
+        root = logging.getLogger()
+        loggers.setup_security_logging(root=root, log_file=log_file)
+        loggers.setup_security_logging(root=root, log_file=log_file)
+        security_handlers = [
+            h
+            for h in root.handlers
+            if isinstance(h, logging.FileHandler)
+            and h.baseFilename == log_file
+        ]
+        assert len(security_handlers) == 1
+
+    def test_setup_security_logging_oserror_is_silent(self, tmp_path):
+        """setup_security_logging silent return on unwriatable log."""
+        unwritable = "/root/cannot-create-this-security.log"
+        root = logging.getLogger()
+        handlers_before = list(root.handlers)
+        loggers.setup_security_logging(root=root, log_file=unwritable)
+        # No new handler should have been attached.
+        assert root.handlers == handlers_before
+
+    def test_security_formatter_datetime_iso8601(self, tmp_path):
+        """SecurityFormatter logs an ISO-8601 timestamp with offset."""
+        import re
+
+        log_file = tmp_path / "sec.log"
+        loggers.setup_basic_logging()
+        root = cast(loggers.CustomLoggerType, logging.getLogger())
+        loggers.setup_security_logging(root=root, log_file=str(log_file))
+        root.security({"event": "test"})
+        logged = json.loads(log_file.read_text())
+        # e.g. 2026-04-24T16:20:43.123+00:00
+        iso8601_ms_tz = re.compile(
+            r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}\+00:00$"
+        )
+        assert iso8601_ms_tz.match(
+            logged["datetime"]
+        ), f"Unexpected datetime format: {logged['datetime']}"
+
+    def test_security_only_filter_passes_security_records(self):
+        """SecurityOnlyFilter allows only SECURITY-level records through."""
+        f = loggers.SecurityOnlyFilter()
+        sec_record = logging.LogRecord(
+            "test", loggers.SECURITY, "", 0, {}, (), None
+        )
+        warn_record = logging.LogRecord(
+            "test", logging.WARNING, "", 0, "msg", (), None
+        )
+        assert f.filter(sec_record) is True
+        assert f.filter(warn_record) is False
+
+    def test_no_security_filter_blocks_security_records(self):
+        """NoSecurityFilter blocks SECURITY-level records and passes others."""
+        f = loggers.NoSecurityFilter()
+        sec_record = logging.LogRecord(
+            "test", loggers.SECURITY, "", 0, {}, (), None
+        )
+        warn_record = logging.LogRecord(
+            "test", logging.WARNING, "", 0, "msg", (), None
+        )
+        assert f.filter(sec_record) is False
+        assert f.filter(warn_record) is True
+
+    def test_security_logs_absent_from_regular_stderr(self, tmp_path, capsys):
+        """SECURITY records absent on stderr after setup_basic_logging."""
+        log_file = tmp_path / "sec.log"
+        loggers.setup_basic_logging()
+        root = cast(loggers.CustomLoggerType, logging.getLogger())
+        loggers.setup_security_logging(root=root, log_file=str(log_file))
+        root.security({"event": "should-not-be-on-stderr"})
+        assert "should-not-be-on-stderr" not in capsys.readouterr().err

--- a/tests/unittests/test_log.py
+++ b/tests/unittests/test_log.py
@@ -173,7 +173,7 @@ class TestDeprecatedLogs:
         assert 2 == len(caplog.records)
 
 
-def test_logger_prints_to_stderr(capsys, caplog):
+def test_logger_prints_to_stderr(capsys):
     message = "to stdout"
     loggers.setup_basic_logging()
     logging.getLogger().warning(message)


### PR DESCRIPTION
## Proposed Commit Message
```
feat: owasp security event logging for user, password, and shutdown

Add a security event logging module following the OWASP
Logging Vocabulary Cheat Sheet. Events are emitted as JSON Lines on a
new SECURITY log level which is routed to a separate log file
(default: /var/log/cloud-init-security.log).

Add cloudinit/log/security_event_log.py which provides:
- OWASPEventType / OWASPEventLevel enums for standardized event strings
- Four decorators to be consumed by Distro methods:
   sec_log_user_created, sec_log_password_changed,
   sec_log_password_changed_batch, sec_log_system_shutdown

cloudinit/log/loggers.py now has a custom SecurityFormatter that injects
an ISO-8601 timestamp into log records.
```

## Additional Context
Separated from #6801 to limit complexity of the PR.  Will recreate 

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
