### PR TITLE
feat(opennebula): support ETHx_ALIASn_IP/MASK for anycast addresses

### DIFF
--- a/cloudinit/sources/DataSourceOpenNebula.py
+++ b/cloudinit/sources/DataSourceOpenNebula.py
@@ -289,6 +289,28 @@ class OpenNebulaNetwork:
         # allow empty string to return the default.
         return default if val in (None, "") else val
 
+    def get_alias_addresses(self, c_dev: str) -> List[str]:
+        """Return list of alias IP/prefix strings for context device c_dev.
+
+        Scans context for ETHx_ALIASn_IP / ETHx_ALIASn_MASK keys, where x
+        matches c_dev (e.g. 'ETH0').  Missing MASK defaults to /32.
+        Stops at the first gap in the alias index sequence.
+        """
+        aliases: List[str] = []
+        prefix = c_dev.upper() + "_ALIAS"
+        idx = 0
+        while True:
+            ip_key = "%s%d_IP" % (prefix, idx)
+            ip = self.context.get(ip_key)
+            if not ip:
+                break
+            mask_key = "%s%d_MASK" % (prefix, idx)
+            mask = self.context.get(mask_key) or "255.255.255.255"
+            net_prefix = str(net.ipv4_mask_to_net_prefix(mask))
+            aliases.append("%s/%s" % (ip, net_prefix))
+            idx += 1
+        return aliases
+
     def gen_conf(self) -> Dict[str, Any]:
         netconf: Dict[str, Any] = {"version": 2, "ethernets": {}}
 
@@ -310,6 +332,11 @@ class OpenNebulaNetwork:
             mask = self.get_mask(c_dev)
             prefix = str(net.ipv4_mask_to_net_prefix(mask))
             devconf["addresses"].append(self.get_ip(c_dev, mac) + "/" + prefix)
+
+            # Set alias (anycast) IPv4 addresses
+            alias_addresses: List[str] = self.get_alias_addresses(c_dev)
+            if alias_addresses:
+                devconf["addresses"].extend(alias_addresses)
 
             # Set IPv6 Global and ULA address
             addresses6 = self.get_ip6(c_dev)

--- a/cloudinit/sources/DataSourceOpenNebula.py
+++ b/cloudinit/sources/DataSourceOpenNebula.py
@@ -294,7 +294,9 @@ class OpenNebulaNetwork:
 
         Scans context for ETHx_ALIASn_IP / ETHx_ALIASn_MASK keys, where x
         matches c_dev (e.g. 'ETH0').  Missing MASK defaults to /32.
-        Stops at the first gap in the alias index sequence.
+        Stops at the first gap in the alias index sequence and warns if
+        further alias indices exist beyond that gap, since that likely
+        indicates a misconfigured context.
         """
         aliases: List[str] = []
         prefix = c_dev.upper() + "_ALIAS"
@@ -309,6 +311,19 @@ class OpenNebulaNetwork:
             net_prefix = str(net.ipv4_mask_to_net_prefix(mask))
             aliases.append("%s/%s" % (ip, net_prefix))
             idx += 1
+
+        key_re = re.compile(r"^%s(\d+)_IP$" % re.escape(prefix))
+        skipped = sorted(
+            int(m.group(1)) for m in map(key_re.match, self.context) if m
+        )
+        skipped = [i for i in skipped if i >= idx]
+        if skipped:
+            LOG.warning(
+                "Ignoring %s: found gap at %s%d_IP",
+                ", ".join("%s%d_IP" % (prefix, i) for i in skipped),
+                prefix,
+                idx,
+            )
         return aliases
 
     def gen_conf(self) -> Dict[str, Any]:

--- a/cloudinit/sources/DataSourceOpenNebula.py
+++ b/cloudinit/sources/DataSourceOpenNebula.py
@@ -300,23 +300,24 @@ class OpenNebulaNetwork:
         """
         aliases: List[str] = []
         prefix = c_dev.upper() + "_ALIAS"
+        key_re = re.compile(r"^%s(\d+)_IP$" % re.escape(prefix))
+        indices = sorted(
+            int(m.group(1)) for m in map(key_re.match, self.context) if m
+        )
+
         idx = 0
-        while True:
-            ip_key = "%s%d_IP" % (prefix, idx)
-            ip = self.context.get(ip_key)
-            if not ip:
-                break
-            mask_key = "%s%d_MASK" % (prefix, idx)
-            mask = self.context.get(mask_key) or "255.255.255.255"
+        skipped = []
+        for i in indices:
+            if i != idx:
+                skipped.append(i)
+                continue
+            ip = self.context["%s%d_IP" % (prefix, i)]
+            mask = self.context.get("%s%d_MASK" % (prefix, i))
+            mask = mask or "255.255.255.255"
             net_prefix = str(net.ipv4_mask_to_net_prefix(mask))
             aliases.append("%s/%s" % (ip, net_prefix))
             idx += 1
 
-        key_re = re.compile(r"^%s(\d+)_IP$" % re.escape(prefix))
-        skipped = sorted(
-            int(m.group(1)) for m in map(key_re.match, self.context) if m
-        )
-        skipped = [i for i in skipped if i >= idx]
         if skipped:
             LOG.warning(
                 "Ignoring %s: found gap at %s%d_IP",

--- a/cloudinit/sources/DataSourceOpenNebula.py
+++ b/cloudinit/sources/DataSourceOpenNebula.py
@@ -320,7 +320,7 @@ class OpenNebulaNetwork:
 
         if skipped:
             LOG.warning(
-                "Ignoring %s: found gap at %s%d_IP",
+                "Ignoring network config keys %s due to missing %s%d_IP",
                 ", ".join("%s%d_IP" % (prefix, i) for i in skipped),
                 prefix,
                 idx,

--- a/doc/rtd/reference/datasources/opennebula.rst
+++ b/doc/rtd/reference/datasources/opennebula.rst
@@ -89,6 +89,16 @@ duplicate entries across both levels are suppressed.
 
 ::
 
+    ETH<x>_ALIAS<n>_IP
+    ETH<x>_ALIAS<n>_MASK
+
+Additional (anycast) IPv4 addresses for interface ``ETH<x>``. Aliases are
+numbered from 0 (e.g. ``ETH0_ALIAS0_IP``, ``ETH0_ALIAS1_IP``, …). The
+``MASK`` field defaults to ``255.255.255.255`` (``/32``) when absent. All
+alias addresses are added to the interface alongside the primary address.
+
+::
+
     SET_HOSTNAME
     HOSTNAME
 

--- a/tests/unittests/sources/test_opennebula.py
+++ b/tests/unittests/sources/test_opennebula.py
@@ -1140,6 +1140,110 @@ class TestOpenNebulaNetwork:
         conf = net.gen_conf()
         assert "routes" not in conf["ethernets"]["eth0"]
 
+    # ------------------------------------------------------------------ #
+    # ETHx_ALIASn                                                          #
+    # ------------------------------------------------------------------ #
+
+    def test_get_alias_addresses_single(self):
+        """Single alias on ETH0 produces one extra address."""
+        context = {
+            "ETH0_ALIAS0_IP": "192.168.1.10",
+            "ETH0_ALIAS0_MASK": "255.255.255.0",
+        }
+        net = ds.OpenNebulaNetwork(context, mock.Mock())
+        aliases = net.get_alias_addresses("ETH0")
+        assert aliases == ["192.168.1.10/24"]
+
+    def test_get_alias_addresses_multiple(self):
+        """Multiple aliases on same interface are all returned."""
+        context = {
+            "ETH0_ALIAS0_IP": "192.168.1.10",
+            "ETH0_ALIAS0_MASK": "255.255.255.0",
+            "ETH0_ALIAS1_IP": "192.168.1.11",
+            "ETH0_ALIAS1_MASK": "255.255.255.0",
+            "ETH0_ALIAS2_IP": "192.168.1.12",
+            "ETH0_ALIAS2_MASK": "255.255.255.0",
+        }
+        net = ds.OpenNebulaNetwork(context, mock.Mock())
+        aliases = net.get_alias_addresses("ETH0")
+        assert aliases == [
+            "192.168.1.10/24",
+            "192.168.1.11/24",
+            "192.168.1.12/24",
+        ]
+
+    def test_get_alias_addresses_none(self):
+        """No alias variables → empty list."""
+        net = ds.OpenNebulaNetwork({}, mock.Mock())
+        aliases = net.get_alias_addresses("ETH0")
+        assert aliases == []
+
+    def test_get_alias_addresses_default_mask(self):
+        """Alias without MASK uses default /32."""
+        context = {
+            "ETH0_ALIAS0_IP": "10.0.0.5",
+        }
+        net = ds.OpenNebulaNetwork(context, mock.Mock())
+        aliases = net.get_alias_addresses("ETH0")
+        assert aliases == ["10.0.0.5/32"]
+
+    @mock.patch(DS_PATH + ".get_physical_nics_by_mac")
+    def test_gen_conf_aliases_in_addresses(self, m_get_phys_by_mac):
+        """gen_conf includes alias IPs in addresses list."""
+        context = {
+            "ETH0_MAC": MACADDR,
+            "ETH0_IP": PUBLIC_IP,
+            "ETH0_MASK": "255.255.255.0",
+            "ETH0_ALIAS0_IP": "192.168.1.10",
+            "ETH0_ALIAS0_MASK": "255.255.255.0",
+            "ETH0_ALIAS1_IP": "192.168.1.11",
+            "ETH0_ALIAS1_MASK": "255.255.255.0",
+        }
+        for nic in self.system_nics:
+            m_get_phys_by_mac.return_value = {MACADDR: nic}
+            net = ds.OpenNebulaNetwork(context, mock.Mock())
+            conf = net.gen_conf()
+            addresses = conf["ethernets"][nic]["addresses"]
+            assert PUBLIC_IP + "/24" in addresses
+            assert "192.168.1.10/24" in addresses
+            assert "192.168.1.11/24" in addresses
+
+    @mock.patch(DS_PATH + ".get_physical_nics_by_mac")
+    def test_gen_conf_no_aliases_unchanged(self, m_get_phys_by_mac):
+        """gen_conf without aliases produces same output as before."""
+        context = {
+            "ETH0_MAC": MACADDR,
+            "ETH0_IP": PUBLIC_IP,
+            "ETH0_MASK": "255.255.255.0",
+        }
+        for nic in self.system_nics:
+            m_get_phys_by_mac.return_value = {MACADDR: nic}
+            net = ds.OpenNebulaNetwork(context, mock.Mock())
+            conf = net.gen_conf()
+            assert conf["ethernets"][nic]["addresses"] == [PUBLIC_IP + "/24"]
+
+    @mock.patch(DS_PATH + ".get_physical_nics_by_mac")
+    def test_gen_conf_aliases_on_second_nic(self, m_get_phys_by_mac):
+        """Aliases on a second NIC do not bleed into the first."""
+        MAC_1 = "02:00:0a:12:01:01"
+        MAC_2 = "02:00:0a:12:01:02"
+        context = {
+            "ETH0_MAC": MAC_1,
+            "ETH0_IP": "10.0.0.1",
+            "ETH1_MAC": MAC_2,
+            "ETH1_IP": "10.0.1.1",
+            "ETH1_ALIAS0_IP": "10.0.1.100",
+            "ETH1_ALIAS0_MASK": "255.255.255.0",
+        }
+        net = ds.OpenNebulaNetwork(
+            context,
+            mock.Mock(),
+            system_nics_by_mac={MAC_1: "eth0", MAC_2: "eth1"},
+        )
+        conf = net.gen_conf()
+        assert conf["ethernets"]["eth0"]["addresses"] == ["10.0.0.1/24"]
+        assert "10.0.1.100/24" in conf["ethernets"]["eth1"]["addresses"]
+
 
 class TestParseShellConfig:
     @pytest.mark.allow_subp_for("bash", "sh")

--- a/tests/unittests/sources/test_opennebula.py
+++ b/tests/unittests/sources/test_opennebula.py
@@ -1,6 +1,7 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 # pylint: disable=attribute-defined-outside-init
 
+import logging
 import os
 import pwd
 from unittest import mock
@@ -1186,6 +1187,23 @@ class TestOpenNebulaNetwork:
         net = ds.OpenNebulaNetwork(context, mock.Mock())
         aliases = net.get_alias_addresses("ETH0")
         assert aliases == ["10.0.0.5/32"]
+
+    def test_get_alias_addresses_gap_ignored_and_warned(self, caplog):
+        """A gap in the alias index stops the scan and logs a warning
+        naming the alias index(es) beyond the gap that were ignored."""
+        context = {
+            "ETH0_ALIAS0_IP": "192.168.1.10",
+            "ETH0_ALIAS0_MASK": "255.255.255.0",
+            "ETH0_ALIAS2_IP": "192.168.1.12",
+            "ETH0_ALIAS2_MASK": "255.255.255.0",
+        }
+        net = ds.OpenNebulaNetwork(context, mock.Mock())
+        aliases = net.get_alias_addresses("ETH0")
+        assert aliases == ["192.168.1.10/24"]
+        warnings = [r for r in caplog.record_tuples if r[1] == logging.WARNING]
+        assert len(warnings) == 1
+        assert "ETH0_ALIAS2_IP" in warnings[0][2]
+        assert "ETH0_ALIAS1_IP" in warnings[0][2]
 
     @mock.patch(DS_PATH + ".get_physical_nics_by_mac")
     def test_gen_conf_aliases_in_addresses(self, m_get_phys_by_mac):


### PR DESCRIPTION
## Proposed Commit Message

\`\`\`
feat(opennebula): support ETHx_ALIASn_IP/MASK for anycast addresses

OpenNebula's context-linux package supports per-NIC alias addresses
(ETHx_ALIAS0_IP, ETHx_ALIAS1_IP, …) used for anycast IPs. Add
get_alias_addresses() to OpenNebulaNetwork and wire it into gen_conf()
so alias addresses appear in the Netplan v2 output alongside the
primary address. Missing MASK defaults to /32.
\`\`\`

## Additional Context

OpenNebula allows attaching multiple IP addresses to a single NIC via
`ETH<x>_ALIAS<n>_IP` / `ETH<x>_ALIAS<n>_MASK` context variables. These
are typically used for anycast or VIP addresses. Previously cloud-init
ignored them, leaving the addresses unconfigured on the guest.

## Test Steps

1. In OpenNebula, add alias addresses to a NIC context:
   \`\`\`
   ETH0_ALIAS0_IP = "192.168.1.10"
   ETH0_ALIAS0_MASK = "255.255.255.0"
   ETH0_ALIAS1_IP = "192.168.1.11"
   \`\`\`
2. Boot a cloud-init enabled VM using that context.
3. Verify the alias addresses appear on the interface:
   \`\`\`
   ip addr show eth0
   # expected: 192.168.1.10/24 and 192.168.1.11/32 present
   \`\`\`
4. Verify a NIC without aliases is unaffected.

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)