### PR TITLE
fix(oracle): Prevent DHCPv6 conflict with IMDS IPv6 config

### DIFF
--- a/cloudinit/sources/DataSourceOracle.py
+++ b/cloudinit/sources/DataSourceOracle.py
@@ -388,7 +388,15 @@ class DataSourceOracle(sources.DataSource):
 
             if is_primary:
                 if is_ipv6_only:
-                    subnets = [{"type": "dhcp6"}]
+                    # If IMDS already configured IPv6 (/64),
+                    # don't enable DHCPv6 on the interface
+                    # in order to avoid conflicts with /128.
+                    if vnic_dict.get("ipv6Addresses"):
+                        subnets = [{"type": "manual"}]
+                    # Otherwise, apply DHCPv6
+                    else:
+                        subnets = [{"type": "dhcp6"}]
+
                 else:
                     subnets = [{"type": "dhcp"}]
             else:

--- a/tests/unittests/sources/test_oracle.py
+++ b/tests/unittests/sources/test_oracle.py
@@ -523,7 +523,7 @@ class TestNetworkConfigFromOpcImds:
             assert 9000 == primary_cfg["mtu"]
             assert 1 == len(primary_cfg["subnets"])
             assert "address" not in primary_cfg["subnets"][0]
-            assert "dhcp6" == primary_cfg["subnets"][0]["type"]
+            assert "manual" == primary_cfg["subnets"][0]["type"]
         secondary_cfg = nic_cfg[secondary_nic_index]
         assert "ens4" == secondary_cfg["name"]
         assert "physical" == secondary_cfg["type"]


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [x] I have signed the CLA: https://ubuntu.com/legal/contributors
- [x] I have included a comprehensive commit message using the guide below
- [x] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [x] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [x] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [x] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e doc``.
-->


## Proposed Commit Message

<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix(oracle): Prevent DHCPv6 conflict with IMDS IPv6 config

Oracle instances may receive an IPv6 /64 prefix via IMDS while cloud-init
simultaneously enables DHCPv6 for the same interface.

This results in systemd-networkd attempting to configure a conflicting
DHCPv6 /128 address, which is rejected due to overlap with the existing
/64 configuration. Over time, this leads to intermittent loss of
connectivity until DHCPv6 retries.

To prevent this, disable DHCPv6 when IMDS already provides IPv6
addressing, and mark the interface as manually configured so that only
a single IPv6 configuration source is active.

Update unit tests to reflect the new behavior where IPv6-only primary
NICs use manual configuration instead of DHCPv6.

Refs GH-6867
Signed-off-by: Leah Goldberg <leah.goldberg@canonical.com>
```

## Additional Context
Refs GH-6867

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

1. Launch a single-node IPv6-only OCI instance.
2. Apply this cloud-init patch.
3. Clean the cloud-init logs and reboot: 
```
sudo cloud-init clean --logs --config all
sudo reboot
```
4. Check that the IPv6 configured on the primary NIC is a /64 address from IMDS
```
ip -6 addr show dev <iface>
``` 
5. Check journal logs to verify DHCPv6 is not being applied or rejected
```
journalctl -u systemd-networkd | grep -i dhcp

# You should NOT see something like this
May 04 14:18:11 kajgm-3-00435091 systemd-networkd[4964]: ens300np0: Ignoring DHCPv6 address 2603:c020:401b:4200:0:faa8:95f6:c005/128 (valid for 1d 59min 59s, preferred for 23h 59min 59s) which conflicts with 2603:c020:401b:4200:0:faa8:95f6:c005/64.
```

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)