### PR TITLE
Update Debian backports suite for bullseye (#6873)

### DIFF
--- a/templates/sources.list.debian.tmpl
+++ b/templates/sources.list.debian.tmpl
@@ -26,5 +26,8 @@ deb-src {{mirror}} {{codename}}-updates main
 ## N.B. software from this repository may not have been tested as
 ## extensively as that contained in the main release, although it includes
 ## newer versions of some applications which may provide useful features.
+## N.B. backports repository was deprecated in Debian 11 (bullseye).
+{% if codename != 'bullseye' -%}
 deb {{mirror}} {{codename}}-backports main
 deb-src {{mirror}} {{codename}}-backports main
+{% endif -%}


### PR DESCRIPTION
## Proposed Commit Message
```
fix(debian): Update Debian backports suite for bullseye (#6873)

Add logic to skip Debian 11 (bullseye) backports in templates.
As per the Backports Policy, oldstable-backports are only available
for one year after the new stable release. Since Debian 12 was
released in June 2023, bullseye-backports was disabled on June 2024.

This prevents apt update failures in current (2026) environments.
```

## Additional Context

- Debian 11 backports repository was officially deprecated: [link](https://lists.debian.org/debian-backports-announce/2024/07/msg00000.html)
- Users experience APT errors: `The repository 'http://deb.debian.org/debian bullseye-backports Release' does not have a Release file`
- This affects all cloud-init deployments on Debian 11 that use the default apt configuration

## Test Steps

1. Deploy a Debian 11 (bullseye) instance using cloud-init
2. Check `/etc/apt/sources.list`
3. Observe that `bullseye-backports` repository is included

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
