### PR TITLE
fix(opennebula): coerce MTU to int in gen_conf()

### DIFF
--- a/cloudinit/sources/DataSourceOpenNebula.py
+++ b/cloudinit/sources/DataSourceOpenNebula.py
@@ -302,7 +302,7 @@ class OpenNebulaNetwork:
             # Set MTU size
             mtu = self.get_mtu(c_dev)
             if mtu:
-                devconf["mtu"] = mtu
+                devconf["mtu"] = int(mtu)
 
             ethernets[dev] = devconf
 

--- a/tests/unittests/sources/test_opennebula.py
+++ b/tests/unittests/sources/test_opennebula.py
@@ -789,7 +789,7 @@ class TestOpenNebulaNetwork:
                 "version": 2,
                 "ethernets": {
                     nic: {
-                        "mtu": "1280",
+                        "mtu": 1280,
                         "match": {"macaddress": MACADDR},
                         "addresses": [IP_BY_MACADDR + "/" + IP4_PREFIX],
                     }
@@ -898,7 +898,7 @@ class TestOpenNebulaNetwork:
                             "addresses": ["1.2.3.6", "1.2.3.7", "1.2.3.8"],
                             "search": ["example.com", "example.org"],
                         },
-                        "mtu": "1280",
+                        "mtu": 1280,
                     }
                 },
             }
@@ -959,7 +959,7 @@ class TestOpenNebulaNetwork:
                         "addresses": ["1.2.3.6", "1.2.3.7", "1.2.3.8"],
                         "search": ["example.com"],
                     },
-                    "mtu": "1280",
+                    "mtu": 1280,
                 },
                 "enp0s25": {
                     "match": {"macaddress": MAC_1},


### PR DESCRIPTION
## Proposed Commit Message

\`\`\`
fix(opennebula): coerce MTU to int in gen_conf()

ONE_CONTEXT passes ETHx_MTU as a string, but Netplan's network-config-v2
schema requires mtu to be an integer. Without this, `cloud-init schema
--system` fails with "'1500' is not of type 'integer'".
\`\`\`

## Additional Context

Discovered while backporting to cloud-init 25.1.4-1+deb13u1 (trixie).
The fix is a one-liner: `int(mtu)` in `gen_conf()`. The accompanying test
expectation updates (`"1280"` → `1280`) reflect the corrected behaviour.

The regression is caught by the schema validation fixture introduced in #6855.
With that PR, `test_gen_conf_mtu`, `test_eth0_v4v6_override`, and
`test_multiple_nics` all fail before this fix and pass after.

## Test Steps

Boot an OpenNebula VM with `ETH0_MTU` set in the context, then run:

```
cloud-init schema --system
```

Before this fix, the command fails with:
```
ethernets.eth0.mtu: '1500' is not of type 'integer'
```

After this fix, validation passes.

```
tox -e py3 -- tests/unittests/sources/test_opennebula.py
```

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)