### PR TITLE
fix(cloud.cfg.tmpl): move install_hotplug to an earlier point in the config

### DIFF
--- a/cloudinit/stages.py
+++ b/cloudinit/stages.py
@@ -326,7 +326,7 @@ class Init:
         if util.get_cfg_option_bool(self.cfg, "manual_cache_clean", False):
             # The empty file in instance/ dir indicates manual cleaning,
             # and can be read by ds-identify.
-            util.write_file(
+            atomic_helper.write_file(
                 self.paths.get_ipath_cur("manual_clean_marker"),
                 omode="w",
                 content="",

--- a/config/cloud.cfg.tmpl
+++ b/config/cloud.cfg.tmpl
@@ -118,6 +118,7 @@ cloud_init_modules:
 {% endif %}
 {% if not is_bsd %}
   - disk_setup
+  - install_hotplug
   - mounts
 {% endif %}
   - set_hostname
@@ -217,7 +218,6 @@ cloud_final_modules:
   - scripts_user
   - ssh_authkey_fingerprints
   - keys_to_console
-  - install_hotplug
   - phone_home
   - final_message
   - power_state_change

--- a/tests/unittests/test_stages.py
+++ b/tests/unittests/test_stages.py
@@ -654,6 +654,34 @@ class TestInit:
             "network update allowed" in caplog.text
         )
 
+    @mock.patch(M_PATH + "sources.pkl_store")
+    @mock.patch(M_PATH + "util.write_file")
+    @mock.patch(M_PATH + "atomic_helper.write_file")
+    def test__write_to_cache_uses_atomic_helper(
+        self, m_atomic_write, m_util_write, m_pkl_store
+    ):
+        self.init._cfg["manual_cache_clean"] = True
+        expected_path = self.init.paths.get_ipath_cur("manual_clean_marker")
+
+        self.init._write_to_cache()
+
+        assert [
+            mock.call(expected_path, omode="w", content="")
+        ] == m_atomic_write.call_args_list
+        assert 0 == m_util_write.call_count
+        assert 1 == m_pkl_store.call_count
+
+    @mock.patch(M_PATH + "sources.pkl_store")
+    @mock.patch(M_PATH + "atomic_helper.write_file")
+    def test__write_to_cache_no_manual_clean(
+        self, m_atomic_write, m_pkl_store
+    ):
+        self.init._cfg["manual_cache_clean"] = False
+
+        self.init._write_to_cache()
+
+        assert 0 == m_atomic_write.call_count
+
 
 class TestInit_InitializeFilesystem:
     """Tests for cloudinit.stages.Init._initialize_filesystem.


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [ x] I have signed the CLA: https://ubuntu.com/legal/contributors
- [ x] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [ x] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e doc``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix(cloud.cfg.tmpl): move install_hotplug to an earlier point in the config

We encountered a race condition with the handling of hotplug events.
It's possible that the additional network device is attached right after
the init-network stage and before the config-instsall_hotplug finished.
The likelyhood of this happening is increasing by a "long" running
runcmd script.

That's the reason we propose moving the install_hotplug hook to an
earlier point in the config.
```

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

Script to reproduce:
```
echo '
#cloud-config
runcmd:
- sleep 30
' | hcloud server create --name hotplug-test --type cpx12 --image ubuntu-24.04 --location ash  --user-data-from-file=/dev/stdin 
hcloud server attach-to-network --network hotplug-test hotplug-test
```

Log output:
```
# first network configuration stage
2026-05-13 15:53:04,860 - DataSourceHetzner.py[DEBUG]: Using private_networks source: 'http://[fe80::a9fe:a9fe%25enp1s0]/hetzner/v1/metadata/private-networks'

# NIC event from dmegs
[Wed May 13 15:53:10 2026] virtio_net virtio6 enp7s0: renamed from eth1

# hotplug install from cloudinit
2026-05-13 15:53:43,246 - cc_install_hotplug.py[INFO]: Installing hotplug.
```


## Merge type

- [x] Squash merge using "Proposed Commit Message"
