### PR TITLE
fix(distros): clarify misleading ssh_redirect_user warning

### DIFF
--- a/cloudinit/distros/__init__.py
+++ b/cloudinit/distros/__init__.py
@@ -1008,8 +1008,9 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
             cloud_keys = kwargs.get("cloud_public_ssh_keys", [])
             if not cloud_keys:
                 LOG.warning(
-                    "Unable to disable SSH logins for %s given"
-                    " ssh_redirect_user: %s. No cloud public-keys present.",
+                    "Unable to disable SSH logins for %s."
+                    " ssh_redirect_user was set to redirect logins to"
+                    " %s, but no cloud public-keys are present.",
                     name,
                     kwargs["ssh_redirect_user"],
                 )

--- a/tests/unittests/distros/test_create_users.py
+++ b/tests/unittests/distros/test_create_users.py
@@ -750,8 +750,9 @@ class TestCreateUser:
         dist.create_user(USER, ssh_redirect_user="someuser")
         assert caplog.records[1].levelname in ["WARNING", "DEPRECATED"]
         assert (
-            "Unable to disable SSH logins for foo_user given "
-            "ssh_redirect_user: someuser. No cloud public-keys present.\n"
+            "Unable to disable SSH logins for foo_user."
+            " ssh_redirect_user was set to redirect logins to"
+            " someuser, but no cloud public-keys are present.\n"
         ) in caplog.text
         m_setup_user_keys.assert_not_called()
 


### PR DESCRIPTION
This PR rewords a misleading warning emitted when `ssh_redirect_user` is
configured but no cloud public SSH keys are available.

When `ssh_redirect_user` is set to `true` or `default`, `cc_users_groups`
resolves it to the actual default username before `create_user` runs. The
"no cloud public-keys" warning then printed that resolved name (e.g.
`ubuntu`), making it look like the user had configured `ubuntu`. This
rewords the warning so the value reads as the redirect target, not the
configured value.

Fixes GH-3924

## Proposed Commit Message
\```
fix(distros): clarify misleading ssh_redirect_user warning

When ssh_redirect_user is set to true or default, cc_users_groups
resolves it to the actual default username before create_user runs.
The 'no cloud public-keys' warning then printed that resolved name
(e.g. 'ubuntu'), making it look like the user had configured 'ubuntu'.
Reword the warning so the value reads as the redirect target, not the
configured value.

Fixes GH-3924
\```

## Additional Context
The warning is emitted in `Distro.create_user`
(`cloudinit/distros/__init__.py`). The value substitution happens earlier
in `cc_users_groups`, which replaces a `true`/`default` `ssh_redirect_user`
with the resolved default username before it reaches `create_user`.

## Test Steps
- `pytest tests/unittests/distros/test_create_users.py` — 59 passed,
  including `test_create_user_with_ssh_redirect_user_no_cloud_keys`.
- Ran `tox -e do_format`, `tox -e ruff`, `tox -e mypy`, and `tox -e pylint`
  locally — all clean.

## Merge type
- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)