### PR TITLE
Harden Jinja template rendering with sandboxing

### DIFF
--- a/cloudinit/handlers/jinja_template.py
+++ b/cloudinit/handlers/jinja_template.py
@@ -140,7 +140,11 @@ def render_jinja_payload(payload, payload_fn, instance_data, debug=False):
         )
     try:
         rendered_payload = render_string(payload, instance_jinja_vars)
-    except (TypeError, exceptions.UndefinedError) as e:
+    except (
+        TypeError,
+        exceptions.UndefinedError,
+        exceptions.SecurityError,
+    ) as e:
         LOG.warning("Ignoring jinja template for %s: %s", payload_fn, str(e))
         return None
     warnings = [

--- a/cloudinit/templater.py
+++ b/cloudinit/templater.py
@@ -17,7 +17,8 @@ import logging
 import re
 import sys
 
-from jinja2 import DebugUndefined, Template, TemplateSyntaxError
+from jinja2 import DebugUndefined, TemplateSyntaxError
+from jinja2.sandbox import SandboxedEnvironment
 
 from cloudinit import performance
 from cloudinit import type_utils as tu
@@ -134,15 +135,12 @@ def detect_template(text):
         add = "\n" if content.endswith("\n") else ""
         try:
             with performance.Timed("Rendering jinja2 template"):
-                return (
-                    Template(
-                        content,
-                        undefined=UndefinedJinjaVariable,
-                        trim_blocks=True,
-                        extensions=["jinja2.ext.do"],
-                    ).render(**params)
-                    + add
+                jinja_env = SandboxedEnvironment(
+                    undefined=UndefinedJinjaVariable,
+                    trim_blocks=True,
+                    extensions=["jinja2.ext.do"],
                 )
+                return jinja_env.from_string(content).render(**params) + add
         except TemplateSyntaxError as template_syntax_error:
             template_syntax_error.lineno += 1
             raise JinjaSyntaxParsingException(

--- a/tests/unittests/test_builtin_handlers.py
+++ b/tests/unittests/test_builtin_handlers.py
@@ -388,6 +388,23 @@ class TestRenderJinjaPayload:
         )
         assert expected_log in caplog.text
 
+    def test_render_jinja_payload_blocks_unsafe_attribute_access(self, caplog):
+        payload = (
+            "## template: jinja\n"
+            "{{ ''.__class__.__mro__[1].__subclasses__()[:3] }}"
+        )
+
+        assert (
+            render_jinja_payload(
+                payload=payload,
+                payload_fn="myfile",
+                instance_data={"v1": {"hostname": "foo"}},
+            )
+            is None
+        )
+        assert "Ignoring jinja template for myfile" in caplog.text
+        assert "__class__" in caplog.text
+
 
 class TestShellScriptByFrequencyHandlers:
     @pytest.fixture(autouse=True)

--- a/tests/unittests/test_templating.py
+++ b/tests/unittests/test_templating.py
@@ -7,6 +7,7 @@
 import textwrap
 
 import pytest
+from jinja2.exceptions import SecurityError
 
 from cloudinit import templater
 from cloudinit.templater import JinjaSyntaxParsingException
@@ -147,6 +148,15 @@ class TestTemplates:
             ).strip()
             == expected_result
         )
+
+    def test_jinja_blocks_unsafe_attribute_access(self):
+        template = self.add_header(
+            "jinja",
+            "{{ ''.__class__.__mro__[1].__subclasses__()[:3] }}",
+        )
+
+        with pytest.raises(SecurityError):
+            templater.render_string(template, {})
 
 
 class TestJinjaSyntaxParsingException:


### PR DESCRIPTION
## Summary
Harden cloud-init Jinja template rendering by switching to a sandboxed Jinja environment.

## Changes
- replace direct jinja2.Template rendering with SandboxedEnvironment
- handle SecurityError in the Jinja payload handler so unsafe templates are ignored cleanly
- add unit regressions covering unsafe attribute access in templater and handler paths

## Verification
- reproduced the pre-fix behavior directly in Python: template expressions could access __class__, __mro__, and __subclasses__
- verified post-fix behavior directly in Python: unsafe attribute access is blocked, and handler rendering returns None with a warning
- I could not run the repo pytest suite on this host because the Python environment here does not have the pytest module installed
