### PR TITLE
test: apt resolute gpg remove accounts for gpg-from-sq

### DIFF
--- a/tests/integration_tests/modules/test_apt_functionality.py
+++ b/tests/integration_tests/modules/test_apt_functionality.py
@@ -18,6 +18,7 @@ from tests.integration_tests.releases import (
     CURRENT_RELEASE,
     IS_UBUNTU,
     MANTIC,
+    QUESTING,
 )
 from tests.integration_tests.util import (
     get_feature_flag_value,
@@ -523,11 +524,16 @@ RE_GPG_SW_PROPERTIES_INSTALLED = (
     r"software-properties-common', 'gnupg)"
 )
 
-REMOVE_GPG_USERDATA = """
+GPG_PACKAGES = "gpg software-properties-common"
+# On Ubuntu Resolute and newer, gpg-from-sq can replace the gpg metapackage
+# when gpg is removed. Remove other packages which rdepend on gpg to avoid
+# gpg-from-sq being installed as an alternative to gpg.
+GPG_PACKAGES_SQ = f"{GPG_PACKAGES}  python3-software-properties libgpgme45"
+
+REMOVE_GPG_USERDATA_TMPL = """
 #cloud-config
 runcmd:
-  - DEBIAN_FRONTEND=noninteractive apt-get remove gpg -y
-  - DEBIAN_FRONTEND=noninteractive apt-get remove software-properties-common -y
+  - DEBIAN_FRONTEND=noninteractive apt-get remove {packages} -y
 """
 
 
@@ -570,9 +576,11 @@ def test_install_missing_deps(session_cloud: IntegrationCloud):
       'software-properties-common' are installed successfully.
     """
     # Two stage install: First stage:  remove gpg noninteractively from image
-    instance1 = session_cloud.launch(
-        user_data=_do_oci_customization(REMOVE_GPG_USERDATA)
-    )
+    if CURRENT_RELEASE <= QUESTING:
+        userdata = REMOVE_GPG_USERDATA_TMPL.format(packages=GPG_PACKAGES)
+    else:
+        userdata = REMOVE_GPG_USERDATA_TMPL.format(packages=GPG_PACKAGES_SQ)
+    instance1 = session_cloud.launch(user_data=_do_oci_customization(userdata))
 
     # look for r"un  gpg" using regex ('un' means uninstalled)
     for package in ["gpg", "software-properties-common"]:

--- a/tests/unittests/config/test_cc_phone_home.py
+++ b/tests/unittests/config/test_cc_phone_home.py
@@ -54,8 +54,8 @@ class TestPhoneHome:
             (0, -1),
             (1, 0),
             (2, 1),
-            # override parametrized id to differentiate str "2" from int 2 in former test
-            # GH pytest-dev/pytest#14650.
+            # override parametrized id to differentiate str "2" from int 2 in
+            # former test GH pytest-dev/pytest#14650.
             pytest.param("2", 1, id="retries-as-int-str"),
             ("two", 9),
             (None, 9),


### PR DESCRIPTION
## Proposed Commit Message
```
test: apt resolute gpg remove accounts for gpg-from-sq

On resolute and newer, removal of gpg triggers the install
of gpg-from-sq as an alternative for the metapkg if
python3-software-properties or libgpgme45 are still installed.

Ensure removal of the additional rdepends to avoid triggering
installation of gpg-from-sq during the removal of gpg.
```


## Additional Context
[Daily integration test failures in CI on test_missing_deps](https://github.com/canonical/cloud-init/actions/runs/27240430984). Symptom is gpg was not seen as being re-installed after initial removal (because gpg-from-sq was added in it's place, as seen in /var/log/apt/term.log during initial test image creation)



## Test Steps
```
CLOUD_INIT_OS_IMAGE=questing CLOUD_INIT_PLATFORM=lxd_container CLOUD_INIT_CLOUD_INIT_SOURCE=NONE tox -e integration-tests -- tests/integration_tests/modules/test_apt_functionality::test_intsall_missing_deps
```

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
