### PR TITLE
test(opennebula): validate gen_conf() output against network-config-v2 schema

### DIFF
--- a/tests/unittests/sources/test_opennebula.py
+++ b/tests/unittests/sources/test_opennebula.py
@@ -5,9 +5,11 @@ import os
 import pwd
 from unittest import mock
 
+import jsonschema
 import pytest
 
 from cloudinit import atomic_helper
+from cloudinit.config.schema import SchemaType, get_schema
 from cloudinit.sources import DataSourceOpenNebula as ds
 from tests.unittests.helpers import populate_dir
 
@@ -370,8 +372,23 @@ class TestOpenNebulaDataSource:
 
 @mock.patch(DS_PATH + ".net.get_interfaces_by_mac", mock.Mock(return_value={}))
 class TestOpenNebulaNetwork:
-
     system_nics = ("eth0", "ens3")
+
+    @pytest.fixture(autouse=True)
+    def _validate_gen_conf_schema(self, monkeypatch):
+        """Wrap gen_conf() to assert schema validity on every test."""
+        schema = get_schema(SchemaType.NETWORK_CONFIG_V2)
+        assert schema, "network-config-v2 schema must not be empty"
+        validator_cls = jsonschema.validators.validator_for(schema)
+        validator = validator_cls(schema)
+        original = ds.OpenNebulaNetwork.gen_conf
+
+        def validated(self_inner):
+            result = original(self_inner)
+            validator.validate(result)
+            return result
+
+        monkeypatch.setattr(ds.OpenNebulaNetwork, "gen_conf", validated)
 
     def test_context_devname(self):
         """Verify context_devname correctly returns mac and name."""


### PR DESCRIPTION
## Proposed Commit Message

\`\`\`
test(opennebula): validate gen_conf() output against network-config-v2 schema

Add an autouse fixture to TestOpenNebulaNetwork that wraps gen_conf() and
runs jsonschema validation against schema-network-config-v2.json on every
call, so all existing tests implicitly assert schema conformance without
requiring dedicated per-field type checks.
\`\`\`

## Additional Context

OpenNebula's `gen_conf()` directly produces a Netplan v2 dict. Previously,
no test validated the output against the network-config-v2 JSON schema, so
type errors (e.g. a field being a string when the schema requires an integer)
could go undetected. The autouse fixture catches any such regression across
all existing and future tests in the class for free.

## Test Steps

```
tox -e py3 -- tests/unittests/sources/test_opennebula.py
```

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)