### PR TITLE
test: logger specifically configure localhost:514 destination

### DIFF
--- a/tests/integration_tests/modules/test_combined.py
+++ b/tests/integration_tests/modules/test_combined.py
@@ -77,7 +77,7 @@ rsyslog:
         input(type="imtcp" port="514")
         $template RemoteLogs,"/var/spool/rsyslog/cloudinit.log"
         *.* ?RemoteLogs
-        & ~
+        & stop
   remotes:
     me: "127.0.0.1"
 runcmd:
@@ -85,7 +85,7 @@ runcmd:
   - echo '💩' > /var/tmp/unicode_data
 
   - #
-  - logger "My test log"
+  - logger --server localhost --tcp --port 514 "My test log"
 snap:
   commands:
     - snap install hello-world


### PR DESCRIPTION
## Proposed Commit Message

```
logger from bsdutils v2.39 defaults to UDP unless --tcp is
specified. Since our integration test is only grabbing
imtcp events, udp is ignored on Noble and newer.

Drop deprecated `~` in favor of explicit `stop`
```
## Additional Context
logger previously defaulted to udp and fellback to tcp when udp didn't work. logger 2.39 doesn't fallback to tcp
unless specified.

Found during integration testing during SRU of cloud-init 26.1.
Not a regression: affects 25.3 and older on Noble and newer series.

## Test Steps
```
# Quick test of existing released cloud-init 25.3
 CLOUD_INIT_KEEP_INSTANCE=1 CLOUD_INIT_PLATFORM=lxd_container CLOUD_INIT_CLOUD_INIT_SOURCE=NONE CLOUD_INIT_OS_IMAGE=noble  tox -e integration-tests -- tests/integration_tests/modules/test_combined.py::TestCombined::test_rsyslog
CLOUD_INIT_KEEP_INSTANCE=1 CLOUD_INIT_PLATFORM=lxd_container CLOUD_INIT_CLOUD_INIT_SOURCE=NONE CLOUD_INIT_OS_IMAGE=jammy  tox -e integration-tests -- tests/integration_tests/modules/test_combined.py::TestCombined::test_rsyslog
```


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)