### PR TITLE
chore: deprecate cloud-config modules for unmaintained software

### DIFF
--- a/cloudinit/config/cc_disable_ec2_metadata.py
+++ b/cloudinit/config/cc_disable_ec2_metadata.py
@@ -10,7 +10,7 @@
 
 import logging
 
-from cloudinit import subp, util
+from cloudinit import lifecycle, subp, util
 from cloudinit.cloud import Cloud
 from cloudinit.config import Config
 from cloudinit.config.schema import MetaSchema
@@ -33,6 +33,11 @@ meta: MetaSchema = {
 def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     disabled = util.get_cfg_option_bool(cfg, "disable_ec2_metadata", False)
     if disabled:
+        lifecycle.deprecate(
+            deprecated="Module cc_disable_ec2_metadata",
+            deprecated_version="26.2",
+            extra_message="The disable_ec2_metadata module is deprecated and will be removed in a future release.",
+        )
         reject_cmd = None
         if subp.which("ip"):
             reject_cmd = REJECT_CMD_IP

--- a/cloudinit/config/cc_disable_ec2_metadata.py
+++ b/cloudinit/config/cc_disable_ec2_metadata.py
@@ -10,7 +10,7 @@
 
 import logging
 
-from cloudinit import subp, util
+from cloudinit import lifecycle, subp, util
 from cloudinit.cloud import Cloud
 from cloudinit.config import Config
 from cloudinit.config.schema import MetaSchema
@@ -33,6 +33,10 @@ meta: MetaSchema = {
 def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     disabled = util.get_cfg_option_bool(cfg, "disable_ec2_metadata", False)
     if disabled:
+        lifecycle.deprecate(
+            deprecated="Module cc_disable_ec2_metadata",
+            deprecated_version="26.2",
+        )
         reject_cmd = None
         if subp.which("ip"):
             reject_cmd = REJECT_CMD_IP

--- a/cloudinit/config/cc_mcollective.py
+++ b/cloudinit/config/cc_mcollective.py
@@ -17,7 +17,7 @@ import logging
 # and doesn't need a top level section
 from configobj import ConfigObj
 
-from cloudinit import subp, util
+from cloudinit import lifecycle, subp, util
 from cloudinit.cloud import Cloud
 from cloudinit.config import Config
 from cloudinit.config.schema import MetaSchema
@@ -106,6 +106,11 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
             name,
         )
         return
+    lifecycle.deprecate(
+        deprecated="Module cc_mcollective",
+        deprecated_version="26.2",
+        extra_message="The mcollective module is deprecated and will be removed in a future release.",
+    )
 
     mcollective_cfg = cfg["mcollective"]
 

--- a/cloudinit/config/cc_mcollective.py
+++ b/cloudinit/config/cc_mcollective.py
@@ -17,7 +17,7 @@ import logging
 # and doesn't need a top level section
 from configobj import ConfigObj
 
-from cloudinit import subp, util
+from cloudinit import lifecycle, subp, util
 from cloudinit.cloud import Cloud
 from cloudinit.config import Config
 from cloudinit.config.schema import MetaSchema
@@ -106,6 +106,10 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
             name,
         )
         return
+    lifecycle.deprecate(
+        deprecated="Module cc_mcollective",
+        deprecated_version="26.2",
+    )
 
     mcollective_cfg = cfg["mcollective"]
 

--- a/cloudinit/config/cc_reset_rmc.py
+++ b/cloudinit/config/cc_reset_rmc.py
@@ -27,7 +27,7 @@ Prerequisite of using this module is to install RSCT packages.
 import logging
 import os
 
-from cloudinit import subp, util
+from cloudinit import lifecycle, subp, util
 from cloudinit.cloud import Cloud
 from cloudinit.config import Config
 from cloudinit.config.schema import MetaSchema
@@ -66,6 +66,12 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     if not os.path.isdir(RSCT_PATH):
         LOG.debug("module disabled, RSCT_PATH not present")
         return
+
+    lifecycle.deprecate(
+        deprecated="Module cc_reset_rmc",
+        deprecated_version="26.2",
+        extra_message="The reset_rmc module is deprecated and will be removed in a future release.",
+    )
 
     orig_path = os.environ.get("PATH")
     try:

--- a/cloudinit/config/cc_reset_rmc.py
+++ b/cloudinit/config/cc_reset_rmc.py
@@ -28,7 +28,7 @@ Prerequisite of using this module is to install RSCT packages.
 import logging
 import os
 
-from cloudinit import subp, util
+from cloudinit import lifecycle, subp, util
 from cloudinit.cloud import Cloud
 from cloudinit.config import Config
 from cloudinit.config.schema import MetaSchema
@@ -67,6 +67,11 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     if not os.path.isdir(RSCT_PATH):
         LOG.debug("module disabled, RSCT_PATH not present")
         return
+
+    lifecycle.deprecate(
+        deprecated="Module cc_reset_rmc",
+        deprecated_version="26.2",
+    )
 
     orig_path = os.environ.get("PATH")
     try:

--- a/cloudinit/config/cc_spacewalk.py
+++ b/cloudinit/config/cc_spacewalk.py
@@ -3,7 +3,7 @@
 
 import logging
 
-from cloudinit import subp
+from cloudinit import lifecycle, subp
 from cloudinit.cloud import Cloud
 from cloudinit.config import Config
 from cloudinit.config.schema import MetaSchema
@@ -68,6 +68,11 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
             name,
         )
         return
+    lifecycle.deprecate(
+        deprecated="Module cc_spacewalk",
+        deprecated_version="26.2",
+        extra_message="The spacewalk module is deprecated and will be removed in a future release.",
+    )
     cfg = cfg["spacewalk"]
     spacewalk_server = cfg.get("server")
     if spacewalk_server:

--- a/cloudinit/config/cc_spacewalk.py
+++ b/cloudinit/config/cc_spacewalk.py
@@ -3,7 +3,7 @@
 
 import logging
 
-from cloudinit import subp
+from cloudinit import lifecycle, subp
 from cloudinit.cloud import Cloud
 from cloudinit.config import Config
 from cloudinit.config.schema import MetaSchema
@@ -68,6 +68,10 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
             name,
         )
         return
+    lifecycle.deprecate(
+        deprecated="Module cc_spacewalk",
+        deprecated_version="26.2",
+    )
     cfg = cfg["spacewalk"]
     spacewalk_server = cfg.get("server")
     if spacewalk_server:

--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -1452,9 +1452,18 @@
       "type": "object",
       "properties": {
         "disable_ec2_metadata": {
-          "default": false,
-          "description": "Set true to disable IPv4 routes to EC2 metadata. Default: ``false``.",
-          "type": "boolean"
+          "allOf": [
+            {
+              "default": false,
+              "description": "Set true to disable IPv4 routes to EC2 metadata. Default: ``false``.",
+              "type": "boolean"
+            },
+            {
+              "deprecated": true,
+              "deprecated_version": "26.2",
+              "deprecated_description": "The disable_ec2_metadata module is deprecated and will be removed in a future release."
+            }
+          ]
         }
       }
     },
@@ -2059,40 +2068,49 @@
       "type": "object",
       "properties": {
         "mcollective": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "conf": {
+          "allOf": [
+            {
               "type": "object",
               "additionalProperties": false,
               "properties": {
-                "public-cert": {
-                  "type": "string",
-                  "description": "Optional value of server public certificate which will be written to ``/etc/mcollective/ssl/server-public.pem``."
-                },
-                "private-cert": {
-                  "type": "string",
-                  "description": "Optional value of server private certificate which will be written to ``/etc/mcollective/ssl/server-private.pem``."
-                }
-              },
-              "patternProperties": {
-                "^.+$": {
-                  "description": "Optional config key: value pairs which will be appended to ``/etc/mcollective/server.cfg``.",
-                  "oneOf": [
-                    {
-                      "type": "boolean"
+                "conf": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "public-cert": {
+                      "type": "string",
+                      "description": "Optional value of server public certificate which will be written to ``/etc/mcollective/ssl/server-public.pem``."
                     },
-                    {
-                      "type": "integer"
-                    },
-                    {
-                      "type": "string"
+                    "private-cert": {
+                      "type": "string",
+                      "description": "Optional value of server private certificate which will be written to ``/etc/mcollective/ssl/server-private.pem``."
                     }
-                  ]
+                  },
+                  "patternProperties": {
+                    "^.+$": {
+                      "description": "Optional config key: value pairs which will be appended to ``/etc/mcollective/server.cfg``.",
+                      "oneOf": [
+                        {
+                          "type": "boolean"
+                        },
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ]
+                    }
+                  }
                 }
               }
+            },
+            {
+              "deprecated": true,
+              "deprecated_version": "26.2",
+              "deprecated_description": "The mcollective module is deprecated and will be removed in a future release."
             }
-          }
+          ]
         }
       }
     },
@@ -2560,6 +2578,24 @@
               }
             }
           }
+        }
+      }
+    },
+    "cc_reset_rmc": {
+      "type": "object",
+      "properties": {
+        "reset_rmc": {
+          "allOf": [
+            {
+              "type": "boolean",
+              "description": "Reset the RSCT node id."
+            },
+            {
+              "deprecated": true,
+              "deprecated_version": "26.2",
+              "deprecated_description": "The reset_rmc module is deprecated and will be removed in a future release."
+            }
+          ]
         }
       }
     },
@@ -3278,22 +3314,31 @@
       "type": "object",
       "properties": {
         "spacewalk": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "server": {
-              "type": "string",
-              "description": "The Spacewalk server to use."
+          "allOf": [
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "server": {
+                  "type": "string",
+                  "description": "The Spacewalk server to use."
+                },
+                "proxy": {
+                  "type": "string",
+                  "description": "The proxy to use when connecting to Spacewalk."
+                },
+                "activation_key": {
+                  "type": "string",
+                  "description": "The activation key to use when registering with Spacewalk."
+                }
+              }
             },
-            "proxy": {
-              "type": "string",
-              "description": "The proxy to use when connecting to Spacewalk."
-            },
-            "activation_key": {
-              "type": "string",
-              "description": "The activation key to use when registering with Spacewalk."
+            {
+              "deprecated": true,
+              "deprecated_version": "26.2",
+              "deprecated_description": "The spacewalk module is deprecated and will be removed in a future release."
             }
-          }
+          ]
         }
       }
     },
@@ -4111,6 +4156,9 @@
       "$ref": "#/$defs/cc_resolv_conf"
     },
     {
+      "$ref": "#/$defs/cc_reset_rmc"
+    },
+    {
       "$ref": "#/$defs/cc_rh_subscription"
     },
     {
@@ -4251,6 +4299,7 @@
     "puppet": {},
     "random_seed": {},
     "reporting": {},
+    "reset_rmc": {},
     "resize_rootfs": {},
     "resolv_conf": {},
     "rh_subscription": {},

--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -1452,9 +1452,18 @@
       "type": "object",
       "properties": {
         "disable_ec2_metadata": {
-          "default": false,
-          "description": "Set true to disable IPv4 routes to EC2 metadata. Default: ``false``.",
-          "type": "boolean"
+          "allOf": [
+            {
+              "default": false,
+              "description": "Set true to disable IPv4 routes to EC2 metadata. Default: ``false``.",
+              "type": "boolean"
+            },
+            {
+              "deprecated": true,
+              "deprecated_version": "26.2",
+              "deprecated_description": "The disable_ec2_metadata module is deprecated and scheduled to be removed in 31.2."
+            }
+          ]
         }
       }
     },
@@ -2059,40 +2068,49 @@
       "type": "object",
       "properties": {
         "mcollective": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "conf": {
+          "allOf": [
+            {
               "type": "object",
               "additionalProperties": false,
               "properties": {
-                "public-cert": {
-                  "type": "string",
-                  "description": "Optional value of server public certificate which will be written to ``/etc/mcollective/ssl/server-public.pem``."
-                },
-                "private-cert": {
-                  "type": "string",
-                  "description": "Optional value of server private certificate which will be written to ``/etc/mcollective/ssl/server-private.pem``."
-                }
-              },
-              "patternProperties": {
-                "^.+$": {
-                  "description": "Optional config key: value pairs which will be appended to ``/etc/mcollective/server.cfg``.",
-                  "oneOf": [
-                    {
-                      "type": "boolean"
+                "conf": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "public-cert": {
+                      "type": "string",
+                      "description": "Optional value of server public certificate which will be written to ``/etc/mcollective/ssl/server-public.pem``."
                     },
-                    {
-                      "type": "integer"
-                    },
-                    {
-                      "type": "string"
+                    "private-cert": {
+                      "type": "string",
+                      "description": "Optional value of server private certificate which will be written to ``/etc/mcollective/ssl/server-private.pem``."
                     }
-                  ]
+                  },
+                  "patternProperties": {
+                    "^.+$": {
+                      "description": "Optional config key: value pairs which will be appended to ``/etc/mcollective/server.cfg``.",
+                      "oneOf": [
+                        {
+                          "type": "boolean"
+                        },
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ]
+                    }
+                  }
                 }
               }
+            },
+            {
+              "deprecated": true,
+              "deprecated_version": "26.2",
+              "deprecated_description": "The mcollective module is deprecated and scheduled to be removed in 31.2."
             }
-          }
+          ]
         }
       }
     },
@@ -2560,6 +2578,24 @@
               }
             }
           }
+        }
+      }
+    },
+    "cc_reset_rmc": {
+      "type": "object",
+      "properties": {
+        "reset_rmc": {
+          "allOf": [
+            {
+              "type": "boolean",
+              "description": "Reset the RSCT node id."
+            },
+            {
+              "deprecated": true,
+              "deprecated_version": "26.2",
+              "deprecated_description": "The reset_rmc module is deprecated and scheduled to be removed in 31.2."
+            }
+          ]
         }
       }
     },
@@ -3278,22 +3314,31 @@
       "type": "object",
       "properties": {
         "spacewalk": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "server": {
-              "type": "string",
-              "description": "The Spacewalk server to use."
+          "allOf": [
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "server": {
+                  "type": "string",
+                  "description": "The Spacewalk server to use."
+                },
+                "proxy": {
+                  "type": "string",
+                  "description": "The proxy to use when connecting to Spacewalk."
+                },
+                "activation_key": {
+                  "type": "string",
+                  "description": "The activation key to use when registering with Spacewalk."
+                }
+              }
             },
-            "proxy": {
-              "type": "string",
-              "description": "The proxy to use when connecting to Spacewalk."
-            },
-            "activation_key": {
-              "type": "string",
-              "description": "The activation key to use when registering with Spacewalk."
+            {
+              "deprecated": true,
+              "deprecated_version": "26.2",
+              "deprecated_description": "The spacewalk module is deprecated and scheduled to be removed in 31.2."
             }
-          }
+          ]
         }
       }
     },
@@ -4111,6 +4156,9 @@
       "$ref": "#/$defs/cc_resolv_conf"
     },
     {
+      "$ref": "#/$defs/cc_reset_rmc"
+    },
+    {
       "$ref": "#/$defs/cc_rh_subscription"
     },
     {
@@ -4251,6 +4299,7 @@
     "puppet": {},
     "random_seed": {},
     "reporting": {},
+    "reset_rmc": {},
     "resize_rootfs": {},
     "resolv_conf": {},
     "rh_subscription": {},

--- a/config/cloud.cfg.tmpl
+++ b/config/cloud.cfg.tmpl
@@ -200,9 +200,6 @@ cloud_final_modules:
   - ansible
   - mcollective
   - salt_minion
-{% if variant not in ["alpine"] %}
-  - reset_rmc
-{% endif %}
   - scripts_vendor
   - scripts_per_once
   - scripts_per_boot

--- a/config/cloud.cfg.tmpl
+++ b/config/cloud.cfg.tmpl
@@ -166,7 +166,7 @@ cloud_config_modules:
   - rh_subscription
 {% endif %}
 {% if variant not in ["amazon", "azurelinux", "mariner", "photon"] %}
-  - spacewalk
+  - spacewalk  # deprecated: removal in 31.2
 {% endif %}
   - yum_add_repo
 {% elif variant == "suse" %}
@@ -177,7 +177,7 @@ cloud_config_modules:
 {% if variant == "raspberry-pi-os" %}
   - raspberry_pi
 {% endif %}
-  - disable_ec2_metadata
+  - disable_ec2_metadata  # deprecated: removal in 31.2
   - runcmd
 {% if variant in ["debian", "ubuntu", "unknown"] %}
   - byobu
@@ -198,11 +198,9 @@ cloud_final_modules:
   - puppet
   - chef
   - ansible
-  - mcollective
+  - mcollective  # deprecated: removal in 31.2
   - salt_minion
-{% if variant not in ["alpine"] %}
-  - reset_rmc
-{% endif %}
+{# SRU_BLOCKER: retain reset_rmc on non Alpine to avoid change in behavior on stable releases #}
   - scripts_vendor
   - scripts_per_once
   - scripts_per_boot

--- a/doc/examples/cloud-config.txt
+++ b/doc/examples/cloud-config.txt
@@ -83,12 +83,6 @@ ssh_keys:
 
   rsa_public: ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAGEAoPRhIfLvedSDKw7XdewmZ3h8eIXJD7TRHtVW7aJX1ByifYtlL/HVzJ09nilCl+MSFrpbFnqjxyL8Rr/DSf7QcY/BrGUQbZn2Kc22PemAWthxHO18QJvWPocKJtlsDNi3 smoser@localhost
 
-# remove access to the ec2 metadata service early in boot via null route
-#  the null route can be removed (by root) with:
-#    route del -host 169.254.169.254 reject
-# default: false (service available)
-disable_ec2_metadata: true
-
 # run commands
 # default: none
 # runcmd contains a list of either lists or a string
@@ -139,7 +133,6 @@ cloud_config_modules:
  - grub_dpkg
  - [ apt_update_upgrade, always ]
  - puppet
- - disable_ec2_metadata
  - runcmd
  - byobu
 

--- a/tests/unittests/config/test_cc_disable_ec2_metadata.py
+++ b/tests/unittests/config/test_cc_disable_ec2_metadata.py
@@ -3,6 +3,7 @@
 """Tests cc_disable_ec2_metadata handler"""
 
 
+import re
 from unittest import mock
 
 import pytest
@@ -54,6 +55,7 @@ class TestEC2MetadataRoute:
         m_subp.assert_not_called()
 
 
+@pytest.mark.usefixtures("clear_deprecation_log")
 @skipUnlessJsonSchema()
 class TestDisableEc2MetadataSchema:
     """Directly test schema rather than through handle."""
@@ -61,7 +63,16 @@ class TestDisableEc2MetadataSchema:
     @pytest.mark.parametrize(
         "config, error_msg",
         (
-            # Valid schemas tested by meta.examples in test_schema
+            # Valid, yet deprecated schema
+            (
+                {"disable_ec2_metadata": True},
+                re.escape(
+                    "Cloud config schema deprecations: "
+                    "disable_ec2_metadata:  Deprecated in version 26.2. "
+                    "The disable_ec2_metadata module is deprecated and will "
+                    "be removed in a future release."
+                ),
+            ),
             # Invalid schemas
             (
                 {"disable_ec2_metadata": 1},
@@ -76,3 +87,15 @@ class TestDisableEc2MetadataSchema:
         schema = get_schema()
         with pytest.raises(SchemaValidationError, match=error_msg):
             validate_cloudconfig_schema(config, schema, strict=True)
+
+
+@pytest.mark.usefixtures("clear_deprecation_log")
+class TestDisableEc2MetadataDeprecation:
+    @mock.patch("cloudinit.config.cc_disable_ec2_metadata.subp.which")
+    @mock.patch("cloudinit.config.cc_disable_ec2_metadata.subp.subp")
+    def test_deprecate_module_warning(self, m_subp, m_which, caplog):
+        """Assert warning is logged for deprecated module."""
+        m_which.side_effect = lambda x: x if x == "ip" else None
+        ec2_meta.handle("foo", {"disable_ec2_metadata": True}, mock.MagicMock(), [])
+        assert "Module cc_disable_ec2_metadata is deprecated in" in caplog.text
+        assert "deprecat" in caplog.text

--- a/tests/unittests/config/test_cc_disable_ec2_metadata.py
+++ b/tests/unittests/config/test_cc_disable_ec2_metadata.py
@@ -2,6 +2,7 @@
 
 """Tests cc_disable_ec2_metadata handler"""
 
+import re
 from unittest import mock
 
 import pytest
@@ -53,6 +54,7 @@ class TestEC2MetadataRoute:
         m_subp.assert_not_called()
 
 
+@pytest.mark.usefixtures("clear_deprecation_log")
 @skipUnlessJsonSchema()
 class TestDisableEc2MetadataSchema:
     """Directly test schema rather than through handle."""
@@ -60,7 +62,16 @@ class TestDisableEc2MetadataSchema:
     @pytest.mark.parametrize(
         "config, error_msg",
         (
-            # Valid schemas tested by meta.examples in test_schema
+            # Valid, yet deprecated schema
+            (
+                {"disable_ec2_metadata": True},
+                re.escape(
+                    "Cloud config schema deprecations: "
+                    "disable_ec2_metadata:  Deprecated in version 26.2. "
+                    "The disable_ec2_metadata module is deprecated and will "
+                    "be removed in a future release."
+                ),
+            ),
             # Invalid schemas
             (
                 {"disable_ec2_metadata": 1},
@@ -75,3 +86,17 @@ class TestDisableEc2MetadataSchema:
         schema = get_schema()
         with pytest.raises(SchemaValidationError, match=error_msg):
             validate_cloudconfig_schema(config, schema, strict=True)
+
+
+@pytest.mark.usefixtures("clear_deprecation_log")
+class TestDisableEc2MetadataDeprecation:
+    @mock.patch("cloudinit.config.cc_disable_ec2_metadata.subp.which")
+    @mock.patch("cloudinit.config.cc_disable_ec2_metadata.subp.subp")
+    def test_deprecate_module_warning(self, m_subp, m_which, caplog):
+        """Assert warning is logged for deprecated module."""
+        m_which.side_effect = lambda x: x if x == "ip" else None
+        ec2_meta.handle(
+            "foo", {"disable_ec2_metadata": True}, mock.MagicMock(), []
+        )
+        assert "Module cc_disable_ec2_metadata is deprecated in" in caplog.text
+        assert "deprecat" in caplog.text

--- a/tests/unittests/config/test_cc_mcollective.py
+++ b/tests/unittests/config/test_cc_mcollective.py
@@ -1,6 +1,6 @@
 # This file is part of cloud-init. See LICENSE file for license information.
-import logging
 import os
+import re
 from io import BytesIO
 from unittest import mock
 
@@ -16,8 +16,6 @@ from cloudinit.config.schema import (
 )
 from tests.unittests.helpers import skipUnlessJsonSchema
 from tests.unittests.util import get_cloud
-
-LOG = logging.getLogger(__name__)
 
 
 STOCK_CONFIG = """\
@@ -157,6 +155,7 @@ class TestHandler:
         ]
 
 
+@pytest.mark.usefixtures("clear_deprecation_log")
 class TestMcollectiveSchema:
     @pytest.mark.parametrize(
         "config, error_msg",
@@ -166,8 +165,15 @@ class TestMcollectiveSchema:
                 {"mcollective": {"customkey": True}},
                 "mcollective: Additional properties are not allowed",
             ),
-            # Allow undocumented keys client keys below 'conf' without error
-            ({"mcollective": {"conf": {"customkey": 1}}}, None),
+            # Allow undocumented keys client keys below 'conf' with deprecation
+            (
+                {"mcollective": {"conf": {"customkey": 1}}},
+                re.escape(
+                    "Cloud config schema deprecations: mcollective:  "
+                    "Deprecated in version 26.2. The mcollective module is "
+                    "deprecated and will be removed in a future release."
+                ),
+            ),
             # Don't allow undocumented keys that don't match expected type
             (
                 {"mcollective": {"conf": {"": {"test": None}}}},
@@ -176,6 +182,15 @@ class TestMcollectiveSchema:
             (
                 {"mcollective": {"conf": {"public-cert": 1}}},
                 "mcollective.conf.public-cert: 1 is not of type 'string'",
+            ),
+            # Valid, yet deprecated schema
+            (
+                {"mcollective": {"conf": {"loglevel": "debug"}}},
+                re.escape(
+                    "Cloud config schema deprecations: mcollective:  "
+                    "Deprecated in version 26.2. The mcollective module is "
+                    "deprecated and will be removed in a future release."
+                ),
             ),
         ],
     )
@@ -186,3 +201,17 @@ class TestMcollectiveSchema:
         else:
             with pytest.raises(SchemaValidationError, match=error_msg):
                 validate_cloudconfig_schema(config, get_schema(), strict=True)
+
+    @mock.patch("cloudinit.config.cc_mcollective.subp")
+    @mock.patch("cloudinit.config.cc_mcollective.util")
+    def test_deprecate_module_warning(
+        self, mock_util, mock_subp, caplog
+    ):
+        """Assert warning is logged for deprecated module."""
+        cc = get_cloud()
+        cc.distro = mock.MagicMock()
+        mock_util.load_binary_file.return_value = b""
+        mycfg = {"mcollective": {"conf": {"loglevel": "debug"}}}
+        cc_mcollective.handle("cc_mcollective", mycfg, cc, [])
+        assert "Module cc_mcollective is deprecated in" in caplog.text
+        assert "deprecat" in caplog.text

--- a/tests/unittests/config/test_cc_mcollective.py
+++ b/tests/unittests/config/test_cc_mcollective.py
@@ -1,6 +1,6 @@
 # This file is part of cloud-init. See LICENSE file for license information.
-import logging
 import os
+import re
 from io import BytesIO
 from unittest import mock
 
@@ -16,9 +16,6 @@ from cloudinit.config.schema import (
 )
 from tests.unittests.helpers import skipUnlessJsonSchema
 from tests.unittests.util import get_cloud
-
-LOG = logging.getLogger(__name__)
-
 
 STOCK_CONFIG = """\
 main_collective = mcollective
@@ -157,6 +154,7 @@ class TestHandler:
         ]
 
 
+@pytest.mark.usefixtures("clear_deprecation_log")
 class TestMcollectiveSchema:
     @pytest.mark.parametrize(
         "config, error_msg",
@@ -166,8 +164,15 @@ class TestMcollectiveSchema:
                 {"mcollective": {"customkey": True}},
                 "mcollective: Additional properties are not allowed",
             ),
-            # Allow undocumented keys client keys below 'conf' without error
-            ({"mcollective": {"conf": {"customkey": 1}}}, None),
+            # Allow undocumented keys client keys below 'conf' with deprecation
+            (
+                {"mcollective": {"conf": {"customkey": 1}}},
+                re.escape(
+                    "Cloud config schema deprecations: mcollective:  "
+                    "Deprecated in version 26.2. The mcollective module is "
+                    "deprecated and will be removed in a future release."
+                ),
+            ),
             # Don't allow undocumented keys that don't match expected type
             (
                 {"mcollective": {"conf": {"": {"test": None}}}},
@@ -176,6 +181,15 @@ class TestMcollectiveSchema:
             (
                 {"mcollective": {"conf": {"public-cert": 1}}},
                 "mcollective.conf.public-cert: 1 is not of type 'string'",
+            ),
+            # Valid, yet deprecated schema
+            (
+                {"mcollective": {"conf": {"loglevel": "debug"}}},
+                re.escape(
+                    "Cloud config schema deprecations: mcollective:  "
+                    "Deprecated in version 26.2. The mcollective module is "
+                    "deprecated and will be removed in a future release."
+                ),
             ),
         ],
     )
@@ -186,3 +200,15 @@ class TestMcollectiveSchema:
         else:
             with pytest.raises(SchemaValidationError, match=error_msg):
                 validate_cloudconfig_schema(config, get_schema(), strict=True)
+
+    @mock.patch("cloudinit.config.cc_mcollective.subp")
+    @mock.patch("cloudinit.config.cc_mcollective.util")
+    def test_deprecate_module_warning(self, mock_util, mock_subp, caplog):
+        """Assert warning is logged for deprecated module."""
+        cc = get_cloud()
+        cc.distro = mock.MagicMock()
+        mock_util.load_binary_file.return_value = b""
+        mycfg = {"mcollective": {"conf": {"loglevel": "debug"}}}
+        cc_mcollective.handle("cc_mcollective", mycfg, cc, [])
+        assert "Module cc_mcollective is deprecated in" in caplog.text
+        assert "deprecat" in caplog.text

--- a/tests/unittests/config/test_cc_spacewalk.py
+++ b/tests/unittests/config/test_cc_spacewalk.py
@@ -1,12 +1,19 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
-import logging
+import re
 from unittest import mock
+
+import pytest
 
 from cloudinit import subp
 from cloudinit.config import cc_spacewalk
-
-LOG = logging.getLogger(__name__)
+from cloudinit.config.schema import (
+    SchemaValidationError,
+    get_schema,
+    validate_cloudconfig_schema,
+)
+from tests.unittests.helpers import skipUnlessJsonSchema
+from tests.unittests.util import get_cloud
 
 
 class TestSpacewalk:
@@ -42,3 +49,43 @@ class TestSpacewalk:
             ],
             capture=False,
         )
+
+
+@pytest.mark.usefixtures("clear_deprecation_log")
+class TestSpacewalkSchema:
+    """Directly test schema rather than through handle."""
+
+    @pytest.mark.parametrize(
+        "config, error_msg",
+        (
+            # Valid, yet deprecated schema
+            (
+                {"spacewalk": {"server": "localhost"}},
+                re.escape(
+                    "Cloud config schema deprecations: spacewalk:  "
+                    "Deprecated in version 26.2. The spacewalk module is "
+                    "deprecated and will be removed in a future release."
+                ),
+            ),
+        ),
+    )
+    @skipUnlessJsonSchema()
+    def test_schema_validation(self, config, error_msg):
+        """Assert expected schema validation and error messages."""
+        schema = get_schema()
+        with pytest.raises(SchemaValidationError, match=error_msg):
+            validate_cloudconfig_schema(config, schema, strict=True)
+
+    @mock.patch("cloudinit.config.cc_spacewalk.subp.subp")
+    @mock.patch("cloudinit.config.cc_spacewalk.is_registered")
+    def test_deprecate_module_warning(
+        self, m_is_registered, m_subp, caplog
+    ):
+        """Assert warning is logged for deprecated module."""
+        cloud = get_cloud("fedora")
+        m_is_registered.return_value = True
+        cc_spacewalk.handle(
+            "cc_spacewalk", {"spacewalk": {"server": "localhost"}}, cloud, []
+        )
+        assert "Module cc_spacewalk is deprecated in" in caplog.text
+        assert "deprecat" in caplog.text

--- a/tests/unittests/config/test_cc_spacewalk.py
+++ b/tests/unittests/config/test_cc_spacewalk.py
@@ -1,12 +1,19 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
-import logging
+import re
 from unittest import mock
+
+import pytest
 
 from cloudinit import subp
 from cloudinit.config import cc_spacewalk
-
-LOG = logging.getLogger(__name__)
+from cloudinit.config.schema import (
+    SchemaValidationError,
+    get_schema,
+    validate_cloudconfig_schema,
+)
+from tests.unittests.helpers import skipUnlessJsonSchema
+from tests.unittests.util import get_cloud
 
 
 class TestSpacewalk:
@@ -42,3 +49,41 @@ class TestSpacewalk:
             ],
             capture=False,
         )
+
+
+@pytest.mark.usefixtures("clear_deprecation_log")
+class TestSpacewalkSchema:
+    """Directly test schema rather than through handle."""
+
+    @pytest.mark.parametrize(
+        "config, error_msg",
+        (
+            # Valid, yet deprecated schema
+            (
+                {"spacewalk": {"server": "localhost"}},
+                re.escape(
+                    "Cloud config schema deprecations: spacewalk:  "
+                    "Deprecated in version 26.2. The spacewalk module is "
+                    "deprecated and will be removed in a future release."
+                ),
+            ),
+        ),
+    )
+    @skipUnlessJsonSchema()
+    def test_schema_validation(self, config, error_msg):
+        """Assert expected schema validation and error messages."""
+        schema = get_schema()
+        with pytest.raises(SchemaValidationError, match=error_msg):
+            validate_cloudconfig_schema(config, schema, strict=True)
+
+    @mock.patch("cloudinit.config.cc_spacewalk.subp.subp")
+    @mock.patch("cloudinit.config.cc_spacewalk.is_registered")
+    def test_deprecate_module_warning(self, m_is_registered, m_subp, caplog):
+        """Assert warning is logged for deprecated module."""
+        cloud = get_cloud("fedora")
+        m_is_registered.return_value = True
+        cc_spacewalk.handle(
+            "cc_spacewalk", {"spacewalk": {"server": "localhost"}}, cloud, []
+        )
+        assert "Module cc_spacewalk is deprecated in" in caplog.text
+        assert "deprecat" in caplog.text

--- a/tests/unittests/config/test_schema.py
+++ b/tests/unittests/config/test_schema.py
@@ -251,6 +251,7 @@ class TestGetSchema:
             {"$ref": "#/$defs/cc_raspberry_pi"},
             {"$ref": "#/$defs/cc_resizefs"},
             {"$ref": "#/$defs/cc_resolv_conf"},
+            {"$ref": "#/$defs/cc_reset_rmc"},
             {"$ref": "#/$defs/cc_rh_subscription"},
             {"$ref": "#/$defs/cc_rsyslog"},
             {"$ref": "#/$defs/cc_runcmd"},


### PR DESCRIPTION
## Proposed Commit Message
```
chore: deprecate cloud-config modules for unmaintained software (#6934)

Avoid supporting cloud-config modules for unmaintained software stacks or historic
platform needs.
- cc_mcollective is supplanted by puppet in many cases
- cc_spacewalk unmaintained and EOL
- cc_disable_ec2_metadata use-cases originally centered around testing and 
  generally should not be used on production EC2-based platforms
- cc_reset_rmc deprecation as the platform images should no longer required this
  setup on first boot.
```

## Additional Context
<!-- If relevant -->

## Test Steps


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
