### PR TITLE
docs: document per-frequency shell script MIME types

### DIFF
--- a/doc/rtd/explanation/format/mime.rst
+++ b/doc/rtd/explanation/format/mime.rst
@@ -81,7 +81,8 @@ Per-frequency shell scripts
 ---------------------------
 
 Cloud-init supports three MIME content types for controlling how often a
-shell script runs:
+shell script runs, corresponding to the run frequencies described in
+:ref:`module_frequency`:
 
 ``text/x-shellscript-per-boot``
     The script runs on **every boot**. Useful for tasks that must be
@@ -89,15 +90,14 @@ shell script runs:
     storage or refreshing dynamic configuration.
 
 ``text/x-shellscript-per-instance``
-    The script runs **once per instance-id** (typically on first boot
-    for that instance). Useful for one-time instance setup tasks.
+    The script runs **once per instance-id**. A new instance-id is
+    assigned each time a new instance is provisioned.
 
 ``text/x-shellscript-per-once``
-    The script runs **once per cloud-init state**, using the cloud-level
-    semaphore directory (:file:`/var/lib/cloud/sem`). A freshly
-    provisioned instance will normally run it once, but an instance
-    created from an image that preserves existing cloud-init state may
-    not. To allow it to run again, clean cloud-init state (for example,
-    remove :file:`/var/lib/cloud` or run :command:`cloud-init clean`).
+    The script runs **once**, tracked by a semaphore in
+    :file:`/var/lib/cloud/sem`. If cloud-init state is preserved — for
+    example, when an image is created from a running instance — the
+    semaphore persists and the script will not run again on instances
+    booted from that image.
 
 .. _make-mime: https://github.com/canonical/cloud-init/blob/main/cloudinit/cmd/devel/make_mime.py

--- a/doc/rtd/explanation/format/mime.rst
+++ b/doc/rtd/explanation/format/mime.rst
@@ -93,9 +93,12 @@ shell script runs:
     for one-time instance setup tasks.
 
 ``text/x-shellscript-per-once``
-    The script runs **exactly once**, even across different instances
-    created from the same image. Useful for tasks that should never
-    repeat regardless of instance lifecycle.
+    The script runs **once per cloud-init state**, using the cloud-level
+    semaphore directory (:file:`/var/lib/cloud/sem`). A freshly
+    provisioned instance will normally run it once, but an instance
+    created from an image that preserves existing cloud-init state may
+    not. To allow it to run again, clean cloud-init state (for example,
+    remove :file:`/var/lib/cloud` or run :command:`cloud-init clean`).
 
 Scripts are stored on disk under the following directories:
 

--- a/doc/rtd/explanation/format/mime.rst
+++ b/doc/rtd/explanation/format/mime.rst
@@ -100,15 +100,4 @@ shell script runs:
     not. To allow it to run again, clean cloud-init state (for example,
     remove :file:`/var/lib/cloud` or run :command:`cloud-init clean`).
 
-Scripts are stored on disk under the following directories:
-
-- ``/var/lib/cloud/scripts/per-boot/``
-- ``/var/lib/cloud/scripts/per-instance/``
-- ``/var/lib/cloud/scripts/per-once/``
-
-These are handled by :ref:`cc_scripts_per_boot<mod_cc_scripts_per_boot>`,
-:ref:`cc_scripts_per_instance<mod_cc_scripts_per_instance>`, and
-:ref:`cc_scripts_per_once<mod_cc_scripts_per_once>` respectively, via
-``cloudinit/handlers/shell_script_by_frequency.py``.
-
 .. _make-mime: https://github.com/canonical/cloud-init/blob/main/cloudinit/cmd/devel/make_mime.py

--- a/doc/rtd/explanation/format/mime.rst
+++ b/doc/rtd/explanation/format/mime.rst
@@ -77,4 +77,35 @@ Create user-data containing 3 shell scripts:
 
     $ cloud-init devel make-mime -a always.sh:x-shellscript-per-boot -a instance.sh:x-shellscript-per-instance -a once.sh:x-shellscript-per-once
 
+Per-frequency shell scripts
+---------------------------
+
+Cloud-init supports three MIME content types for controlling how often a
+shell script runs:
+
+``text/x-shellscript-per-boot``
+    The script runs on **every boot**. Useful for tasks that must be
+    repeated each time the instance starts, such as mounting ephemeral
+    storage or refreshing dynamic configuration.
+
+``text/x-shellscript-per-instance``
+    The script runs **once per instance** (on first boot only). Useful
+    for one-time instance setup tasks.
+
+``text/x-shellscript-per-once``
+    The script runs **exactly once**, even across different instances
+    created from the same image. Useful for tasks that should never
+    repeat regardless of instance lifecycle.
+
+Scripts are stored on disk under the following directories:
+
+- ``/var/lib/cloud/scripts/per-boot/``
+- ``/var/lib/cloud/scripts/per-instance/``
+- ``/var/lib/cloud/scripts/per-once/``
+
+These are handled by :ref:`cc_scripts_per_boot<mod_cc_scripts_per_boot>`,
+:ref:`cc_scripts_per_instance<mod_cc_scripts_per_instance>`, and
+:ref:`cc_scripts_per_once<mod_cc_scripts_per_once>` respectively, via
+``cloudinit/handlers/shell_script_by_frequency.py``.
+
 .. _make-mime: https://github.com/canonical/cloud-init/blob/main/cloudinit/cmd/devel/make_mime.py

--- a/doc/rtd/explanation/format/mime.rst
+++ b/doc/rtd/explanation/format/mime.rst
@@ -89,8 +89,8 @@ shell script runs:
     storage or refreshing dynamic configuration.
 
 ``text/x-shellscript-per-instance``
-    The script runs **once per instance** (on first boot only). Useful
-    for one-time instance setup tasks.
+    The script runs **once per instance-id** (typically on first boot
+    for that instance). Useful for one-time instance setup tasks.
 
 ``text/x-shellscript-per-once``
     The script runs **exactly once**, even across different instances


### PR DESCRIPTION
Add a dedicated subsection to the MIME multi-part archive documentation
explaining the three per-frequency shell script MIME types:

- text/x-shellscript-per-boot — runs every boot
- text/x-shellscript-per-instance — runs once per instance
- text/x-shellscript-per-once — runs exactly once ever

Includes on-disk script directories and pointers to the handler
(cloudinit/handlers/shell_script_by_frequency.py) and the relevant
modules.

Fixes #6283