### PR TITLE
fix(temp_utils): create scratch dir ancestors with mode 0700

### DIFF
--- a/cloudinit/temp_utils.py
+++ b/cloudinit/temp_utils.py
@@ -44,7 +44,7 @@ def _tempfile_dir_arg(odir=None, needs_exe: bool = False):
     tdir = get_tmp_ancestor(odir, needs_exe)
     if not os.path.isdir(tdir):
         os.makedirs(tdir)
-        os.chmod(tdir, 0o1777)
+        os.chmod(tdir, 0o700)
 
     if needs_exe:
         if util.has_mount_opt(tdir, "noexec"):

--- a/tests/unittests/test_temp_utils.py
+++ b/tests/unittests/test_temp_utils.py
@@ -3,6 +3,7 @@
 """Tests for cloudinit.temp_utils"""
 
 import os
+import stat
 from tempfile import gettempdir
 
 import pytest
@@ -119,6 +120,25 @@ class TestTempUtils:
         )
         assert "/fake/return/path" == retval
         assert [{"dir": "/run/cloud-init/tmp"}] == calls
+
+    def test_mkdtemp_creates_missing_ancestor_not_world_writable(
+        self, tmp_path
+    ):
+        """mkdtemp creates missing ancestor dirs with mode 0o700 (GH-4189)."""
+        ancestor = str(tmp_path / "scratch")
+        retval = mkdtemp(dir=ancestor)
+        assert os.path.isdir(retval)
+        assert 0o700 == stat.S_IMODE(os.stat(ancestor).st_mode)
+
+    def test_mkstemp_creates_missing_ancestor_not_world_writable(
+        self, tmp_path
+    ):
+        """mkstemp creates missing ancestor dirs with mode 0o700 (GH-4189)."""
+        ancestor = str(tmp_path / "scratch")
+        fd, retval = mkstemp(dir=ancestor)
+        os.close(fd)
+        assert os.path.isfile(retval)
+        assert 0o700 == stat.S_IMODE(os.stat(ancestor).st_mode)
 
     def test_tempdir_error_suppression(self):
         """test tempdir suppresses errors during directory removal."""


### PR DESCRIPTION
The exec-capable fallback scratch directories (/var/tmp/cloud-init and the /usr/lib/cloud-init/clouddir fallback used when /var/tmp is noexec) were created world-writable (0o1777) and left behind after cloud-init ran. All consumers run as root and the per-run mkdtemp children are already 0o700, so the ancestor need not be world-writable. Create it 0o700 instead, which also satisfies STIG UBTU-20-010427.

Fixes GH-4189

<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [x] I have signed the CLA: https://ubuntu.com/legal/contributors
- [x] I have included a comprehensive commit message using the guide below
- [x] I have added unit tests to cover the new behavior under `tests/unittests/`
- [x] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [x] I have added a reference to issues that this PR relates to in the PR message (Fixes GH-4189)
- [x] I have updated the documentation with the changed behavior.
  - change is trivial and doesn't touch the user interface, so per the guide this step is skipped.

## Proposed Commit Message

```
fix(temp_utils): create scratch dir ancestors with mode 0700

The exec-capable fallback scratch directories (/var/tmp/cloud-init and
the /usr/lib/cloud-init/clouddir fallback used when /var/tmp is noexec)
were created world-writable (0o1777) and left behind after cloud-init
ran. All consumers run as root and the per-run mkdtemp children are
already 0o700, so the ancestor need not be world-writable. Create it
0o700 instead, which also satisfies STIG UBTU-20-010427.

Fixes GH-4189
```

## Additional Context

the issue thread raised two possible fixes: restricting the mode (what the reporter asked for) or keeping it tmp-like and deleting it when done (@igalic's suggestion). i went with 0700 after tracing the callers:

- everything that uses these dirs runs as root (cc_chef, cc_growpart, the dhcp discovery paths), and the mkdtemp children inside are already 0700, so nothing needs the ancestor world-writable
- net/dhcp.py writes files with fixed names (udhcpc_script, `<iface>-dhclient.conf`) directly into the shared ancestor and root executes/consumes them — with 1777 an unprivileged local user can pre-create those names, so this is hardening and not just compliance
- deletion doesn't have a clean owner: cloud-init-hotplugd can need the dir at any point after boot, so there's no safe "we're done" moment

happy to switch to the deletion approach if you'd prefer. one thing i'd like a sanity check on: is there any supported setup where a dhcp client re-execs its script as non-root? that's the one case i can think of where 0700 would break something.

## Test Steps

reproduced before/after in an `ubuntu:24.04` container with `/tmp` and `/var/tmp` mounted noexec (`tmpfs rw,nosuid,nodev,noexec`), driving the same sequence as `cc_growpart.py:90-91`:

- **before:** `/usr/lib/cloud-init/clouddir` created `1777 root:root`, left behind after the run, and `su nobody -c "touch .../file"` inside it succeeds
- **after:** created `0700`, exec inside still works (the noexec workaround is intact), `nobody`'s touch fails with `Permission denied`; same result for the `/var/tmp/cloud-init` path

unit tests: `tox -e py3 -- tests/unittests/test_temp_utils.py` → 8 pass (2 new tests cover the previously-untested creation branch). black / ruff / isort clean.

i wasn't able to test on a live deployed system, only in containers exercising the affected code path directly.

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)