### PR TITLE
feat(fwcfg): add new DataSource for QEMU fw_cfg device blobs

### DIFF
--- a/cloudinit/settings.py
+++ b/cloudinit/settings.py
@@ -21,6 +21,7 @@ DEFAULT_RUN_DIR = "/run/cloud-init"
 # What u get if no config is provided
 CFG_BUILTIN = {
     "datasource_list": [
+        "QemuFwCfg",
         "NoCloud",
         "ConfigDrive",
         "LXD",

--- a/cloudinit/sources/DataSourceQemuFwCfg.py
+++ b/cloudinit/sources/DataSourceQemuFwCfg.py
@@ -1,0 +1,146 @@
+# This file is part of cloud-init. See LICENSE file for license information.
+
+"""DataSource for QEMU fw_cfg sysfs interface.
+
+QEMU exposes arbitrary blobs to the guest via the fw_cfg mechanism.
+The Linux ``qemu_fw_cfg`` kernel driver surfaces these blobs under
+``/sys/firmware/qemu_fw_cfg/by_name/<entry-name>/raw``.
+
+This datasource reads under the ``opt/io.cloud-init/cloud-init/``
+namespace one entry for each of the cloud-init data, in the order
+that cloud-init processes them:
+
+``meta-data``
+    YAML dict with instance metadata (``instance-id``, ``local-hostname``,
+    etc.)
+``network-config``
+    Network configuration in v1 or v2 YAML format.
+``user-data``
+    User-data payload (cloud-config YAML, shell script, etc.)
+``vendor-data``
+    Vendor-data payload.
+
+Both ``meta-data`` and ``user-data`` must be present for the datasource to
+claim the instance.
+"""
+
+import logging
+import os
+from typing import Any, Dict, List, Optional, Set
+
+from cloudinit import sources, util
+
+LOG = logging.getLogger(__name__)
+
+# Base sysfs path exposed by the qemu_fw_cfg kernel driver.
+FWCFG_SYSFS = "/sys/firmware/qemu_fw_cfg/by_name"
+# fw_cfg entry namespace agreed upon by the cloud-init project.
+FWCFG_PREFIX = "opt/io.cloud-init/cloud-init"
+FWCFG_PATH = os.path.join(FWCFG_SYSFS, FWCFG_PREFIX)
+
+DEFAULT_IID = "iid-qemufwcfg"
+DEFAULT_METADATA = {"instance-id": DEFAULT_IID}
+
+# Slots in the order they are read and applied by cloud-init.
+_SLOT_FILES = ("meta-data", "network-config", "user-data", "vendor-data")
+_REQUIRED_SLOTS = frozenset({"meta-data", "user-data"})
+
+
+def _read_fwcfg_slot(name: str) -> Optional[bytes]:
+    """Return raw bytes from a fw_cfg slot, or None if the slot is absent."""
+    raw_path = os.path.join(FWCFG_PATH, name, "raw")
+    try:
+        return util.load_binary_file(raw_path)
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        LOG.warning("Failed to read fw_cfg slot %s: %s", name, exc)
+        return None
+
+
+class DataSourceQemuFwCfg(sources.DataSource):
+    """Read instance configuration from QEMU fw_cfg sysfs entries."""
+
+    dsname = "QemuFwCfg"
+
+    def __init__(self, sys_cfg, distro, paths):
+        super().__init__(sys_cfg, distro, paths)
+        self._network_config = None
+
+    def _unpickle(self, ci_pkl_version: int) -> None:
+        super()._unpickle(ci_pkl_version)
+        if not hasattr(self, "_network_config"):
+            self._network_config = None
+
+    def ds_detect(self) -> bool:
+        """Return True when the fw_cfg namespace directory exists in sysfs."""
+        return os.path.isdir(FWCFG_PATH)
+
+    def _get_data(self) -> bool:
+        mydata: Dict[str, Any] = {
+            "meta-data": {},
+            "network-config": None,
+            "user-data": "",
+            "vendor-data": "",
+        }
+        found: Set[str] = set()
+
+        for slot in _SLOT_FILES:
+            raw = _read_fwcfg_slot(slot)
+            if raw is None:
+                continue
+            found.add(slot)
+            text = raw.decode("utf-8", errors="replace")
+
+            if slot == "meta-data":
+                md = util.load_yaml(text)
+                if isinstance(md, dict):
+                    mydata["meta-data"] = md
+                else:
+                    LOG.warning(
+                        "meta-data did not parse as a YAML dict: ignoring"
+                    )
+            elif slot == "network-config":
+                nc = util.load_yaml(text)
+                if nc:
+                    mydata["network-config"] = nc
+            else:
+                mydata[slot] = text
+
+        missing = _REQUIRED_SLOTS - found
+        if missing:
+            LOG.debug(
+                "QemuFwCfg: required slot(s) missing: %s",
+                ", ".join(sorted(missing)),
+            )
+            return False
+
+        # DEFAULT_METADATA to fill gap if user did not specify
+        mydata["meta-data"] = util.mergemanydict(
+            [mydata["meta-data"], DEFAULT_METADATA]
+        )
+        self.metadata = mydata["meta-data"]
+        self._network_config = mydata["network-config"]
+        self.userdata_raw = mydata["user-data"]
+        self.vendordata_raw = mydata["vendor-data"]
+        return True
+
+    def _get_subplatform(self) -> str:
+        return "fw_cfg (%s)" % FWCFG_PATH
+
+    def _get_cloud_name(self) -> str:
+        return sources.METADATA_UNKNOWN
+
+    @property
+    def network_config(self) -> Optional[Dict]:
+        return self._network_config
+
+
+# QemuFwCfg only needs the filesystem (sysfs is available in the local stage).
+datasources = [
+    (DataSourceQemuFwCfg, (sources.DEP_FILESYSTEM,)),
+]
+
+
+def get_datasource_list(depends: List[str]) -> List[sources.DataSource]:
+    return sources.list_from_depends(depends, datasources)

--- a/doc/rtd/reference/datasources.rst
+++ b/doc/rtd/reference/datasources.rst
@@ -57,6 +57,7 @@ The following is a page for each supported datasource:
    datasources/openstack.rst
    datasources/oracle.rst
    datasources/ovf.rst
+   datasources/qemufwcfg.rst
    datasources/rbxcloud.rst
    datasources/scaleway.rst
    datasources/smartos.rst

--- a/doc/rtd/reference/datasources/qemufwcfg.rst
+++ b/doc/rtd/reference/datasources/qemufwcfg.rst
@@ -1,0 +1,117 @@
+.. _datasource_qemufwcfg:
+
+QEMU fw_cfg
+***********
+
+The ``QemuFwCfg`` datasource reads cloud-init configuration from the QEMU
+firmware configuration device (``fw_cfg``). This allows the hypervisor to
+inject ``user-data``, ``meta-data``, ``vendor-data``, and ``network-config``
+directly into a guest VM without requiring virtual disks, kernel command line
+injection, SMBIOS strings, or a network metadata service.
+
+The Linux ``qemu_fw_cfg`` kernel driver (``CONFIG_FW_CFG_SYSFS``) exposes
+fw_cfg entries to the guest as sysfs files under
+:file:`/sys/firmware/qemu_fw_cfg/by_name/`.
+See the `QEMU fw_cfg specification <https://www.qemu.org/docs/master/specs/fw_cfg.html>`_
+and the `Linux fw_cfg sysfs driver <https://www.kernel.org/doc/Documentation/ABI/testing/sysfs-firmware-qemu_fw_cfg>`_
+for more details.
+The datasource reads from the ``opt/io.cloud-init/cloud-init/`` namespace:
+
+- ``opt/io.cloud-init/cloud-init/meta-data``
+- ``opt/io.cloud-init/cloud-init/network-config``
+- ``opt/io.cloud-init/cloud-init/user-data``
+- ``opt/io.cloud-init/cloud-init/vendor-data``
+
+Each entry is exposed in sysfs as a directory; its content is available via
+the ``raw`` file inside that directory.
+
+Both ``meta-data`` and ``user-data`` must be present for the datasource to
+claim the instance. ``network-config`` and ``vendor-data`` are optional.
+
+Detection
+=========
+
+The datasource is detected by ``ds-identify`` during the
+:ref:`detect stage<boot-Detect>` when the sysfs directory
+:file:`/sys/firmware/qemu_fw_cfg/by_name/opt/io.cloud-init/cloud-init`
+exists in the guest.
+
+Injecting configuration
+=======================
+
+QEMU command line
+-----------------
+
+Use the ``-fw_cfg`` option to inject each slot as a named entry:
+
+.. code-block:: shell-session
+
+   $ qemu-system-x86_64 \
+       -fw_cfg name=opt/io.cloud-init/cloud-init/meta-data,file=meta-data \
+       -fw_cfg name=opt/io.cloud-init/cloud-init/user-data,file=user-data \
+       [other options...]
+
+libvirt domain XML
+------------------
+
+When using libvirt, pass the entries via ``<sysinfo type='fwcfg'>`` in the
+domain XML:
+
+.. code-block:: xml
+
+   <sysinfo type='fwcfg'>
+     <entry name='opt/io.cloud-init/cloud-init/meta-data'>instance-id: vm-001</entry>
+     <entry name='opt/io.cloud-init/cloud-init/user-data'>#cloud-config</entry>
+   </sysinfo>
+
+Example
+=======
+
+The following minimal example creates a VM with a guest user:
+
+**meta-data** (saved as :file:`meta-data`):
+
+.. code-block:: yaml
+
+   instance-id: my-vm-001
+   local-hostname: my-vm
+
+**user-data** (saved as :file:`user-data`):
+
+.. code-block:: yaml
+
+   #cloud-config
+   users:
+     - name: guest
+       lock_passwd: false
+       shell: /bin/bash
+       sudo: ALL=(ALL) NOPASSWD:ALL
+
+   chpasswd:
+     users:
+       - name: guest
+         password: guest
+         type: text
+     expire: false
+
+Launch the VM:
+
+.. code-block:: shell-session
+
+   $ qemu-system-x86_64 \
+       -fw_cfg name=opt/io.cloud-init/cloud-init/meta-data,file=meta-data \
+       -fw_cfg name=opt/io.cloud-init/cloud-init/user-data,file=user-data \
+       [other options...]
+
+Once the guest has booted, log in as ``guest``.
+To debug issues, check the blob contents:
+
+.. code-block:: shell-session
+
+   $ cat /sys/firmware/qemu_fw_cfg/by_name/opt/io.cloud-init/cloud-init/meta-data/raw
+   $ cat /sys/firmware/qemu_fw_cfg/by_name/opt/io.cloud-init/cloud-init/user-data/raw
+
+See :ref:`user-data <user_data_formats>` and
+:ref:`vendor-data <vendor-data>` for the supported data formats, and
+:ref:`network_config_v1` or :ref:`network_config_v2` for network
+configuration syntax.

--- a/tests/integration_tests/datasources/test_qemufwcfg.py
+++ b/tests/integration_tests/datasources/test_qemufwcfg.py
@@ -1,0 +1,119 @@
+"""QemuFwCfg datasource integration tests."""
+
+import os
+import pathlib
+
+import pytest
+from pycloudlib.lxd.instance import LXDInstance
+
+from cloudinit.subp import subp
+from tests.integration_tests.instances import IntegrationInstance
+from tests.integration_tests.integration_settings import PLATFORM
+from tests.integration_tests.util import verify_clean_boot
+
+FWCFG_PREFIX = "opt/io.cloud-init/cloud-init"
+
+META_DATA = '{"instance-id":"test-vm","local-hostname":"test-vm"}'
+USER_DATA = "#cloud-config\nruncmd:\n  - touch /var/tmp/qemufwcfg_test_file"
+
+
+def _write_datafile(content: str, name: str) -> str:
+    path = os.path.join(pathlib.Path.home(), f"qemufwcfg_{name}")
+    with open(path, "w") as f:
+        f.write(content)
+    return path
+
+
+@pytest.fixture(scope="class", autouse=True)
+def cleanup_datafiles():
+    """Delete host-side fw_cfg files after the class's tests finish."""
+    yield
+    for name in ("meta-data", "user-data"):
+        try:
+            os.unlink(os.path.join(pathlib.Path.home(), f"qemufwcfg_{name}"))
+        except OSError:
+            pass
+
+
+def setup_qemufwcfg(instance: LXDInstance):
+    meta_data_path = _write_datafile(META_DATA, "meta-data")
+    user_data_path = _write_datafile(USER_DATA, "user-data")
+    home = pathlib.Path.home()
+    subp(
+        [
+            "lxc",
+            "config",
+            "set",
+            instance.name,
+            f"raw.apparmor=file {home}/** r,",
+        ]
+    )
+    subp(
+        [
+            "lxc",
+            "config",
+            "set",
+            instance.name,
+            "raw.qemu="
+            f"-fw_cfg name={FWCFG_PREFIX}/meta-data,file={meta_data_path} "
+            f"-fw_cfg name={FWCFG_PREFIX}/user-data,file={user_data_path}",
+        ]
+    )
+
+
+@pytest.mark.lxd_setup.with_args(setup_qemufwcfg)
+@pytest.mark.lxd_use_exec
+@pytest.mark.skipif(
+    PLATFORM != "lxd_vm",
+    reason="fw_cfg requires a QEMU-based VM",
+)
+class TestQemuFwCfg:
+    @pytest.fixture(autouse=True, scope="class")
+    @classmethod
+    def configure_and_reboot(cls, class_client: IntegrationInstance):
+        """Override datasource_list and reboot so QemuFwCfg is selected.
+
+        90_dpkg.cfg from the Ubuntu package overrides datasource_list without
+        QemuFwCfg. Write a higher-priority config on the running instance,
+        clean cloud-init state, and restart so the second boot uses QemuFwCfg.
+        """
+        class_client.write_to_file(
+            "/etc/cloud/cloud.cfg.d/99-qemufwcfg.cfg",
+            "datasource_list: [QemuFwCfg, None]\n",
+        )
+        # qemu_fw_cfg is compiled as a module (CONFIG_FW_CFG_SYSFS=m) but
+        # ships in linux-modules-extra, not installed by default.  Install it
+        # and add it to /etc/modules so systemd-modules-load loads it on boot
+        # before cloud-init-local.service starts.
+        class_client.execute(
+            "apt-get install -qy linux-modules-extra-$(uname -r)"
+        )
+        class_client.execute("echo qemu_fw_cfg >> /etc/modules")
+        class_client.execute("cloud-init clean --logs")
+        class_client.restart()
+
+    def test_datasource_detected(self, class_client: IntegrationInstance):
+        """QemuFwCfg datasource is selected when fw_cfg slots are present."""
+        log = class_client.execute("cat /var/log/cloud-init.log").stdout
+        assert "DataSourceQemuFwCfg" in log
+
+    def test_userdata_applied(self, class_client: IntegrationInstance):
+        """user-data delivered via fw_cfg is executed by cloud-init."""
+        assert class_client.execute("test -f /var/tmp/qemufwcfg_test_file").ok
+
+    def test_metadata_applied(self, class_client: IntegrationInstance):
+        """meta-data delivered via fw_cfg sets hostname."""
+        assert "test-vm" == class_client.execute("hostname").stdout.strip()
+
+    def test_clean_boot(self, class_client: IntegrationInstance):
+        """Boot completes without errors or unexpected warnings."""
+        verify_clean_boot(class_client)
+
+    def test_fwcfg_slots_visible_in_sysfs(
+        self, class_client: IntegrationInstance
+    ):
+        """fw_cfg entries are accessible via the kernel sysfs driver."""
+        assert class_client.execute(
+            f"test -f /sys/firmware/qemu_fw_cfg/by_name/"
+            f"{FWCFG_PREFIX}/user-data/raw"
+        ).ok

--- a/tests/unittests/sources/test_common.py
+++ b/tests/unittests/sources/test_common.py
@@ -28,6 +28,7 @@ from cloudinit.sources import DataSourceOpenNebula as OpenNebula
 from cloudinit.sources import DataSourceOpenStack as OpenStack
 from cloudinit.sources import DataSourceOracle as Oracle
 from cloudinit.sources import DataSourceOVF as OVF
+from cloudinit.sources import DataSourceQemuFwCfg as QemuFwCfg
 from cloudinit.sources import DataSourceRbxCloud as RbxCloud
 from cloudinit.sources import DataSourceScaleway as Scaleway
 from cloudinit.sources import DataSourceSmartOS as SmartOS
@@ -51,6 +52,7 @@ DEFAULT_LOCAL = [
     OpenNebula.DataSourceOpenNebula,
     Oracle.DataSourceOracle,
     OVF.DataSourceOVF,
+    QemuFwCfg.DataSourceQemuFwCfg,
     SmartOS.DataSourceSmartOS,
     Vultr.DataSourceVultr,
     Ec2.DataSourceEc2Local,

--- a/tests/unittests/sources/test_qemufwcfg.py
+++ b/tests/unittests/sources/test_qemufwcfg.py
@@ -1,0 +1,174 @@
+# This file is part of cloud-init. See LICENSE file for license information.
+
+import logging
+
+import pytest
+import yaml
+
+import cloudinit.sources.DataSourceQemuFwCfg as ds_mod
+from cloudinit.sources.DataSourceQemuFwCfg import (
+    DEFAULT_IID,
+    DataSourceQemuFwCfg,
+)
+
+
+@pytest.fixture
+def fwcfg_path(tmp_path, mocker):
+    """Redirect FWCFG_PATH to a temporary directory and return it."""
+    mocker.patch.object(ds_mod, "FWCFG_PATH", str(tmp_path))
+    return tmp_path
+
+
+def write_slot(fwcfg_path, name: str, content: bytes) -> None:
+    """Write content into the ``<name>/raw`` file under fwcfg_path."""
+    slot_dir = fwcfg_path / name
+    slot_dir.mkdir(parents=True, exist_ok=True)
+    (slot_dir / "raw").write_bytes(content)
+
+
+@pytest.fixture
+def ds(paths):
+    return DataSourceQemuFwCfg(sys_cfg={}, distro=None, paths=paths)
+
+
+class TestDsDetect:
+    def test_true_when_path_exists(self, fwcfg_path, ds):
+        assert ds.ds_detect() is True
+
+    def test_false_when_path_absent(self, tmp_path, ds, mocker):
+        mocker.patch.object(
+            ds_mod, "FWCFG_PATH", str(tmp_path / "nonexistent")
+        )
+        assert ds.ds_detect() is False
+
+
+class TestGetDataRequired:
+    def test_both_required_slots_present(self, fwcfg_path, ds):
+        write_slot(fwcfg_path, "meta-data", b"instance-id: my-id\n")
+        write_slot(fwcfg_path, "user-data", b"#cloud-config\n{}")
+        assert ds.get_data() is True
+
+    def test_missing_meta_data_returns_false(self, fwcfg_path, ds):
+        write_slot(fwcfg_path, "user-data", b"#cloud-config\n{}")
+        assert ds.get_data() is False
+
+    def test_missing_user_data_returns_false(self, fwcfg_path, ds):
+        write_slot(fwcfg_path, "meta-data", b"instance-id: my-id\n")
+        assert ds.get_data() is False
+
+    def test_no_slots_returns_false(self, fwcfg_path, ds):
+        assert ds.get_data() is False
+
+
+class TestGetDataMetadata:
+    def test_instance_id_from_meta_data(self, fwcfg_path, ds):
+        write_slot(fwcfg_path, "meta-data", b"instance-id: my-vm\n")
+        write_slot(fwcfg_path, "user-data", b"")
+        ds.get_data()
+        assert ds.metadata["instance-id"] == "my-vm"
+
+    def test_get_instance_id(self, fwcfg_path, ds):
+        write_slot(fwcfg_path, "meta-data", b"instance-id: test-id-123\n")
+        write_slot(fwcfg_path, "user-data", b"")
+        ds.get_data()
+        assert ds.get_instance_id() == "test-id-123"
+
+    def test_default_instance_id_when_absent_from_meta_data(
+        self, fwcfg_path, ds
+    ):
+        write_slot(fwcfg_path, "meta-data", b"local-hostname: myhost\n")
+        write_slot(fwcfg_path, "user-data", b"")
+        ds.get_data()
+        assert ds.metadata["instance-id"] == DEFAULT_IID
+
+    def test_invalid_yaml_meta_data_logs_warning_and_uses_default(
+        self, fwcfg_path, ds, caplog
+    ):
+        # YAML list is not a dict: load_yaml returns None, slot still 'found'
+        write_slot(fwcfg_path, "meta-data", b"- item1\n- item2\n")
+        write_slot(fwcfg_path, "user-data", b"")
+        with caplog.at_level(logging.WARNING):
+            result = ds.get_data()
+        assert result is True
+        assert "did not parse as a YAML dict" in caplog.text
+        assert ds.metadata["instance-id"] == DEFAULT_IID
+
+    def test_extra_metadata_keys_preserved(self, fwcfg_path, ds):
+        md = {"instance-id": "i-1", "local-hostname": "myhost"}
+        write_slot(fwcfg_path, "meta-data", yaml.dump(md).encode())
+        write_slot(fwcfg_path, "user-data", b"")
+        ds.get_data()
+        assert ds.metadata["local-hostname"] == "myhost"
+
+
+class TestGetDataPayloads:
+    def test_user_data_stored(self, fwcfg_path, ds):
+        write_slot(fwcfg_path, "meta-data", b"instance-id: i-1\n")
+        write_slot(fwcfg_path, "user-data", b"#cloud-config\npackages: [git]")
+        ds.get_data()
+        assert ds.userdata_raw == "#cloud-config\npackages: [git]"
+
+    def test_invalid_utf8_bytes_replaced(self, fwcfg_path, ds):
+        write_slot(fwcfg_path, "meta-data", b"instance-id: i-1\n")
+        write_slot(fwcfg_path, "user-data", b"#cloud-config\n\xff\xfe")
+        ds.get_data()
+        assert "�" in ds.userdata_raw
+
+    def test_vendor_data_stored(self, fwcfg_path, ds):
+        write_slot(fwcfg_path, "meta-data", b"instance-id: i-1\n")
+        write_slot(fwcfg_path, "user-data", b"")
+        write_slot(fwcfg_path, "vendor-data", b"#cloud-config\nruncmd: [true]")
+        ds.get_data()
+        assert ds.vendordata_raw == "#cloud-config\nruncmd: [true]"
+
+    def test_vendor_data_empty_string_when_slot_absent(self, fwcfg_path, ds):
+        write_slot(fwcfg_path, "meta-data", b"instance-id: i-1\n")
+        write_slot(fwcfg_path, "user-data", b"")
+        ds.get_data()
+        assert ds.vendordata_raw == ""
+
+
+class TestGetDataNetworkConfig:
+    def test_network_config_parsed(self, fwcfg_path, ds):
+        netconf = {"version": 2, "ethernets": {"eth0": {"dhcp4": True}}}
+        write_slot(fwcfg_path, "meta-data", b"instance-id: i-1\n")
+        write_slot(fwcfg_path, "user-data", b"")
+        write_slot(fwcfg_path, "network-config", yaml.dump(netconf).encode())
+        ds.get_data()
+        assert ds.network_config == netconf
+
+    def test_network_config_none_when_slot_absent(self, fwcfg_path, ds):
+        write_slot(fwcfg_path, "meta-data", b"instance-id: i-1\n")
+        write_slot(fwcfg_path, "user-data", b"")
+        ds.get_data()
+        assert ds.network_config is None
+
+    def test_network_config_invalid_yaml_treated_as_absent(
+        self, fwcfg_path, ds
+    ):
+        write_slot(fwcfg_path, "meta-data", b"instance-id: i-1\n")
+        write_slot(fwcfg_path, "user-data", b"")
+        write_slot(fwcfg_path, "network-config", b"invalid: [unclosed")
+        ds.get_data()
+        assert ds.network_config is None
+
+
+class TestGetDataErrors:
+    def test_oserror_on_slot_logs_warning_and_continues(
+        self, fwcfg_path, ds, caplog
+    ):
+        write_slot(fwcfg_path, "meta-data", b"instance-id: i-1\n")
+        write_slot(fwcfg_path, "user-data", b"")
+        # raw as a directory triggers IsADirectoryError (OSError) on open()
+        (fwcfg_path / "vendor-data" / "raw").mkdir(parents=True)
+        with caplog.at_level(logging.WARNING):
+            assert ds.get_data() is True
+        assert "vendor-data" in caplog.text
+
+
+class TestDataSourceMetadata:
+    def test_subplatform_format(self, ds):
+        assert ds.subplatform == "fw_cfg (%s)" % ds_mod.FWCFG_PATH
+
+    def test_cloud_name_is_unknown(self, ds):
+        assert ds.cloud_name == "unknown"

--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -71,6 +71,7 @@ PATH_ROOT=${PATH_ROOT:-""}
 PATH_SYS_CLASS_DMI_ID=${PATH_SYS_CLASS_DMI_ID:-${PATH_ROOT}/sys/class/dmi/id}
 PATH_SYS_HYPERVISOR=${PATH_SYS_HYPERVISOR:-${PATH_ROOT}/sys/hypervisor}
 PATH_SYS_CLASS_BLOCK=${PATH_SYS_CLASS_BLOCK:-${PATH_ROOT}/sys/class/block}
+PATH_SYS_FWCFG=${PATH_SYS_FWCFG:-${PATH_ROOT}/sys/firmware/qemu_fw_cfg/by_name/opt/io.cloud-init/cloud-init}
 PATH_DEV_DISK="${PATH_DEV_DISK:-${PATH_ROOT}/dev/disk}"
 PATH_VAR_LIB_CLOUD="${PATH_VAR_LIB_CLOUD:-${PATH_ROOT}/var/lib/cloud}"
 PATH_DI_CONFIG="${PATH_DI_CONFIG:-${PATH_ROOT}/etc/cloud/ds-identify.cfg}"
@@ -128,7 +129,7 @@ DI_SYSTEMD_VIRTUALIZATION=${SYSTEMD_VIRTUALIZATION:-}
 DI_DSNAME=""
 # this has to match the builtin list in cloud-init, it is what will
 # be searched if there is no setting found in config.
-DI_DSLIST_DEFAULT="MAAS ConfigDrive NoCloud AltCloud Azure Bigstep \
+DI_DSLIST_DEFAULT="MAAS QemuFwCfg ConfigDrive NoCloud AltCloud Azure Bigstep \
 CloudSigma CloudStack DigitalOcean Vultr AliYun Ec2 GCE OpenNebula OpenStack \
 VMware OVF SmartOS Scaleway Hetzner IBMCloud Oracle Exoscale RbxCloud UpCloud \
 LXD NWCS Akamai WSL CloudCIX"
@@ -1013,6 +1014,11 @@ dscheck_LXD() {
             return ${DS_FOUND}
         fi
     done
+    return ${DS_NOT_FOUND}
+}
+
+dscheck_QemuFwCfg() {
+    [ -d "${PATH_SYS_FWCFG}" ] && return ${DS_FOUND}
     return ${DS_NOT_FOUND}
 }
 


### PR DESCRIPTION
allow sourcing the data from sysfs as exposed by the linux guest fw_cfg driver in /sys/firmware/qemu_fw_cfg/

- add new cloudinit/sources/DataSourceQemuFwCfg.py
- add unit test test_qemufwcfg.py and list it in test_common.py
- add "QemuFwCfg" to the datasource_list in cloudinit/settings.py
- add "QemuFwCfg" to ds-identify
- add documentation in doc/rtd/reference/datasources/qemufwcfg.rst
- add reference to doc file in doc/rtd/reference/datasources.rst
- add integration test test_qemufwcfg.py

Fixes: GH 3684
Fixes: GH 3133

<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [ ] I have signed the CLA: https://ubuntu.com/legal/contributors
- [ ] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [ ] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e doc``.
-->


## Proposed Commit Message
```
feat(fwcfg): add new DataSource for QEMU fw_cfg device blobs

allow sourcing the data from sysfs as exposed by the linux guest fw_cfg driver in /sys/firmware/qemu_fw_cfg/

- add new cloudinit/sources/DataSourceQemuFwCfg.py
- add unit test test_qemufwcfg.py and list it in test_common.py
- add "QemuFwCfg" to the datasource_list in cloudinit/settings.py
- add "QemuFwCfg" to ds-identify
- add documentation in doc/rtd/reference/datasources/qemufwcfg.rst
- add reference to doc file in doc/rtd/reference/datasources.rst
- add integration test test_qemufwcfg.py

Fixes: GH 3684
Fixes: GH 3133
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
