### PR TITLE
fix(helpers): append vendor cloud-config lists instead of dropping them

### DIFF
--- a/cloudinit/helpers.py
+++ b/cloudinit/helpers.py
@@ -220,7 +220,20 @@ class ConfigMerger:
             cc_fn = self._paths.get_ipath_cur(cc_p)
             if cc_fn and os.path.isfile(cc_fn):
                 try:
-                    i_cfgs.append(util.read_conf(cc_fn))
+                    cfg = util.read_conf(cc_fn)
+                    # Vendor configs should append list values (like
+                    # write_files, runcmd) rather than being silently
+                    # dropped when user-data defines the same key.
+                    if cc_p in (
+                        "vendor_cloud_config",
+                        "vendor2_cloud_config",
+                    ):
+                        cfg.setdefault(
+                            "merge_how",
+                            "list(append)+dict(no_replace,recurse_list)"
+                            "+str()",
+                        )
+                    i_cfgs.append(cfg)
                 except PermissionError:
                     LOG.debug(
                         "Skipped loading cloud-config from %s due to"

--- a/tests/unittests/test_data.py
+++ b/tests/unittests/test_data.py
@@ -297,9 +297,8 @@ run:
         assert "vendor_data" in cfg
         assert cfg["a"] == "c"
         assert cfg["name"] == "user"
-        assert "x" not in cfg["run"]
-        assert "y" not in cfg["run"]
-        assert "z" in cfg["run"]
+        # Vendor list entries are appended after user entries
+        assert cfg["run"] == ["z", "x", "y"]
 
     @pytest.mark.usefixtures("fake_filesystem")
     def test_vendordata_script(self):


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [x] I have signed the CLA: https://ubuntu.com/legal/contributors
- [x] I have included a comprehensive commit message using the guide below
- [x] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [x] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [x] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [x] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e doc``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix(helpers): append vendor cloud-config lists instead of dropping them
    
When deploying a machine (such as a MAAS node) with a custom user-data
configuration, top-level lists in vendor-data (e.g., `write_files` or
`runcmd`) are silently ignored if the user-data contains the same keys.
This occurs because user-data is loaded first, and the default merging
strategy (`no_replace` with `recurse_list=False`) discards duplicate
keys from subsequent sources.
    
In MAAS deployments, this behavior breaks networking by completely
dropping the MAAS-generated `write_files` block that writes the netplan
configuration (e.g., `/etc/netplan/50-maas.yaml`), leaving only the
PXE interface configured.
    
This PR fixes  this by updating `ConfigMerger._get_instance_configs`
to inject a default `merge_how` strategy for `vendor_cloud_config`
and `vendor2_cloud_config`. This updates the strategy to:
`list(append)+dict(no_replace,recurse_list)+str()`
    
This ensures vendor-defined lists are appended to user-defined lists
rather than being discarded, while maintaining `no_replace` for
dictionary values and strings.
    
Signed-off-by: Leah Goldberg <leah.goldberg@canonical.com>

Fixes GH-6268
LP: #2158442
```

## Additional Context

This PR fixes an issue where the default merge strategy for user-data and vendor-data silently discards critical vendor-data list keys (such as `write_files`). Because user-data is loaded first, cloud-init's default `no_replace` strategy drops matching vendor keys. This breaks networking on ephemeral platforms like MAAS by wiping out vendor generated netplan configurations.

This fix injects a default `merge_how` directive into vendor configs (vendor_cloud_config, vendor2_cloud_config) to ensure list values are appended instead of dropped: `list(append)+dict(no_replace,recurse_list)+str()`

For example:

**user-data** 
```
{
    "write_files": [
        {"path": "/leah.txt", "content": "hello leah", "permissions": "0644"}
    ]
}
```
**vendor-data**
```

{
    "write_files": [
        {"path": "/etc/netplan/50-maas.yaml", "content": "network:\n...", "permissions": "0600"}
    ],
    "runcmd": ["netplan apply"]
}
```

The current way of merging is:
```
{
    "write_files": [
        {"path": "/leah.txt", "content": "hello leah", "permissions": "0644"}
    ],
    "runcmd": ["netplan apply"] 
}
```

Notice how the `write_files` from the vendor-data is ignored since the user-data already defined `write_files`.

This PR would change the merge to be:
```
{
    "write_files": [
        {"path": "/leah.txt", "content": "hello leah", "permissions": "0644"},
        {"path": "/etc/netplan/50-maas.yaml", "content": "network:\n...", "permissions": "0600"} 
    ],
    "runcmd": ["netplan apply"]
}
```
This ensures list values are appended instead of dropped.

## Test Steps

**How to reproduce the bug**
1. Deploy MAAS (3.4 or 3.6 - deb or snap) and add a VM.
2. Customize the VM network so it's non-default (e.g. add a VLAN).

<img width="1818" height="836" alt="image" src="https://github.com/user-attachments/assets/4fb57a42-8f03-4fa3-a946-f0a8f10d3d8c" />


3. Deploy the machine to memory with a custom cloud-init config:
```
#cloud-config

write_files:
  - path: /dave.txt
    content: "hello"
    owner: root:root
    permissions: '0644'
```
4. Once the VM is deployed, note the network config. It will only have the PXE config and drop the custom config you added.

**Actual behavior**

| Name | State | IPv4 | IPv6 | Type | Snapshots |
|------|-------|------|------|------|----------:|
| octopus-memory | RUNNING | 10.239.17.2 (enp5s0) | | VIRTUAL-MACHINE | 0 |

The deployed machine only has the PXE interface (`enp5s0`) configured.

**Expected behavior**

| Name | State | IPv4 | IPv6 | Type | Snapshots |
|------|-------|------|------|------|----------:|
| octopus-memory | RUNNING | 10.239.17.2 (enp5s0)<br>10.20.0.1 (enp5s0.100) | | VIRTUAL-MACHINE | 0 |

The expected behavior is for both the PXE interface (`enp5s0`) and the MAAS-configured VLAN interface (`enp5s0.100`) to remain configured after deployment.

**How to test this fix**

Note: I tested this on MAAS 3.5.12 (snap) which uses Ubuntu 22.04 (Jammy). 

1. Download this [custom image](https://drive.google.com/file/d/1n7M63Wp4LYAX-JBiRQOXfDJMHbt9Ykwy/view?usp=sharing) (built with [packer-maas](https://github.com/canonical/packer-maas)) that includes this cloud-init patch.
2. Upload it to your MAAS environment.
```
maas $PROFILE boot-resources create \
    name='custom/packer-custom-ubuntu' \
    title='Ubuntu 22.04 (patched: cloud-init vendor-merge)' \
    architecture='amd64/generic' \
    filetype='tgz' \
    content@=ubuntu-jammy-cloudinit-merge-user-vendor-fix.tar.gz
```
3. Deploy a VM with the custom image to memory and the custom cloud config.
4. SSH into machine and check that networking is set up properly.

You should see networking is set up properly now:
```
ubuntu@octopus-memory:~$ ip a
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
    inet6 ::1/128 scope host 
       valid_lft forever preferred_lft forever
2: enp5s0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP group default qlen 1000
    link/ether 00:16:3e:2d:fb:b3 brd ff:ff:ff:ff:ff:ff
    inet 10.239.17.2/24 brd 10.239.17.255 scope global enp5s0
       valid_lft forever preferred_lft forever
    inet6 fe80::216:3eff:fe2d:fbb3/64 scope link 
       valid_lft forever preferred_lft forever
3: enp5s0.100@enp5s0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
    link/ether 00:16:3e:2d:fb:b3 brd ff:ff:ff:ff:ff:ff
    inet 10.20.0.1/24 brd 10.20.0.255 scope global enp5s0.100
       valid_lft forever preferred_lft forever
    inet6 fe80::216:3eff:fe2d:fbb3/64 scope link 
       valid_lft forever preferred_lft forever
```


**Related Links**
-  #6268
- [LP 2158442: custom cloud-config conflicts with MAAS-generated vendor-data in deploy-to-memory workflows](https://bugs.launchpad.net/maas/+bug/2158442)

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)