### PR TITLE
ci: bump labeler ver add pull-request write permission for labeling

### DIFF
--- a/.github/workflows/45-ci-label.yml
+++ b/.github/workflows/45-ci-label.yml
@@ -5,6 +5,9 @@ on:
 jobs:
   labeler:
     if: github.repository == 'canonical/cloud-init'
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b  # v6.0.1
+    - uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213  # v6.1.0


### PR DESCRIPTION
## Proposed Commit Message
```
ci: bump labeler ver add pull-request write permission for labeling
```

## Additional Context
Fix [CI permissions errors on non-main (ubuntu/devel) branches for labelling](https://github.com/canonical/cloud-init/pull/6903)
update security posture to explicitly set write perms only on the labeler job to premit adding labels on a PR
in canonical/cloud-init repo.


## Test Steps


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
