### PR TITLE
test: fix expected empty stderr on cloud-init analyze boot

### DIFF
--- a/tests/integration_tests/cmd/test_analyze.py
+++ b/tests/integration_tests/cmd/test_analyze.py
@@ -21,7 +21,10 @@ class TestAnalyzeCommand:
         """
         assert module_client.execute("cloud-init status --wait --long").ok
         result = module_client.execute("cloud-init analyze boot")
-        assert result.stderr == "container"
+        assert (
+            result.ok
+        ), f"cloud-init analyze boot unexpected exit [{result.return_code}]"
+        assert result.stderr == ""
 
         container_start_time = get_datetime_from_string(
             result.stdout, "^\\s*Container started at: (.+?)$"


### PR DESCRIPTION

## Proposed Commit Message
```
test: fix expected empty stderr on cloud-init analyze boot

Fixed behavior in c9a520abef which no longer spits out container
on stderr. Update the integration tests to assert exit code and
empty stderr.

```

## Additional Context
Failing integration tests on https://github.com/canonical/cloud-init/actions/runs/28896154678 and stonking.


## Test Steps
```
CLOUD_INIT_OS_IMAGE=resolute CLOUD_INIT_CLOUD_INIT_SOURCE=IN_PLACE tox -e integration-tests -- tests/integration_tests/cmd/test_analyze.py::TestAnalyzeCommand::test_analyze_boot_ordered_timestamps
```

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
