### PR TITLE
fix(mounts): escape special characters in fstab mount paths

### DIFF
--- a/cloudinit/config/cc_mounts.py
+++ b/cloudinit/config/cc_mounts.py
@@ -369,7 +369,7 @@ def parse_fstab() -> Tuple[List[str], Dict[str, str], List[str]]:
                 continue
             toks = line.split()
             if toks:
-                fstab_devs[toks[0]] = line
+                fstab_devs[util.unescape_fstab_field(toks[0])] = line
                 fstab_lines.append(line)
     return fstab_lines, fstab_devs, fstab_removed
 
@@ -584,7 +584,18 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
         LOG.debug("No modifications to fstab needed")
         return
 
-    cfg_lines = ["\t".join(entry) for entry in updated_cfg]
+    # Only fs_spec (device) and fs_file (mount point) can contain values that
+    # need escaping; the remaining fstab fields never do, so we skip them.
+    cfg_lines = [
+        "\t".join(
+            [
+                util.escape_fstab_field(entry[0]),
+                util.escape_fstab_field(entry[1]),
+                *entry[2:],
+            ]
+        )
+        for entry in updated_cfg
+    ]
 
     dirs = [d[1] for d in updated_cfg if d[1].startswith("/")]
 

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -1910,6 +1910,35 @@ def unmounter(umount):
             subp.subp(umount_cmd)
 
 
+# Per fstab(5), fstab fields are whitespace-separated, so these characters
+# must be octal-escaped when they appear inside a field. Backslash must come
+# first so we don't double-escape the escapes we introduce.
+_FSTAB_ESCAPES = (
+    ("\\", "\\134"),
+    (" ", "\\040"),
+    ("\t", "\\011"),
+    ("\n", "\\012"),
+)
+
+
+def escape_fstab_field(value: str) -> str:
+    """Octal-escape special characters for safe writing to fstab."""
+    for char, escaped in _FSTAB_ESCAPES:
+        value = value.replace(char, escaped)
+    return value
+
+
+def unescape_fstab_field(value: str) -> str:
+    """Reverse escape_fstab_field.
+
+    Iterate _FSTAB_ESCAPES in reverse so backslash is decoded last; this
+    avoids mis-decoding a field whose original value contained a backslash.
+    """
+    for char, escaped in reversed(_FSTAB_ESCAPES):
+        value = value.replace(escaped, char)
+    return value
+
+
 def mounts():
     mounted = {}
     try:
@@ -1938,9 +1967,9 @@ def mounts():
                 mp = m.group(2)
                 fstype = m.group(3)
                 opts = m.group(4)
-            # If the name of the mount point contains spaces these
-            # can be escaped as '\040', so undo that..
-            mp = mp.replace("\\040", " ")
+            # Mount points may contain octal-escaped characters (e.g. a
+            # space as '\040'); undo that so callers see the real path.
+            mp = unescape_fstab_field(mp)
             mounted[dev] = {
                 "fstype": fstype,
                 "mountpoint": mp,

--- a/doc/module-docs/cc_mounts/data.yaml
+++ b/doc/module-docs/cc_mounts/data.yaml
@@ -11,7 +11,12 @@ cc_mounts:
     omitted. Any mounts that do not appear to either an attached block device
     or network resource will be skipped with a log like "Ignoring nonexistent
     mount ...".
-    
+
+    Whitespace and other special characters in the ``fs_spec`` and ``fs_file``
+    fields are automatically octal-escaped when written to ``/etc/fstab`` (for
+    example, a space becomes ``\040``), so mount points containing spaces work
+    without any manual escaping in the config.
+
     Cloud-init will attempt to add the following mount directives if available
     and unconfigured in ``/etc/fstab``:
 
@@ -65,5 +70,11 @@ cc_mounts:
       Example 2: Create a 2 GB swap file at ``/swapfile`` using human-readable
       values.
     file: cc_mounts/example2.yaml
+  - comment: >
+      Example 3: Mount a device at a mount point whose path contains a space.
+      Whitespace and other special characters in the ``fs_spec`` and
+      ``fs_file`` fields are automatically escaped (e.g. a space is written as
+      ``\040``) so that the resulting ``/etc/fstab`` entry can be parsed.
+    file: cc_mounts/example3.yaml
   name: Mounts
   title: Configure mount points and swap files

--- a/doc/module-docs/cc_mounts/example3.yaml
+++ b/doc/module-docs/cc_mounts/example3.yaml
@@ -1,0 +1,3 @@
+#cloud-config
+mounts:
+- [ /dev/sr0, "/mnt/Cdrom Drive", auto, "uid=1000,gid=1000", "0", "0" ]

--- a/tests/integration_tests/bugs/test_gh3603.py
+++ b/tests/integration_tests/bugs/test_gh3603.py
@@ -1,0 +1,45 @@
+"""Integration test for gh-3603.
+
+cc_mounts historically wrote /etc/fstab entries without escaping, so a
+space in the device (fs_spec) or mount point (fs_file) produced an
+unparseable line and broke ``mount -a``. Verify that a mount point
+containing a space is octal-escaped in /etc/fstab, that cloud-init logs
+stay clean, and that the real (unescaped) directory is created.
+
+A network fs_spec (contains ``:``) with ``noauto`` keeps the entry in
+fstab without cloud-init attempting the actual mount, so the test does
+not depend on any real device or NFS server.
+
+https://github.com/canonical/cloud-init/issues/3603
+"""
+
+import pytest
+
+from tests.integration_tests.instances import IntegrationInstance
+from tests.integration_tests.util import verify_clean_log
+
+USER_DATA = """\
+#cloud-config
+mounts:
+- - server.example:/export
+  - /mnt/Cdrom Drive
+  - nfs
+  - defaults,noauto
+  - "0"
+  - "0"
+"""
+
+
+@pytest.mark.user_data(USER_DATA)
+def test_mount_point_with_space_is_escaped(client: IntegrationInstance):
+    # cloud-init should have configured mounts without any errors.
+    log = client.read_from_file("/var/log/cloud-init.log")
+    verify_clean_log(log)
+    assert "SUCCESS: config-mounts ran successfully" in log
+
+    # The space must be octal-escaped (\040) in the /etc/fstab entry.
+    fstab = client.read_from_file("/etc/fstab")
+    assert "/mnt/Cdrom\\040Drive" in fstab
+
+    # The real directory (with a literal space) must have been created.
+    assert client.execute("test -d '/mnt/Cdrom Drive'").ok

--- a/tests/unittests/config/test_cc_mounts.py
+++ b/tests/unittests/config/test_cc_mounts.py
@@ -535,6 +535,52 @@ class TestFstabHandling:
             ).strip()
         )
 
+    def test_fstab_mountpoint_with_spaces(self):
+        """Spaces in the fs_spec and fs_file fields are octal-escaped.
+
+        Reproduces GH-3603: an unescaped space in the device or mount point
+        breaks `mount -a` parsing of /etc/fstab.
+        """
+        cfg = {
+            "mounts": [
+                [
+                    "/dev/sr0 spaced",
+                    "/mnt/Cdrom Drive",
+                    "auto",
+                    "uid=1000,gid=1000",
+                    "0",
+                    "0",
+                ],
+            ]
+        }
+        cc_mounts.handle("", cfg, self.mock_cloud, [])
+        with open(cc_mounts.FSTAB_PATH, "r") as fd:
+            fstab_new_content = fd.read()
+        assert (
+            "/dev/sr0\\040spaced\t/mnt/Cdrom\\040Drive\tauto\t"
+            "uid=1000,gid=1000,comment=cloudconfig\t0\t0\n"
+        ) in fstab_new_content
+
+    def test_fstab_mountpoint_with_spaces_idempotent(self):
+        """A second run must not duplicate an escaped mount entry."""
+        cfg = {
+            "mounts": [
+                [
+                    "/dev/sr0",
+                    "/mnt/Cdrom Drive",
+                    "auto",
+                    "uid=1000,gid=1000",
+                    "0",
+                    "0",
+                ],
+            ]
+        }
+        cc_mounts.handle("", cfg, self.mock_cloud, [])
+        cc_mounts.handle("", cfg, self.mock_cloud, [])
+        with open(cc_mounts.FSTAB_PATH, "r") as fd:
+            fstab_new_content = fd.read()
+        assert fstab_new_content.count("/mnt/Cdrom\\040Drive") == 1
+
 
 class TestCreateSwapfile:
     @pytest.mark.parametrize("fstype", ("xfs", "btrfs", "ext4", "other"))

--- a/tests/unittests/test_util.py
+++ b/tests/unittests/test_util.py
@@ -2145,6 +2145,44 @@ class TestLoadYaml:
         ]
 
 
+class TestFstabEscaping:
+    @pytest.mark.parametrize(
+        "raw, escaped",
+        [
+            ("/mnt/Cdrom Drive", "/mnt/Cdrom\\040Drive"),
+            ("/mnt/a\tb", "/mnt/a\\011b"),
+            ("/mnt/a\nb", "/mnt/a\\012b"),
+            ("/mnt/a\\b", "/mnt/a\\134b"),
+            # backslash escaped first so existing escapes aren't doubled
+            ("/mnt/a \\b", "/mnt/a\\040\\134b"),
+            ("/mnt/plain", "/mnt/plain"),
+        ],
+    )
+    def test_escape_unescape_roundtrip(self, raw, escaped):
+        assert util.escape_fstab_field(raw) == escaped
+        assert util.unescape_fstab_field(escaped) == raw
+
+
+class TestMounts:
+    def test_mounts_unescapes_mountpoint(self, mocker):
+        """mounts() octal-unescapes fs_file via unescape_fstab_field.
+
+        Exercises the ``mount`` command fallback (no /proc/mounts), where an
+        escaped space (octal 040) appears in the mount point of the output.
+        """
+        # No /proc/mounts, so mounts() parses the `mount` command output.
+        mocker.patch(M_PATH + "os.path.exists", return_value=False)
+        mocker.patch(
+            M_PATH + "subp.subp",
+            return_value=SubpResult(
+                "/dev/sr0 on /mnt/Cdrom\\040Drive (ufs, local, journaled)\n",
+                "",
+            ),
+        )
+        result = util.mounts()
+        assert result["/dev/sr0"]["mountpoint"] == "/mnt/Cdrom Drive"
+
+
 class TestMountinfoParsing:
     def test_invalid_mountinfo(self):
         line = (


### PR DESCRIPTION
Mount points containing spaces (and tabs/newlines/backslashes) are now
octal-escaped (\040, \011, \012, \134) when written to /etc/fstab, so
`mount -a` can parse them. Directories are still created with real characters.

LP: #1861903
Fixes GH-3603

<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [x] I have signed the CLA: https://ubuntu.com/legal/contributors
- [x] I have included a comprehensive commit message using the guide below
- [x] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [x] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [x] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [x] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e doc``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix(mounts): escape special characters in fstab mount paths

Mount points containing spaces (and tabs/newlines/backslashes) are now
octal-escaped (\040, \011, \012, \134) when written to /etc/fstab, so
`mount -a` can parse them. Directories are still created with real
characters.

The escape/unescape helpers live in `cloudinit.util` and are reused by
`util.mounts()`, which previously only undid `\040` for spaces and now
decodes tabs, newlines and backslashes as well.

Add unit tests plus a one-off integration test (`test_gh3603.py`) and
document the behaviour in the `cc_mounts` examples.

LP: #1861903
Fixes GH-3603
```

## Additional Context
<!-- If relevant -->

Fixes GH-3603 (migrated from Launchpad LP: #1861903).

`cc_mounts` built each `/etc/fstab` line with a bare `"\t".join(entry)`, so any
whitespace inside a field (most commonly a space in the mount point) was written
verbatim. Because fstab fields are whitespace-separated, the resulting line is
unparseable and `mount -a` fails with `parse error at line N -- ignored`. The
documented user workaround (`\040` in the YAML) didn't help either: the literal
characters `\040` ended up as the directory name instead of a space.

This change octal-escapes the four characters significant in an fstab field
(backslash `\134`, space `\040`, tab `\011`, newline `\012`), applied only to
the `fs_spec` and `fs_file` fields — the other fields never contain characters
that need escaping. Backslash is escaped first so the escapes we introduce are
not re-escaped. This matches util-linux's `mangle`/`unmangle` behaviour.

Notes:
    - The escape/unescape helpers (`escape_fstab_field`/`unescape_fstab_field`)
      live in `cloudinit.util`; `util.mounts()` now reuses `unescape_fstab_field`
      instead of its previous spaces-only `replace("\040", " ")`, so it also
      decodes escaped tabs, newlines and backslashes from `/proc/mounts`.
    - The mount-point directory is still created from the unescaped config value
      (`util.ensure_dir`), so the real directory contains a real space.
    - `parse_fstab()` unescapes the device token before using it as the dedup key,
      keeping the module idempotent (a re-run won't add a duplicate entry).
    - A docs example (`cc_mounts/example3.yaml`) and a note about automatic
      escaping were added.

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

Reproduces the bug and verifies the fix on a live system. No extra hardware is
needed: a network `fs_spec` (contains `:`) is kept by `cc_mounts` without the
device existing, and `noauto` keeps `mount -a` from touching it at boot, so the
test isolates the fstab-escaping behaviour.

 1. Boot an instance with `user-data.yaml`:
```yml
 #cloud-config
 mounts:
   - [ "server.example:/export", "/mnt/Cdrom Drive", nfs, "defaults,noauto", "0", "0" ]
```
```sh
$ lxc launch ubuntu:noble test-mounts --config=user.user-data="$(cat user-data.yaml)"
$ lxc exec test-mounts -- cloud-init status --wait
```

 2. The fstab entry is octal-escaped (space written as \040):
```sh
$ lxc exec test-mounts -- tail -n1 /etc/fstab
server.example:/export  /mnt/Cdrom\040Drive  nfs  defaults,noauto,comment=cloudconfig  0  0
```
 
3. util-linux can now parse the entry and resolve the mount point (this is the
  step that printed `parse error ... -- ignored` before the fix):
```sh
$ lxc exec test-mounts -- findmnt --fstab "/mnt/Cdrom Drive"
# prints the resolved TARGET/SOURCE row, no parse error
```

4. The directory was created with a real space (not the literal \040):
```sh
$ lxc exec test-mounts -- ls -d "/mnt/Cdrom Drive"
```

5. Idempotency: re-running the module must not duplicate the entry:

```sh
$ lxc exec test-mounts -- cloud-init single --name mounts --frequency always
$ lxc exec test-mounts -- grep -c 'Cdrom\\040Drive' /etc/fstab   # -> 1
```

Before the fix, step 2 shows a literal space in /etc/fstab and steps 3/mount -a
fail with parse error at line N -- ignored.

**Unit tests**:

```sh
  $ tox -e py3 -- tests/unittests/config/test_cc_mounts.py tests/unittests/test_util.py
```

New cases: `TestFstabHandling.test_fstab_mountpoint_with_spaces` (space in both
the device and the mount point) and `test_fstab_mountpoint_with_spaces_idempotent`
in test_cc_mounts.py, plus `TestFstabEscaping` (escape/unescape round-trip) and
`TestMounts.test_mounts_unescapes_mountpoint` (verifies unescaping inside
`util.mounts()`) in test_util.py.


**Integration test**:

`tests/integration_tests/bugs/test_gh3603.py` boots the user-data above and
asserts clean cloud-init logs, the escaped value in `/etc/fstab`, and that
`/mnt/Cdrom Drive` exists.

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
