### PR TITLE
tests: expect  warning on azure pro images. avoid client.destroy

### DIFF
--- a/tests/integration_tests/modules/test_ubuntu_pro.py
+++ b/tests/integration_tests/modules/test_ubuntu_pro.py
@@ -231,7 +231,6 @@ def maybe_install_cloud_init(session_cloud: IntegrationCloud):
 
         client.install_new_cloud_init(source)
         session_cloud.snapshot_id = client.snapshot()
-        client.destroy()
 
     return {"image_id": session_cloud.snapshot_id}
 
@@ -251,8 +250,6 @@ class TestUbuntuAdvantagePro:
             user_data=AUTO_ATTACH_CUSTOM_SERVICES,
             launch_kwargs=launch_kwargs,
         ) as client:
-            log = client.read_from_file("/var/log/cloud-init.log")
-            verify_clean_log(log)
             verify_clean_boot(client)
             assert_ua_service_noop(client)
             assert is_attached(client)

--- a/tests/integration_tests/util.py
+++ b/tests/integration_tests/util.py
@@ -137,6 +137,11 @@ def verify_clean_boot(
         ignore_warnings = append_or_create_list(
             ignore_warnings, "No lease found; using default endpoint"
         )
+        # Pro images sometimes hit a single 404 in early provisioning
+        ignore_warnings = append_or_create_list(
+            ignore_warnings,
+            "Polling IMDS failed attempt 1 with exception: UrlError('404",
+        )
     elif "lxd_vm" == PLATFORM:
         # Ubuntu lxd storage
         ignore_warnings = append_or_create_list(


### PR DESCRIPTION
Fix integration test errors seen on Azure UbuntuPro testing seen during SRU review of 26.1.

1. Ignore intermittent warning about single retry seen on some Azure Pro images during first attempt to contact IMDS during first boot. This issue seems to occur most frequently on Azure marketplace Pro images but may not be limited to Pro images.

2. Avoid client.destroy when our integration test is within cloud_session.launch context manager because that tear down is performed by the context manager.

## Proposed Commit Message
```
tests: expect intermittent warning accessing Azure IMDS. Avoid client.destroy

Avoid client.destroy within the cloud_session.launch context manager
as it already performs cloud.destroy on context exit which calls
instance.destroy. This avoids the following error seen by pycloudlib
on Azure instances:

  <pycloudlib.azure.instance.AzureInstance object at ....
    
  @property
  def id(self):
      """Return instance id."""
      return self._instance["vm"].id
               ^^^^^^^^^^^^^^^^^^^^
      TypeError: 'NoneType' object is not subscriptable

Additionally, some Azure instance launches encounter intemittent
warning reaching IMDS on first attempt. Avoid failing integration
tests when encountering a single warning about IMDS access.

If multiple retries are required to reach Azure IMDS, treat this as
an error.
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
