### PR TITLE
ci: fix alpine edge python3.14 tox missing dep py3-python-discovery

### DIFF
--- a/.github/workflows/23-pr-unit-distro.yml
+++ b/.github/workflows/23-pr-unit-distro.yml
@@ -42,7 +42,7 @@ jobs:
           lxc exec alpine -- ping -c 1 dl-cdn.alpinelinux.org || true
 
       - name: Install dependencies
-        run: lxc exec alpine -- apk add py3-tox git tzdata
+        run: lxc exec alpine -- apk add py3-tox py3-python-discovery git tzdata
 
       - name: Mount source into container directory
         run: lxc config device add alpine gitdir disk source=$(pwd) path=/root/cloud-init-ro


### PR DESCRIPTION
## Proposed Commit Message
```ci: fix alpine edge python3.14 tox missing dep py3-python-discovery```


## Additional Context
Seen failing on PR 6852 CI alternate disto builds:
https://github.com/canonical/cloud-init/actions/runs/25227607897/job/74349126966?pr=6852


## Test Steps
Should be covered by a successful `name: "Unit: Alternate Distros"` action on this PR.
[Success run on this PR ](https://github.com/canonical/cloud-init/actions/runs/25357678617/job/74350258726?pr=6864)

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
