### PR TITLE
fix(analyze): warn before GNU date fallback

### DIFF
--- a/cloudinit/analyze/dump.py
+++ b/cloudinit/analyze/dump.py
@@ -1,11 +1,14 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
 import calendar
+import logging
 import sys
 from datetime import datetime, timezone
 from typing import IO, Any, Dict, List, Optional, TextIO, Tuple
 
 from cloudinit import atomic_helper, subp, util
+
+LOG = logging.getLogger(__name__)
 
 stage_to_description: Dict[str, str] = {
     "finished": "finished running cloud-init",
@@ -76,6 +79,16 @@ def parse_timestamp_from_date(timestampstr: str) -> float:
         raise ValueError(
             f"Unable to parse timestamp without GNU date: [{timestampstr}]"
         )
+    # Transitional: shelling out to GNU date is slated for removal in favor of
+    # native Python parsing. Log the unrecognized timestamp so maintainers can
+    # collect formats that need direct support (see GH-4357).
+    LOG.warning(
+        "analyze: falling back to GNU %s(1) to parse unrecognized "
+        "timestamp %r; please report this format upstream so it can be "
+        "handled natively in Python.",
+        date,
+        timestampstr,
+    )
     return float(
         subp.subp([date, "-u", "+%s.%3N", "-d", timestampstr]).stdout.strip()
     )

--- a/tests/unittests/analyze/test_dump.py
+++ b/tests/unittests/analyze/test_dump.py
@@ -168,9 +168,7 @@ class TestParseTimestamp:
         with caplog.at_level(logging.WARNING, logger="cloudinit.analyze.dump"):
             with pytest.raises(ValueError):
                 parse_timestamp_from_date("17:15 08/13")
-        assert [] == [
-            r for r in caplog.records if r.levelname == "WARNING"
-        ]
+        assert [] == [r for r in caplog.records if r.levelname == "WARNING"]
 
 
 class TestParseCILogLine:
@@ -282,15 +280,13 @@ class TestParseCILogLine:
         assert expected == parse_ci_logline(line)
 
 
-SAMPLE_LOGS = dedent(
-    """\
+SAMPLE_LOGS = dedent("""\
 Nov 03 06:51:06.074410 x2 cloud-init[106]: [CLOUDINIT] util.py[DEBUG]:\
  Cloud-init v. 0.7.8 running 'init-local' at Thu, 03 Nov 2016\
  06:51:06 +0000. Up 1.0 seconds.
 2016-08-30 21:53:25.972325+00:00 y1 [CLOUDINIT] handlers.py[DEBUG]: finish:\
  modules-final: SUCCESS: running modules for final
-"""
-)
+""")
 
 
 class TestDumpEvents:

--- a/tests/unittests/analyze/test_dump.py
+++ b/tests/unittests/analyze/test_dump.py
@@ -280,13 +280,15 @@ class TestParseCILogLine:
         assert expected == parse_ci_logline(line)
 
 
-SAMPLE_LOGS = dedent("""\
+SAMPLE_LOGS = dedent(
+    """\
 Nov 03 06:51:06.074410 x2 cloud-init[106]: [CLOUDINIT] util.py[DEBUG]:\
  Cloud-init v. 0.7.8 running 'init-local' at Thu, 03 Nov 2016\
  06:51:06 +0000. Up 1.0 seconds.
 2016-08-30 21:53:25.972325+00:00 y1 [CLOUDINIT] handlers.py[DEBUG]: finish:\
  modules-final: SUCCESS: running modules for final
-""")
+"""
+)
 
 
 class TestDumpEvents:

--- a/tests/unittests/analyze/test_dump.py
+++ b/tests/unittests/analyze/test_dump.py
@@ -1,5 +1,6 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
+import logging
 import warnings
 from contextlib import suppress
 from datetime import datetime, timezone
@@ -13,7 +14,9 @@ from cloudinit.analyze.dump import (
     has_gnu_date,
     parse_ci_logline,
     parse_timestamp,
+    parse_timestamp_from_date,
 )
+from cloudinit.subp import SubpResult
 from cloudinit.util import write_file
 
 
@@ -111,6 +114,63 @@ class TestParseTimestamp:
             )
             == "2020-09-12 12:39:20"
         )
+
+    @mock.patch("cloudinit.analyze.dump.subp.subp")
+    @mock.patch("cloudinit.analyze.dump.has_gnu_date", return_value=True)
+    @mock.patch("cloudinit.analyze.dump.util.is_Linux", return_value=True)
+    def test_parse_timestamp_from_date_warns_on_gnu_date_fallback(
+        self, _m_is_linux, _m_has_gnu, m_subp, caplog
+    ):
+        """A warning is emitted whenever GNU date(1) is used as a fallback."""
+        m_subp.return_value = SubpResult("1597333950.000\n", "")
+        timestampstr = "17:15 08/13"
+        with caplog.at_level(logging.WARNING, logger="cloudinit.analyze.dump"):
+            assert 1597333950.0 == parse_timestamp_from_date(timestampstr)
+        m_subp.assert_called_once_with(
+            ["date", "-u", "+%s.%3N", "-d", timestampstr]
+        )
+        warnings_logged = [
+            r for r in caplog.records if r.levelname == "WARNING"
+        ]
+        assert 1 == len(warnings_logged)
+        assert "date(1)" in warnings_logged[0].getMessage()
+        assert repr(timestampstr) in warnings_logged[0].getMessage()
+
+    @mock.patch("cloudinit.analyze.dump.subp.which", return_value="/bin/gdate")
+    @mock.patch("cloudinit.analyze.dump.subp.subp")
+    @mock.patch("cloudinit.analyze.dump.has_gnu_date", return_value=False)
+    @mock.patch("cloudinit.analyze.dump.util.is_Linux", return_value=False)
+    def test_parse_timestamp_from_date_warns_on_gdate_fallback(
+        self, _m_is_linux, _m_has_gnu, m_subp, _m_which, caplog
+    ):
+        """The warning identifies gdate when used on non-Linux systems."""
+        m_subp.return_value = SubpResult("1597333950.000\n", "")
+        timestampstr = "17:15 08/13"
+        with caplog.at_level(logging.WARNING, logger="cloudinit.analyze.dump"):
+            parse_timestamp_from_date(timestampstr)
+        m_subp.assert_called_once_with(
+            ["gdate", "-u", "+%s.%3N", "-d", timestampstr]
+        )
+        warnings_logged = [
+            r for r in caplog.records if r.levelname == "WARNING"
+        ]
+        assert 1 == len(warnings_logged)
+        assert "gdate(1)" in warnings_logged[0].getMessage()
+        assert repr(timestampstr) in warnings_logged[0].getMessage()
+
+    @mock.patch("cloudinit.analyze.dump.subp.which", return_value=None)
+    @mock.patch("cloudinit.analyze.dump.has_gnu_date", return_value=False)
+    @mock.patch("cloudinit.analyze.dump.util.is_Linux", return_value=True)
+    def test_parse_timestamp_from_date_no_warning_when_no_gnu_date(
+        self, _m_is_linux, _m_has_gnu, _m_which, caplog
+    ):
+        """No warning is logged when there is no GNU date to fall back to."""
+        with caplog.at_level(logging.WARNING, logger="cloudinit.analyze.dump"):
+            with pytest.raises(ValueError):
+                parse_timestamp_from_date("17:15 08/13")
+        assert [] == [
+            r for r in caplog.records if r.levelname == "WARNING"
+        ]
 
 
 class TestParseCILogLine:


### PR DESCRIPTION
## Summary

Adds a transitional warning when `cloud-init analyze dump` falls back to GNU `date`/`gdate` for timestamp parsing. The warning includes the unrecognized timestamp format and the selected binary so maintainers can collect formats that still need native Python support before removing the shell-out path.

The no-GNU-date behavior is unchanged: unsupported formats still raise `ValueError` when neither `date` nor `gdate` is available.

Fixes #4357.

## Testing

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/unittests/analyze/test_dump.py`
- `git diff --check`

Plain `pytest` in this environment auto-loads a missing external plugin (`evalcraft`), so I disabled plugin autoload for the focused test run.
