### PR TITLE
docs: clarify default user entry in users examples

### DIFF
--- a/doc/module-docs/cc_users_groups/data.yaml
+++ b/doc/module-docs/cc_users_groups/data.yaml
@@ -23,15 +23,20 @@ cc_users_groups:
     ``default_user key``.
 
     Each ``users`` dictionary item must contain either a ``name`` or
-    ``snapuser`` key, otherwise it will be ignored. Omission of ``default`` as
-    the first item in the ``users`` list skips creation the default user. If
-    no ``users`` key is provided, the default behavior is to create the
-    default user via this config:
+    ``snapuser`` key, otherwise it will be ignored. If no ``users`` key is
+    provided, the default behavior is to create the default user via this
+    config:
 
     .. code-block:: yaml
 
        users:
        - default
+
+    .. note::
+       If you provide a ``users`` list and still want cloud-init to create the
+       default distribution user, keep ``default`` as the first item in the
+       list. Omitting ``default`` skips creation of the default user and can
+       prevent cloud-provided SSH keys from being installed for that user.
 
     .. note::
        Specifying a hash of a user's password with ``passwd`` is a security

--- a/doc/rtd/reference/yaml_examples/user_groups.rst
+++ b/doc/rtd/reference/yaml_examples/user_groups.rst
@@ -35,9 +35,14 @@ and ``'sys'``, and the empty group ``cloud-users``.
 Add users to the system
 =======================
 
-Users are added after groups. Note that most of these configuration options
-will not be honored if the user already exists. The following options are
-exceptions and can be applied to already-existing users:
+Users are added after groups. If you provide a ``users`` list and still want
+cloud-init to create the default distribution user, keep ``default`` as the
+first item in the list. Omitting ``default`` skips creation of the default user
+and can prevent cloud-provided SSH keys from being installed for that user.
+
+Note that most of these configuration options will not be honored if the user
+already exists. The following options are exceptions and can be applied to
+already-existing users:
 
 - ``plain_text_passwd``
 - ``hashed_passwd``


### PR DESCRIPTION
﻿## Summary
- turn the existing default-user behavior warning into a more visible note in the Users and Groups module docs
- add the same warning to the YAML example page so custom `users:` lists mention keeping `default` first

Fixes #6702.

## Testing
- `git diff --check HEAD~1..HEAD`
- YAML parse check for `doc/module-docs/cc_users_groups/data.yaml`

Note: I could not run the full Sphinx docs build on Windows because importing cloud-init docs currently requires the Unix-only `grp` module in this environment.