### PR TITLE
feat: Fix import error (issue #6924)

### DIFF
--- a/cloudinit/importer.py
+++ b/cloudinit/importer.py
@@ -8,7 +8,7 @@
 #
 # This file is part of cloud-init. See LICENSE file for license information.
 
-import importlib
+import importlib.util
 from types import ModuleType
 from typing import Optional, Sequence
 
@@ -42,10 +42,7 @@ def match_case_insensitive_module_name(mod_name: str) -> str:
     if not mod_name.startswith("DataSource"):
         mod_name = f"DataSource{mod_name}"
     modules = {}
-    # mypy is right to warn here. This isn't a documented method.
-    # However it has worked for years without issue, so fixing it is not
-    # a high priority. We'll fix it when it breaks.
-    spec = importlib.util.find_spec("cloudinit.sources")  # type: ignore
+    spec = importlib.util.find_spec("cloudinit.sources")
     if spec and spec.submodule_search_locations:
         for dir in spec.submodule_search_locations:
             modules.update(util.get_modules_from_dir(dir))
@@ -70,10 +67,7 @@ def find_module(
         # Add base name to search paths. Filter out empty paths.
         full_path = ".".join(filter(None, [path, base_name]))
         lookup_paths.append(full_path)
-        # mypy is right to warn here. This isn't a documented method.
-        # However it has worked for years without issue, so fixing it is not
-        # a high priority. We'll fix it when it breaks.
-        if not importlib.util.find_spec(full_path):  # type: ignore
+        if not importlib.util.find_spec(full_path):
             continue
         # Check that required_attrs are all present within the module.
         if _count_attrs(full_path, required_attrs) == len(required_attrs):


### PR DESCRIPTION
## Proposed Commit Message
feat: Fix import error (issue #6924)

`importer.py` calls `importlib.util.find_spec()` but the file only actually imports `importlib`
by itself.

Up until now we've gotten away with it as something else has always imported `importlib.util` for us "by accident", but if an end consumer imports `cloud-init` as a library (i.e. `ubuntu-pro-client`) there's no guarantee that will happen. It happened in #6924 so let's fix it now.

## Test Steps

Tested in a LP build with the same functional change in our bootstraps:
```
IMPORTER_PATH="mountpoint_gce/usr/lib/python3/dist-packages/cloudinit/importer.py"

if grep -qx 'import importlib' "$IMPORTER_PATH"; then
  sed -i 's/^import importlib$/import importlib.util/' "$IMPORTER_PATH"
fi

# recompile it so the shipped .pyc matches the patched source
chroot mountpoint_gce py3compile /usr/lib/python3/dist-packages/cloudinit/importer.py

# Now actually try the path that crashed so the build will fail loudly if the workaround
# is missing and/or broken
chroot mountpoint_gce python3 -c "from cloudinit import mergers; mergers.construct(mergers.default_mergers())"
```

it builds fine and `auto-attach` is now fixed :partying_face: 