### PR TITLE
chore: bump pylint version, dropping deprecated argparse.FileType lints

### DIFF
--- a/cloudinit/cmd/main.py
+++ b/cloudinit/cmd/main.py
@@ -161,15 +161,12 @@ def close_stdin(logger: Callable[[str], None] = LOG.debug):
 
 
 def extract_fns(args):
-    # Files are already opened so lets just pass that along
-    # since it would of broke if it couldn't have
-    # read that file already...
     fn_cfgs = []
     if args.files:
-        for fh in args.files:
+        for filepath in args.files:
             # The realpath is more useful in logging
             # so lets resolve to that...
-            fn_cfgs.append(os.path.realpath(fh.name))
+            fn_cfgs.append(os.path.realpath(filepath))
     return fn_cfgs
 
 
@@ -1151,7 +1148,7 @@ def main(sysv_args=None):
         action="append",
         dest="files",
         help="Use additional yaml configuration files.",
-        type=argparse.FileType("rb"),
+        type=str,
     )
     # This is used so that we can know which action is selected +
     # the functor to use to run this subcommand
@@ -1184,7 +1181,7 @@ def main(sysv_args=None):
         action="append",
         dest="files",
         help="Use additional yaml configuration files.",
-        type=argparse.FileType("rb"),
+        type=str,
     )
     parser_mod.set_defaults(action=("modules", main_modules))
 
@@ -1224,7 +1221,7 @@ def main(sysv_args=None):
         action="append",
         dest="files",
         help="Use additional yaml configuration files.",
-        type=argparse.FileType("rb"),
+        type=str,
     )
     parser_single.set_defaults(action=("single", main_single))
 

--- a/tests/unittests/cmd/test_main.py
+++ b/tests/unittests/cmd/test_main.py
@@ -116,7 +116,7 @@ class TestMain:
             supplemental_config_file.write(
                 EXTRA_CLOUD_CONFIG.format(tmpdir=tmpdir)
             )
-            files = [open(supplemental_config_file)]
+            files = [supplemental_config_file]
         else:
             files = None
         cmdargs = MyArgs(

--- a/tox.ini
+++ b/tox.ini
@@ -43,7 +43,7 @@ deps =
     hypothesis_jsonschema==0.23.1
     isort==6.0.1
     mypy==1.19.1
-    pylint==3.3.8
+    pylint==4.0.6
     ruff==0.12.9
 
 [latest_versions]


### PR DESCRIPTION
Update pinned pylint versions to avoid false positives for ProcessPoolExecutor, resolve any update pylint errors.

Resolve python 3.14 deprecated argparse.FileType by converting --files param to str type, adapting extract_fns to use expected file paths instead of filehandle.name during config file processing.

This retains original behavior for multi-file config processing on the CLI.

## Proposed Commit Message
See individ commit message

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
```
tox -e pylint
tox -e py3
```

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
