### PR TITLE
config/cloud.cfg.tmpl: don't join `lxd` group by default

### DIFF
--- a/config/cloud.cfg.tmpl
+++ b/config/cloud.cfg.tmpl
@@ -19,8 +19,8 @@
                   "openmandriva": "wheel, users, systemd-journal",
                   "raspberry-pi-os": "adm, dialout, cdrom, audio, users, sudo, video, games, plugdev, input, gpio, spi, i2c, netdev, render, lpadmin",
                   "suse": "cdrom, users",
-                  "ubuntu": "adm, cdrom, dip, lxd, sudo",
-                  "unknown": "adm, cdrom, dip, lxd, sudo"}) %}
+                  "ubuntu": "adm, cdrom, dip, sudo",
+                  "unknown": "adm, cdrom, dip, sudo"}) %}
 {% set shells = ({"alpine": "/bin/ash", "dragonfly": "/bin/sh",
                   "freebsd": "/bin/tcsh", "netbsd": "/bin/sh",
                   "openbsd": "/bin/ksh"}) %}


### PR DESCRIPTION
https://canonical.com/lxd/docs/latest/explanation/security/#local-access-to-the-lxd-daemon:
> Local access to LXD through the Unix socket always grants full access to LXD.
> This includes the ability to attach file system paths or devices to any
> instance as well as tweak the security features on any instance.
>
> Therefore, you should only give such access to users who you’d trust with
> root access to your system.