### PR TITLE
systemd: add azurelinux variant to service unit templates

### DIFF
--- a/systemd/cloud-init-local.service.tmpl
+++ b/systemd/cloud-init-local.service.tmpl
@@ -2,14 +2,14 @@
 [Unit]
 # https://docs.cloud-init.io/en/latest/explanation/boot.html
 Description=Cloud-init: Local Stage (pre-network)
-{% if variant in ["almalinux", "cloudlinux", "ubuntu", "unknown", "debian", "raspberry-pi-os", "rhel"] %}
+{% if variant in ["almalinux", "azurelinux", "cloudlinux", "ubuntu", "unknown", "debian", "raspberry-pi-os", "rhel"] %}
 DefaultDependencies=no
 {% endif %}
 Wants=network-pre.target
 After=hv_kvp_daemon.service
 Before=network-pre.target
 Before=shutdown.target
-{% if variant in ["almalinux", "cloudlinux", "rhel"] %}
+{% if variant in ["almalinux", "azurelinux", "cloudlinux", "rhel"] %}
 Before=firewalld.target
 {% endif %}
 {% if variant in ["ubuntu", "unknown", "debian", "raspberry-pi-os"] %}
@@ -22,7 +22,7 @@ ConditionEnvironment=!KERNEL_CMDLINE=cloud-init=disabled
 
 [Service]
 Type=oneshot
-{% if variant in ["almalinux", "cloudlinux", "rhel"] %}
+{% if variant in ["almalinux", "azurelinux", "cloudlinux", "rhel"] %}
 ExecStartPre=/sbin/restorecon /run/cloud-init
 {% endif %}
 # This service is a shim which preserves systemd ordering while allowing a

--- a/systemd/cloud-init-main.service.tmpl
+++ b/systemd/cloud-init-main.service.tmpl
@@ -8,10 +8,10 @@
 # https://www.freedesktop.org/software/systemd/man/latest/systemd-remount-fs.service.html
 [Unit]
 Description=Cloud-init: Single Process
-{% if variant in ["almalinux", "cloudlinux", "ubuntu", "unknown", "debian", "raspberry-pi-os", "rhel"] %}
+{% if variant in ["almalinux", "azurelinux", "cloudlinux", "ubuntu", "unknown", "debian", "raspberry-pi-os", "rhel"] %}
 DefaultDependencies=no
 {% endif %}
-{% if variant in ["almalinux", "cloudlinux", "rhel"] %}
+{% if variant in ["almalinux", "azurelinux", "cloudlinux", "rhel"] %}
 Requires=dbus.socket
 After=dbus.socket
 {% endif %}
@@ -31,7 +31,7 @@ ExecStart=/usr/bin/cloud-init --all-stages
 KillMode=process
 TasksMax=infinity
 TimeoutStartSec=infinity
-{% if variant in ["almalinux", "cloudlinux", "rhel"] %}
+{% if variant in ["almalinux", "azurelinux", "cloudlinux", "rhel"] %}
 ExecStartPre=/sbin/restorecon /run/cloud-init
 {% endif %}
 

--- a/systemd/cloud-init-network.service.tmpl
+++ b/systemd/cloud-init-network.service.tmpl
@@ -2,7 +2,7 @@
 [Unit]
 # https://docs.cloud-init.io/en/latest/explanation/boot.html
 Description=Cloud-init: Network Stage
-{% if variant not in ["almalinux", "cloudlinux", "photon", "rhel"] %}
+{% if variant not in ["almalinux", "azurelinux", "cloudlinux", "photon", "rhel"] %}
 DefaultDependencies=no
 {% endif %}
 Wants=cloud-init-local.service
@@ -15,7 +15,7 @@ After=systemd-networkd-wait-online.service
 {% if variant in ["ubuntu", "unknown", "debian", "raspberry-pi-os"] %}
 After=networking.service
 {% endif %}
-{% if variant in ["almalinux", "centos", "cloudlinux", "eurolinux", "fedora",
+{% if variant in ["almalinux", "azurelinux", "centos", "cloudlinux", "eurolinux", "fedora",
                   "miraclelinux", "openeuler", "OpenCloudOS", "openmandriva",
                   "rhel", "rocky", "suse", "TencentOS", "virtuozzo"] %}
 After=NetworkManager.service


### PR DESCRIPTION
Azure Linux inherits from rhel.Distro and is part of the redhat OS family, but was missing from all systemd service template variant conditions. This caused Azure Linux to use generic/fallback systemd unit behavior instead of the RHEL-family specific optimizations.

Add "azurelinux" to the following conditions:
- DefaultDependencies=no (local, main, network services)
- Before=firewalld.target (local service)
- ExecStartPre=/sbin/restorecon (local, main services)
- Requires/After=dbus.socket (main service)
- After=NetworkManager.service (network service)

This ensures proper boot ordering, earlier cloud-init execution, correct D-Bus availability, and NetworkManager synchronization on Azure Linux systems.

<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [ ] I have signed the CLA: https://ubuntu.com/legal/contributors
- [ ] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [ ] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e doc``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
<type>(optional scope): <summary>  # no more than 72 characters

A description of what the change being made is and why it is being
made if the summary line is insufficient.  This should be wrapped at
72 characters.

If you need to write multiple paragraphs, feel free.

Fixes GH-NNNNN (GitHub Issue number. Remove line if irrelevant)
LP: #NNNNNN (Launchpad bug number. Remove line if irrelevant)
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
