### PR TITLE
docs: align users-groups example YAMLs with comment text

### DIFF
--- a/doc/module-docs/cc_users_groups/example3.yaml
+++ b/doc/module-docs/cc_users_groups/example3.yaml
@@ -2,3 +2,5 @@
 users:
 - name: newsuper
   shell: /bin/bash
+  lock_passwd: true
+  ssh_import_id: ['gh:TheRealFalcon', 'lp:falcojr']

--- a/doc/module-docs/cc_users_groups/example4.yaml
+++ b/doc/module-docs/cc_users_groups/example4.yaml
@@ -1,5 +1,6 @@
 #cloud-config
 users:
 - doas: [permit nopass newsuper, deny newsuper as root]
+  lock_passwd: true
   name: newsuper
-
+  ssh_import_id: ['gh:TheRealFalcon', 'lp:falcojr']


### PR DESCRIPTION
## Proposed Commit Message

```
docs: align users-groups example YAMLs with comment text

Examples 3 and 4 in the cc_users_groups module docs describe
behavior (password-based login rejected, SSH access for the GitHub
user TheRealFalcon and the Launchpad user falcojr) that the actual
YAML examples didn't include.

Add the missing lock_passwd and ssh_import_id fields so the
rendered example matches the prose. Inline-array syntax for
ssh_import_id matches the existing convention in
cc_ssh_import_id/example1.yaml and cc_users_groups/example7.yaml.

Fixes GH-6857
```

## Summary

The example3 and example4 comments in `doc/module-docs/cc_users_groups/data.yaml` describe two behaviors that are missing from the corresponding YAML files:

1. "Password-based login is rejected" → `lock_passwd: true` was absent
2. "the GitHub user `TheRealFalcon` and the Launchpad user `falcojr` can SSH as `newsuper`" → `ssh_import_id` was absent

This PR adds the two fields to both example3.yaml and example4.yaml so the rendered docs match the prose.

## Test Plan

- [x] No code changes — docs only
- [x] YAML still parses (verified locally)
- [x] Inline-array form for \`ssh_import_id\` matches existing examples in \`cc_ssh_import_id/example1.yaml\` and \`cc_users_groups/example7.yaml\`

## Checklist

- [ ] CLA — will sign at https://ubuntu.com/legal/contributors when prompted
- [x] Commit message follows conventional-commits format
- [x] Change is small and scoped to the docs fix
- [x] References issue (Fixes #6857)
- [x] No new behavior, so no unit tests needed

Fixes #6857