### PR TITLE
feat(datasource/aliyun): add IPv6 metaserver and DHCP strategy based on NIC metadata

### DIFF
--- a/cloudinit/sources/DataSourceAliYun.py
+++ b/cloudinit/sources/DataSourceAliYun.py
@@ -21,7 +21,7 @@ ALIYUN_PRODUCT = "Alibaba Cloud ECS"
 class DataSourceAliYun(sources.DataSource):
 
     dsname = "AliYun"
-    metadata_urls = ["http://100.100.100.200"]
+    metadata_urls = ["http://100.100.100.200", "http://[fd00:100::100:200]"]
 
     # The minimum supported metadata_version from the ecs metadata apis
     min_metadata_version = "2016-01-01"

--- a/cloudinit/sources/helpers/aliyun.py
+++ b/cloudinit/sources/helpers/aliyun.py
@@ -171,6 +171,8 @@ def convert_ecs_metadata_network_config(
         nic_metadata = macs_metadata.get(mac)
         if nic_metadata.get("ipv6s"):  # Any IPv6 addresses configured
             dev_config["dhcp6"] = True
+        if not nic_metadata.get("private-ipv4s"):  # No IPv4 addresses
+            dev_config["dhcp4"] = False
         netcfg["ethernets"][nic_name] = dev_config
         return netcfg
     nic_name_2_mac_map = dict()
@@ -198,13 +200,16 @@ def convert_ecs_metadata_network_config(
         if nic_metadata.get("ipv6s"):  # Any IPv6 addresses configured
             dev_config["dhcp6"] = True
             dev_config["dhcp6-overrides"] = dhcp_override
+        if not nic_metadata.get("private-ipv4s"):  # No IPv4 addresses
+            dev_config["dhcp4"] = False
+            dev_config.pop("dhcp4-overrides", None)
 
         netcfg["ethernets"][nic_name] = dev_config
     # Remove route-metric dhcp overrides and routes / routing-policy if only
     # one nic configured
     if len(netcfg["ethernets"]) == 1:
         for nic_name in netcfg["ethernets"].keys():
-            netcfg["ethernets"][nic_name].pop("dhcp4-overrides")
+            netcfg["ethernets"][nic_name].pop("dhcp4-overrides", None)
             netcfg["ethernets"][nic_name].pop("dhcp6-overrides", None)
             netcfg["ethernets"][nic_name].pop("routes", None)
             netcfg["ethernets"][nic_name].pop("routing-policy", None)

--- a/tests/unittests/sources/test_aliyun.py
+++ b/tests/unittests/sources/test_aliyun.py
@@ -332,11 +332,13 @@ class TestAliYunDatasource:
                         "00:16:3e:14:59:58": {
                             "ipv6-gateway": "2408:xxxxx",
                             "ipv6s": "[2408:xxxxxx]",
+                            "private-ipv4s": "172.16.101.100",
                             "network-interface-id": "eni-bp13i1xxxxx",
                         },
                         "00:16:3e:39:43:27": {
                             "gateway": "172.16.101.253",
                             "netmask": "255.255.255.0",
+                            "private-ipv4s": "172.16.101.200",
                             "network-interface-id": "eni-bp13i2xxxx",
                         },
                     }
@@ -373,6 +375,7 @@ class TestAliYunDatasource:
                         "00:16:3e:14:59:58": {
                             "gateway": "172.16.101.253",
                             "netmask": "255.255.255.0",
+                            "private-ipv4s": "172.16.101.100",
                             "network-interface-id": "eni-bp13ixxxx",
                         }
                     }
@@ -383,6 +386,84 @@ class TestAliYunDatasource:
         met0 = netcfg["ethernets"]["eth0"]
         # single network card would have no dhcp4-overrides
         assert "dhcp4-overrides" not in met0
+
+    def test_dhcp4_disabled_when_no_private_ipv4s(self):
+        """Test DHCPv4 is disabled when private-ipv4s is absent."""
+        # Multi-NIC: one NIC has private-ipv4s, other does not
+        netcfg = convert_ecs_metadata_network_config(
+            {
+                "interfaces": {
+                    "macs": {
+                        "00:16:3e:14:59:58": {
+                            "private-ipv4s": "172.16.101.100",
+                            "gateway": "172.16.101.253",
+                            "netmask": "255.255.255.0",
+                            "network-interface-id": "eni-bp13i1xxxxx",
+                        },
+                        "00:16:3e:39:43:27": {
+                            "ipv6s": "[2408:xxxxxx]",
+                            "network-interface-id": "eni-bp13i2xxxx",
+                        },
+                    }
+                }
+            },
+            macs_to_nics={
+                "00:16:3e:14:59:58": "eth0",
+                "00:16:3e:39:43:27": "eth1",
+            },
+        )
+
+        # eth0 has private-ipv4s, dhcp4 should be True
+        assert netcfg["ethernets"]["eth0"]["dhcp4"] is True
+        assert "dhcp4-overrides" in netcfg["ethernets"]["eth0"]
+
+        # eth1 has no private-ipv4s, dhcp4 should be False
+        assert netcfg["ethernets"]["eth1"]["dhcp4"] is False
+        assert "dhcp4-overrides" not in netcfg["ethernets"]["eth1"]
+        # eth1 has ipv6s, dhcp6 should be True
+        assert netcfg["ethernets"]["eth1"]["dhcp6"] is True
+
+    def test_dhcp6_enabled_when_ipv6s_present(self):
+        """Test DHCPv6 is enabled when ipv6s field is present."""
+        # Single NIC with ipv6s and private-ipv4s
+        netcfg = convert_ecs_metadata_network_config(
+            {
+                "interfaces": {
+                    "macs": {
+                        "00:16:3e:14:59:58": {
+                            "private-ipv4s": "172.16.101.100",
+                            "ipv6s": "[2408:xxxxxx]",
+                            "network-interface-id": "eni-bp13i1xxxxx",
+                        }
+                    }
+                }
+            },
+            macs_to_nics={"00:16:3e:14:59:58": "eth0"},
+        )
+
+        assert netcfg["ethernets"]["eth0"]["dhcp4"] is True
+        assert netcfg["ethernets"]["eth0"]["dhcp6"] is True
+
+    def test_ipv6_only_nic_config(self):
+        """Test a NIC with only IPv6 (no private-ipv4s)."""
+        netcfg = convert_ecs_metadata_network_config(
+            {
+                "interfaces": {
+                    "macs": {
+                        "00:16:3e:14:59:58": {
+                            "ipv6s": "[2408:xxxxxx]",
+                            "network-interface-id": "eni-bp13i1xxxxx",
+                        }
+                    }
+                }
+            },
+            macs_to_nics={"00:16:3e:14:59:58": "eth0"},
+        )
+
+        # No private-ipv4s: dhcp4 disabled
+        assert netcfg["ethernets"]["eth0"]["dhcp4"] is False
+        # Has ipv6s: dhcp6 enabled
+        assert netcfg["ethernets"]["eth0"]["dhcp6"] is True
 
 
 class TestIsAliYun:


### PR DESCRIPTION
## Proposed Commit Message

Fixes #6892 

```
feat(aliyun): support IPv6 metaserver and IPv6-only NIC config

Alibaba Cloud ECS now exposes the metadata service over both IPv4
(100.100.100.200) and IPv6 (fd00:100::100:200), and supports attaching
IPv6-only ENIs that have no IPv4 address. The current AliYun datasource
only configures the IPv4 endpoint and unconditionally emits dhcp4: true
for every NIC, which prevents IPv6-only instances from reaching IMDS
and causes long boot delays on IPv6-only ENIs.

This change:

- Adds the IPv6 metadata endpoint to DataSourceAliYun.metadata_urls so
  wait_for_url tries both endpoints. IPv4 instances are unaffected.
- Makes DHCP rendering metadata-driven in
  convert_ecs_metadata_network_config():
    * dhcp6 is enabled when 'ipv6s' is present on a NIC (existing).
    * dhcp4 is disabled and dhcp4-overrides is dropped when
      'private-ipv4s' is absent on a NIC, so DHCPv4 is not attempted
      on IPv6-only NICs.
- Adds unit tests covering IPv4-only, dual-stack, and IPv6-only NIC
  scenarios under tests/unittests/sources/test_aliyun.py.

```

## Additional Context

The IPv6 metadata endpoint and IPv6-only ENIs are documented features
of Alibaba Cloud ECS. With these changes, cloud-init can correctly
fetch metadata and render network configuration on:

| NIC metadata                            | dhcp4 | dhcp6 |
| --------------------------------------- | :---: | :---: |
| `private-ipv4s` only                    | true  | false |
| `private-ipv4s` + `ipv6s` (dual-stack)  | true  | true  |
| `ipv6s` only (IPv6-only ENI)            | false | true  |

Backwards compatibility:

- Existing IPv4-only instances are unaffected — their NIC metadata
  always contains `private-ipv4s`, so `dhcp4` stays `true`.
- Adding a second URL to `metadata_urls` does not change behaviour
  when the IPv4 IMDS endpoint responds successfully.

## Test Steps

1. **Unit tests** (covers all three NIC scenarios):

   ```
   tox -e py3 -- tests/unittests/sources/test_aliyun.py
   ```

   Expected: all tests pass, including the new
   `test_dhcp4_disabled_when_no_private_ipv4s`,
   `test_dhcp6_enabled_when_ipv6s_present`, and
   `test_ipv6_only_nic_config`.

2. **Live verification on an Alibaba Cloud ECS instance**:

   a. Launch a dual-stack ECS instance with both IPv4 and IPv6
      addresses, boot with this cloud-init build, and confirm:
      - `/run/cloud-init/instance-data.json` contains metadata fetched
        from IMDS.
      - The rendered netplan contains `dhcp4: true` and `dhcp6: true`
        for the dual-stack NIC.

   b. Attach an IPv6-only secondary ENI (no `private-ipv4s` in
      metadata), reboot, and confirm:
      - Boot is not delayed by DHCPv4 timeouts on the IPv6-only NIC.
      - The rendered netplan for that NIC contains `dhcp4: false` and
        `dhcp6: true`.

   c. (Optional) Disable IPv4 IMDS on a test instance and confirm
      cloud-init still reaches metadata via
      `http://[fd00:100::100:200]`.

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
