### PR TITLE
ci: update workflows to released resolute and add scheduled workflows for stonking

### DIFF
--- a/.github/workflows/100-dispatch-common.yml
+++ b/.github/workflows/100-dispatch-common.yml
@@ -10,8 +10,8 @@ on:
         required: true
         type: choice
         options:
+        - stonking
         - resolute
-        - questing
         - jammy
         - noble
       platform:

--- a/.github/workflows/114-daily-integration-26.10-lxd_container.yml
+++ b/.github/workflows/114-daily-integration-26.10-lxd_container.yml
@@ -1,4 +1,4 @@
-name: "Daily 25.10: lxd_vm"
+name: "Daily 26.10: lxd_container"
 
 on:
   workflow_dispatch:
@@ -17,14 +17,14 @@ on:
         required: false
         type: string
   schedule:
-    - cron: '2 23 * * *'
+    - cron: '2 22 * * *'
 
 jobs:
-  questing-lxd_vm:
+  stonking-lxd_container:
     uses: ./.github/workflows/100-dispatch-common.yml
     with:
-      release: questing
-      platform: lxd_vm
+      release: stonking
+      platform: lxd_container
       install_source: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
       image_type: ${{ inputs.image_type || 'generic' }}
       filter_tests: ${{ inputs.filter_tests }}

--- a/.github/workflows/124-daily-integration-26.10-lxd_vm.yml
+++ b/.github/workflows/124-daily-integration-26.10-lxd_vm.yml
@@ -1,4 +1,4 @@
-name: "Daily 25.10: lxd_container"
+name: "Daily 26.10: lxd_vm"
 
 on:
   workflow_dispatch:
@@ -17,14 +17,14 @@ on:
         required: false
         type: string
   schedule:
-    - cron: '2 22 * * *'
+    - cron: '2 23 * * *'
 
 jobs:
-  questing-lxd_container:
+  stonking-lxd_vm:
     uses: ./.github/workflows/100-dispatch-common.yml
     with:
-      release: questing
-      platform: lxd_container
+      release: stonking
+      platform: lxd_vm
       install_source: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
       image_type: ${{ inputs.image_type || 'generic' }}
       filter_tests: ${{ inputs.filter_tests }}

--- a/.github/workflows/134-daily-integration-26.10-ec2.yml
+++ b/.github/workflows/134-daily-integration-26.10-ec2.yml
@@ -1,4 +1,4 @@
-name: "Twice weekly 25.10: ec2"
+name: "Twice weekly 26.10: ec2"
 
 on:
   workflow_dispatch:
@@ -21,10 +21,10 @@ on:
     - cron: '2 22 * * 1,4'
 
 jobs:
-  questing-ec2:
+  stonking-ec2:
     uses: ./.github/workflows/100-dispatch-common.yml
     with:
-      release: questing
+      release: stonking
       platform: ec2
       install_source: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
       image_type: ${{ inputs.image_type || 'generic' }}

--- a/.github/workflows/24-pr-integration.yml
+++ b/.github/workflows/24-pr-integration.yml
@@ -19,7 +19,7 @@ defaults:
     shell: sh -ex {0}
 
 env:
-  RELEASE: questing
+  RELEASE: resolute
 
 jobs:
   build-package-and-run-tests:

--- a/.github/workflows/30-pr-packaging-patches-upstream.yml
+++ b/.github/workflows/30-pr-packaging-patches-upstream.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Run test - apply patches and run unit tests for each series
         run: |
           # Modify the following line to add / remove ubuntu series
-          for BRANCH in ubuntu/devel ubuntu/questing ubuntu/noble ubuntu/jammy; do
+          for BRANCH in ubuntu/devel ubuntu/resolute ubuntu/noble ubuntu/jammy; do
             # merge - this step is not expected to fail
             git merge "origin/$BRANCH"
             if [ ! -f debian/patches/series ]; then


### PR DESCRIPTION
Questing is EOL in 9 days.
- Add scheduled integration workflows for devel series stonking 26.10
- Migrate existing workflows running `questing` to released/supported `resolute` in preparation for EOL

## Proposed Commit Message
See individ commits
```
    ci: add scheduled integration runners for stonking and drop questing

    ci: update PR workflows from questing to latest released ubuntu series resolute
```

## Additional Context
Test runs for
- [lxd_vm](https://github.com/blackboxsw/cloud-init/actions/runs/28481118290/job/84417492976) and
- [lxd_container](https://github.com/blackboxsw/cloud-init/actions/runs/28481005415/job/84417137898) in my own remote

## Test Steps



## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
