### PR TITLE
docs: fix chpasswd user entries in cloud-config example

### DIFF
--- a/doc/examples/cloud-config.txt
+++ b/doc/examples/cloud-config.txt
@@ -360,9 +360,9 @@ timezone: US/Eastern
 #    - name: user1
 #      password: password1
 #      type: text
-#    - user2
+#    - name: user2
 #      type: RANDOM
-#    - user3
+#    - name: user3
 #      password: $5$eriogqzq$Dg7PxHsKGzziuEGkZgkLvacjuEFeljJ.rLf.hZqKQLA
 #      type: hash
 #   expire: True


### PR DESCRIPTION
In the commented multi-user chpasswd example, user2 and user3 were written as bare list items rather than mappings with a name field, unlike user1 in the same block. The chpasswd.users schema requires each entry to be a mapping containing a name key.

Note: the example originally reported in #6765 (cc_set_passwords/example2.yaml) already uses the modern chpasswd.users form on current main, so the original deprecation no longer reproduces there. This PR fixes the separate inconsistency I found while verifying.

Fixes GH-6765

## Checklist
- [x] I have signed the CLA
- [x] I have included a comprehensive commit message
- [ ] N/A — docs-only change to a commented example; no code behavior to unit test
- [x] I have applicable documentation changes