### PR TITLE
docs: make password lock explicit in users-groups example 3

### DIFF
--- a/doc/module-docs/cc_users_groups/example3.yaml
+++ b/doc/module-docs/cc_users_groups/example3.yaml
@@ -1,5 +1,6 @@
 #cloud-config
 users:
 - name: newsuper
+  lock_passwd: true
   ssh_import_id: [ gh:TheRealFalcon, lp:falcojr ]
   shell: /bin/bash


### PR DESCRIPTION
## Proposed Commits

- 1 commit: add `lock_passwd: true` to `doc/module-docs/cc_users_groups/example3.yaml`

## Additional Context

Follow-up to #6865 (closed in favor of #6858). The merged #6858 fixed the discrepancy between `data.yaml` and the example by adding `ssh_import_id` to `example3.yaml`, but the description still claims "Password-based login is rejected" without `lock_passwd: true` appearing in the YAML.

`lock_passwd: true` is the default, so this is purely a documentation clarity change — readers comparing the example to the prose will now see all three claims (password rejection, SSH import, custom shell) reflected in the YAML.

Suggested by @neitsab in https://github.com/canonical/cloud-init/pull/6865#issuecomment-4388874772.

## Test Steps

N/A — documentation example only. ReadTheDocs build verifies rendering.

## Merge Type

- [x] Squash merge