### PR TITLE
fix(oracle): detect iSCSI root via iBFT for dracut images

### DIFF
--- a/cloudinit/sources/DataSourceOracle.py
+++ b/cloudinit/sources/DataSourceOracle.py
@@ -80,11 +80,13 @@ def _ibft_has_iscsi_boot_target() -> bool:
     for flags_path in glob.glob(IBFT_TARGET_FLAGS_GLOB):
         try:
             flags = int(util.load_text_file(flags_path).strip())
+            if flags & TGT_BLOCK_VALID and flags & TGT_FIRMWARE_BOOT_SELECTED:
+                LOG.debug(
+                    "Detected iSCSI boot target via iBFT: %s", flags_path
+                )
+                return True
         except (OSError, ValueError):
             continue
-        if flags & TGT_BLOCK_VALID and flags & TGT_FIRMWARE_BOOT_SELECTED:
-            LOG.debug("Detected iSCSI boot target via iBFT: %s", flags_path)
-            return True
     return False
 
 
@@ -296,10 +298,7 @@ class DataSourceOracle(sources.DataSource):
 
     def _is_iscsi_root(self) -> bool:
         """Return whether we are on a iscsi machine."""
-        return (
-            _ibft_has_iscsi_boot_target()
-            or self._network_config_source.is_applicable()
-        )
+        return _ibft_has_iscsi_boot_target()
 
     def _get_iscsi_config(self) -> dict:
         return self._network_config_source.render_config()
@@ -318,8 +317,7 @@ class DataSourceOracle(sources.DataSource):
             return self._network_config
 
         set_primary = False
-        is_iscsi = self._is_iscsi_root()
-        if is_iscsi:
+        if self._network_config_source.is_applicable():
             self._network_config = self._get_iscsi_config()
         if not self._has_network_config():
             LOG.debug(
@@ -345,7 +343,7 @@ class DataSourceOracle(sources.DataSource):
 
         # On iSCSI root, mark the primary NIC as critical so it is not torn
         # down on shutdown, whether config came from initramfs or IMDS.
-        if is_iscsi and self._has_network_config():
+        if self._is_iscsi_root() and self._has_network_config():
             LOG.debug(
                 "Instance is using iSCSI root, setting primary NIC as critical"
             )

--- a/cloudinit/sources/DataSourceOracle.py
+++ b/cloudinit/sources/DataSourceOracle.py
@@ -52,8 +52,8 @@ MTU = 9000
 # iBFT target flags exposed by the kernel's iscsi_ibft module. A target that
 # is both valid and firmware-boot-selected indicates an iSCSI boot device.
 IBFT_TARGET_FLAGS_GLOB = "/sys/firmware/ibft/target*/flags"
-TGT_BLOCK_VALID = 0x01
-TGT_FIRMWARE_BOOT_SELECTED = 0x02
+IBFT_TGT_BLOCK_VALID = 0x01
+IBFT_TGT_FIRMWARE_BOOT_SELECTED = 0x02
 
 
 class ReadOpcMetadataResponse(NamedTuple):
@@ -80,7 +80,10 @@ def _ibft_has_iscsi_boot_target() -> bool:
     for flags_path in glob.glob(IBFT_TARGET_FLAGS_GLOB):
         try:
             flags = int(util.load_text_file(flags_path).strip())
-            if flags & TGT_BLOCK_VALID and flags & TGT_FIRMWARE_BOOT_SELECTED:
+            if (
+                flags & IBFT_TGT_BLOCK_VALID
+                and flags & IBFT_TGT_FIRMWARE_BOOT_SELECTED
+            ):
                 LOG.debug(
                     "Detected iSCSI boot target via iBFT: %s", flags_path
                 )

--- a/cloudinit/sources/DataSourceOracle.py
+++ b/cloudinit/sources/DataSourceOracle.py
@@ -14,6 +14,7 @@ Notes:
 """
 
 import base64
+import glob
 import ipaddress
 import json
 import logging
@@ -48,6 +49,12 @@ V2_HEADERS = {"Authorization": "Bearer Oracle"}
 # indicates that an MTU of 9000 is used within OCI
 MTU = 9000
 
+# iBFT target flags exposed by the kernel's iscsi_ibft module. A target that
+# is both valid and firmware-boot-selected indicates an iSCSI boot device.
+IBFT_TARGET_FLAGS_GLOB = "/sys/firmware/ibft/target*/flags"
+TGT_BLOCK_VALID = 0x01
+TGT_FIRMWARE_BOOT_SELECTED = 0x02
+
 
 class ReadOpcMetadataResponse(NamedTuple):
     version: int
@@ -66,6 +73,19 @@ class KlibcOracleNetworkConfigSource(cmdline.KlibcNetworkConfigSource):
     def _is_applicable(self) -> bool:
         """Override _is_applicable"""
         return bool(self._files)
+
+
+def _ibft_has_iscsi_boot_target() -> bool:
+    """Return True if an iBFT target is flagged as a firmware boot device."""
+    for flags_path in glob.glob(IBFT_TARGET_FLAGS_GLOB):
+        try:
+            flags = int(util.load_text_file(flags_path).strip())
+        except (OSError, ValueError):
+            continue
+        if flags & TGT_BLOCK_VALID and flags & TGT_FIRMWARE_BOOT_SELECTED:
+            LOG.debug("Detected iSCSI boot target via iBFT: %s", flags_path)
+            return True
+    return False
 
 
 def _ensure_netfailover_safe(network_config: NetworkConfig) -> None:
@@ -216,7 +236,9 @@ class DataSourceOracle(sources.DataSource):
             )
         else:
             network_context = util.nullcontext()
-        fetch_primary_nic = not self._is_iscsi_root()
+        # Use the klibc source directly rather than _is_iscsi_root: iBFT may
+        # report iSCSI root even when no klibc files exist to render config.
+        fetch_primary_nic = not self._network_config_source.is_applicable()
         fetch_secondary_nics = self.ds_cfg.get(
             "configure_secondary_nics",
             BUILTIN_DS_CONFIG["configure_secondary_nics"],
@@ -274,7 +296,10 @@ class DataSourceOracle(sources.DataSource):
 
     def _is_iscsi_root(self) -> bool:
         """Return whether we are on a iscsi machine."""
-        return self._network_config_source.is_applicable()
+        return (
+            _ibft_has_iscsi_boot_target()
+            or self._network_config_source.is_applicable()
+        )
 
     def _get_iscsi_config(self) -> dict:
         return self._network_config_source.render_config()
@@ -293,15 +318,9 @@ class DataSourceOracle(sources.DataSource):
             return self._network_config
 
         set_primary = False
-        if self._is_iscsi_root():
+        is_iscsi = self._is_iscsi_root()
+        if is_iscsi:
             self._network_config = self._get_iscsi_config()
-            logging.debug(
-                "Instance is using iSCSI root, setting primary NIC as critical"
-            )
-            # This is necessary for Oracle baremetal instances in case they are
-            # running on an IPv6-only network. Without this, they become
-            # unreachable/unrecoverable after a shutdown.
-            self._network_config["config"][0]["keep_configuration"] = True
         if not self._has_network_config():
             LOG.debug(
                 "Could not obtain network configuration from initramfs. "
@@ -323,6 +342,14 @@ class DataSourceOracle(sources.DataSource):
                     LOG,
                     "Failed to parse IMDS network configuration!",
                 )
+
+        # On iSCSI root, mark the primary NIC as critical so it is not torn
+        # down on shutdown, whether config came from initramfs or IMDS.
+        if is_iscsi and self._has_network_config():
+            LOG.debug(
+                "Instance is using iSCSI root, setting primary NIC as critical"
+            )
+            self._network_config["config"][0]["keep_configuration"] = True
 
         # we need to verify that the nic selected is not a netfail over
         # device and, if it is a netfail master, then we need to avoid

--- a/tests/unittests/sources/test_oracle.py
+++ b/tests/unittests/sources/test_oracle.py
@@ -1466,16 +1466,16 @@ class TestNetworkConfig:
     def test_keep_configuration_set_from_imds_fallback(
         self, m_get_interfaces_by_mac, oracle_ds, mocker
     ):
-        """iSCSI root with no initramfs config (dracut) still marks the
+        """iSCSI root with no klibc config (dracut) still marks the
         primary NIC critical when config comes from IMDS."""
         m_get_interfaces_by_mac.return_value = {
             "02:00:17:05:d1:db": "ens3",
             "00:00:17:02:2b:b1": "ens4",
         }
         mocker.patch.object(
-            oracle_ds,
-            "_get_iscsi_config",
-            return_value={"version": 1, "config": []},
+            oracle_ds._network_config_source,
+            "is_applicable",
+            return_value=False,
         )
         oracle_ds._vnics_data = json.loads(OPC_VM_SECONDARY_VNIC_RESPONSE)
 

--- a/tests/unittests/sources/test_oracle.py
+++ b/tests/unittests/sources/test_oracle.py
@@ -381,6 +381,48 @@ class TestIsPlatformViable:
         m_read_dmi_data.assert_has_calls([mock.call("chassis-asset-tag")])
 
 
+class TestIbftHasIscsiBootTarget:
+    @pytest.mark.parametrize(
+        "flags_contents, is_iscsi_root",
+        [
+            # Valid and firmware-boot-selected target is an iSCSI root.
+            (["3"], True),
+            # Valid but not boot-selected is not.
+            (["1"], False),
+            # Neither valid nor boot-selected is not.
+            (["0"], False),
+            # Boot-selected but not valid is not.
+            (["2"], False),
+            # Any valid and boot-selected target among several wins.
+            (["0", "3"], True),
+            (["1", "2"], False),
+            # Malformed flag contents are ignored.
+            (["garbage"], False),
+            # No iBFT targets present.
+            ([], False),
+        ],
+    )
+    def test_flag_values(self, flags_contents, is_iscsi_root, mocker):
+        paths = [
+            f"/sys/firmware/ibft/target{i}/flags"
+            for i in range(len(flags_contents))
+        ]
+        mocker.patch(DS_PATH + ".glob.glob", return_value=paths)
+        mocker.patch(
+            DS_PATH + ".util.load_text_file", side_effect=flags_contents
+        )
+        assert is_iscsi_root == oracle._ibft_has_iscsi_boot_target()
+
+    @pytest.mark.parametrize("error", [FileNotFoundError, PermissionError])
+    def test_unreadable_flags_are_skipped(self, error, mocker):
+        mocker.patch(
+            DS_PATH + ".glob.glob",
+            return_value=["/sys/firmware/ibft/target0/flags"],
+        )
+        mocker.patch(DS_PATH + ".util.load_text_file", side_effect=error)
+        assert not oracle._ibft_has_iscsi_boot_target()
+
+
 @pytest.mark.is_iscsi(False)
 @mock.patch(
     "cloudinit.net.is_openvswitch_internal_interface",
@@ -1411,6 +1453,50 @@ class TestNetworkConfig:
         assert 1 == oracle_ds._get_iscsi_config.call_count
         oracle_ds.network_config  # pylint: disable=pointless-statement
         assert 1 == oracle_ds._get_iscsi_config.call_count
+
+    @pytest.mark.is_iscsi(True)
+    def test_keep_configuration_set_from_iscsi_klibc(
+        self, m_get_interfaces_by_mac, oracle_ds
+    ):
+        """iSCSI root config from initramfs marks the primary NIC critical."""
+        netcfg = oracle_ds.network_config
+        assert netcfg["config"][0]["keep_configuration"] is True
+
+    @pytest.mark.is_iscsi(True)
+    def test_keep_configuration_set_from_imds_fallback(
+        self, m_get_interfaces_by_mac, oracle_ds, mocker
+    ):
+        """iSCSI root with no initramfs config (dracut) still marks the
+        primary NIC critical when config comes from IMDS."""
+        m_get_interfaces_by_mac.return_value = {
+            "02:00:17:05:d1:db": "ens3",
+            "00:00:17:02:2b:b1": "ens4",
+        }
+        mocker.patch.object(
+            oracle_ds,
+            "_get_iscsi_config",
+            return_value={"version": 1, "config": []},
+        )
+        oracle_ds._vnics_data = json.loads(OPC_VM_SECONDARY_VNIC_RESPONSE)
+
+        netcfg = oracle_ds.network_config
+
+        assert netcfg["config"][0]["keep_configuration"] is True
+
+    @pytest.mark.is_iscsi(False)
+    def test_keep_configuration_not_set_without_iscsi(
+        self, m_get_interfaces_by_mac, oracle_ds
+    ):
+        """Non-iSCSI instances do not mark the primary NIC critical."""
+        m_get_interfaces_by_mac.return_value = {
+            "02:00:17:05:d1:db": "ens3",
+            "00:00:17:02:2b:b1": "ens4",
+        }
+        oracle_ds._vnics_data = json.loads(OPC_VM_SECONDARY_VNIC_RESPONSE)
+
+        netcfg = oracle_ds.network_config
+
+        assert "keep_configuration" not in netcfg["config"][0]
 
     @pytest.mark.parametrize(
         "configure_secondary_nics,is_iscsi,expected_set_primary",


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [x] I have signed the CLA: https://ubuntu.com/legal/contributors
- [x] I have included a comprehensive commit message using the guide below
- [x] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [x] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [x] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [] I have updated the documentation with the changed behavior.
  - Skipped: no user-interface change (internal detection logic only).
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e doc``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix(oracle): detect iSCSI root via iBFT for dracut images

_is_iscsi_root() only detected iSCSI root from initramfs-tools klibc
/run/net-*.conf files, which dracut images don't produce. Those
instances fell back to IMDS and never got keep_configuration (netplan
critical: true) on the primary NIC. Without it the interface can be
torn down while the root filesystem is still mounted over iSCSI,
stalling shutdown/reboot.

Detect iSCSI root from the kernel iBFT (/sys/firmware/ibft/target*/
flags), keep klibc as a fallback, and set keep_configuration for both
the klibc and IMDS paths.

Fixes GH-6915
```

## Additional Context
<!-- If relevant -->

On OCI bare metal, the root filesystem is on iSCSI, so the primary NIC must stay configured until root is unmounted. cloud-init marks it with `keep_configuration` (rendered as netplan `critical: true` / `KeepConfiguration=yes`).

Detection previously relied on `KlibcOracleNetworkConfigSource`, which is only applicable when initramfs-tools klibc `/run/net-*.conf` files exist. Resolute (26.04) uses dracut, which does not produce those files, so `_is_iscsi_root()` returned False, network config came from IMDS, and the flag (previously only set on the klibc branch) was never applied.

The iBFT check reads sysfs contents, not module presence: the kernel only creates `/sys/firmware/ibft/` when firmware provided a table during an iSCSI boot, and it is only consulted after `ds_detect()` has already gated on the Oracle chassis asset tag, so it does not affect platform detection.

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

Tested on four OCI instance types by redeploying the datasource,
re-running `cloud-init`, and checking the log, netplan, and iBFT:

```
sudo cloud-init clean --logs
sudo cloud-init init --local
grep DataSourceOracle.py /var/log/cloud-init.log
sudo cat /etc/netplan/50-cloud-init.yaml
ls /sys/firmware/ibft/
```

| Image / shape        | iBFT | "using iSCSI root" log | `critical: true` | Reboot |
|----------------------|------|------------------------|------------------|--------|
| Resolute BM (target) | yes  | yes (fixed)            | yes (fixed)      | prompt (was >100 min hang) |
| Resolute VM          | no   | no                     | no               | unchanged  |
| Noble BM             | yes  | yes (unchanged)        | yes (unchanged)  | unchanged  |
| Noble VM             | no   | no                     | no               | unchanged |

### Resolute BM: before vs. after (same host/NIC)

Before, the iBFT is present but iSCSI root isn't detected, so the NIC
isn't marked critical:

```
$ grep DataSourceOracle.py /var/log/cloud-init.log
... Could not obtain network configuration from initramfs. Falling back to IMDS.

$ sudo cat /etc/netplan/50-cloud-init.yaml
    ens300f0np0:
      match:
        macaddress: "08:c0:eb:eb:0e:6a"
      dhcp4: true
      set-name: "ens300f0np0"
      mtu: 9000
```

After, iSCSI root is detected and `critical: true` is set:

```
$ grep DataSourceOracle.py /var/log/cloud-init.log
... Could not obtain network configuration from initramfs. Falling back to IMDS.
... Instance is using iSCSI root, setting primary NIC as critical

$ sudo cat /etc/netplan/50-cloud-init.yaml
    ens300f0np0:
      match:
        macaddress: "08:c0:eb:eb:0e:6a"
      critical: true
      dhcp4: true
      set-name: "ens300f0np0"
      mtu: 9000
```

Reboot after the fix completes promptly (`RUNNING in 21s`, SSH in 350s),
versus the stock >100 min hang. Note: applying the fix to a running
instance requires two reboots to take effect (the first still runs the
pre-fix systemd-networkd config); a fresh image does not.

### Regression checks

The three non-target cases are unchanged, and all reboot cleanly
(`journalctl -b -1` reaches `reboot.target` with no ext4/journal
errors). Resolute VM and Noble VM have no iBFT and get no
`critical: true`; Noble BM still renders from klibc and keeps
`critical: true` as before.

### Unit tests

```
tox -e py3 -- tests/unittests/sources/test_oracle.py
```

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
