### PR TITLE
fix(analyze): return integer exit code from analyze_boot

### DIFF
--- a/cloudinit/analyze/__init__.py
+++ b/cloudinit/analyze/__init__.py
@@ -115,7 +115,7 @@ def get_parser(
     return parser
 
 
-def analyze_boot(name: str, args: argparse.Namespace) -> str:
+def analyze_boot(name: str, args: argparse.Namespace) -> int:
     """Report a list of how long different boot operations took.
 
     For Example:
@@ -199,7 +199,7 @@ def analyze_boot(name: str, args: argparse.Namespace) -> str:
 
     outfh.write(status_map[status_code].format(**kwargs))
     clean_io(infh, outfh)
-    return status_code
+    return 1 if status_code == show.FAIL_CODE else 0
 
 
 def analyze_blame(name, args: argparse.Namespace) -> None:

--- a/tests/unittests/analyze/test_boot.py
+++ b/tests/unittests/analyze/test_boot.py
@@ -160,7 +160,7 @@ class TestAnalyzeBoot:
         finish_code = analyze_boot(name_default, args)
 
         self.remove_dummy_file(path, log_path)
-        assert FAIL_CODE == finish_code
+        assert 1 == finish_code
 
     @mock.patch("cloudinit.util.is_container", return_value=True)
     @mock.patch("cloudinit.subp.subp", return_value=("U=1000000", None))
@@ -190,7 +190,7 @@ class TestAnalyzeBoot:
         finish_code = analyze_boot(name_default, args)
 
         self.remove_dummy_file(path, log_path)
-        assert CONTAINER_CODE == finish_code
+        assert 0 == finish_code
 
     @mock.patch("cloudinit.analyze.show.SystemctlReader")
     @pytest.mark.parametrize(


### PR DESCRIPTION
## Problem

`cloud-init analyze boot` always exits with return code 1, even on successful analysis.

The user reports `return_code=1` with `stderr=successful`, which is the symptom.

## Root Cause

`analyze_boot` returns a string status code (`"successful"`, `"failure"`, or `"container"`). This return value flows through `sub_main` → `main` → `sys.exit()`. In Python, `sys.exit(string)` prints the string to stderr and exits with code 1 — even when the string is `"successful"`.

## Fix

Return an integer exit code instead of the string status code:
- `0` for `SUCCESS_CODE` and `CONTAINER_CODE` (analysis succeeded)
- `1` for `FAIL_CODE` (analysis failed)

This is consistent with the other analyze subcommands (`analyze_blame`, `analyze_show`, `analyze_dump`) which all return `None`, which `sys.exit()` correctly treats as exit code 0.

## Testing

Updated `tests/unittests/analyze/test_boot.py`:
- `test_container_no_ci_log_line`: asserts `1 == finish_code` (was `FAIL_CODE`)
- `test_container_ci_log_line`: asserts `0 == finish_code` (was `CONTAINER_CODE`)

Fixes #4245