### PR TITLE
backport ESM fix for importlib error

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+cloud-init (23.1.2-0ubuntu0~18.04.1+esm2) bionic-security; urgency=medium
+
+  * d/p/backport-a97e7466-feat-Fix-import-error-6926: fix libimport.util
+    import error in ua-auto-attach.service on minimal cloud images (GH-6924)
+
+ -- Chad Smith <chad.smith@canonical.com>  Fri, 10 Jul 2026 12:03:35 -0600
+
 cloud-init (23.1.2-0ubuntu0~18.04.1+esm1) bionic-security; urgency=medium
 
   * d/cloud-init.postinst: move existing hotplug-cmd fifo to root-only

--- a/debian/patches/backport-a97e7466-feat-Fix-import-error-6926
+++ b/debian/patches/backport-a97e7466-feat-Fix-import-error-6926
@@ -1,0 +1,41 @@
+Description: Backport importlib.util fixes
+ Avoid AttributeError tacebacks from cloudinit.importer.py for
+ ua-auto-attach functionality which calls importlib.util.find_spec.
+ 
+ Fixes GH-6924
+Author: chad.smith@canonical.com
+Origin: backport
+Forwarded: not-needed
+Last-Update: 2023-01-09
+---
+From a97e74661b12f16d1f8554d572698494e62d4fd9 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Chlo=C3=A9=20E=2EM=2E=20Smith?= <chloe.smith@canonical.com>
+Date: Fri, 10 Jul 2026 17:52:34 +0100
+Subject: [PATCH] feat: Fix import error (#6926)
+
+`importer.py` calls `importlib.util.find_spec()`
+but the file only actually imports `importlib`
+by itself.
+
+Up until now we've gotten away with it as something
+else has always imported `importlib.util` for us
+"by accident", but if an end consumer imports
+`cloud-init` as a library (i.e. `ubuntu-pro-client`)
+there's no guarantee that will happen. It happened
+in #6924 so let's fix it now.
+
+Fixes GH-6924
+---
+ cloudinit/importer.py | 12 +++---------
+ 1 file changed, 3 insertions(+), 9 deletions(-)
+
+--- a/cloudinit/importer.py
++++ b/cloudinit/importer.py
+@@ -9,6 +9,7 @@
+ # This file is part of cloud-init. See LICENSE file for license information.
+ 
+ import importlib
++import importlib.util
+ from types import ModuleType
+ from typing import Optional, Sequence
+ 

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -8,3 +8,4 @@ netplan99-cannot-use-default.patch
 cpick-8c3ae1bb-fix-Don-t-attempt-to-identify-non-x86-OpenStack
 cpick-8b45006c-fix-Make-hotplug-socket-writable-only-by-root-25
 cpick-e3f42adc-fix-strict-disable-in-ds-identify-on-no-datasources
+backport-a97e7466-feat-Fix-import-error-6926


### PR DESCRIPTION
CPC is looking to sync changes to ESM images for importlib errors seen on Pro images.
Backport upstream fix a97e74661b12f16d1f8554d572698494e62d4fd9 as a quilt patch to ensure both focal and bionic get the destination patch.

## Proposed Commit Message
Separate commits
```
* releasing cloud-init version 23.1.2-0ubuntu0~18.04.1+esm2

* fix: import specific importlib.util avoiding traces in pro auto-attach
    
    Use direct submodule import of importlib.util to avoid AttributeError
    tracebacks from ua-auto-attach.service on GCE.
    
    Backport-of: a97e7466
    Fixes GH-6924
```

## Additional Context
As this is an ESM fix, this release will be reviewed by security team to be included in ESM infra PPA instead of typical Ubuntiu SRU process.
This upstream fix will make it into LTS releases via typical SRU process.

## Test Steps
```
quilt push -a  # patches apply

lxc launch ubuntu-minimal:bionic b-min
lxc exec b-min -- pro attach <YOUR_TOKEN>
lxc exec b-min -- apt install ubuntu-pro-client cloud-init
lxc file push cloudinit/importer.py b-min/usr/lib/python3/dist-packages/cloudinit/
lxc exec b-min -- python3 /usr/lib/ubuntu-advantage/auto_attach.py   # confirm no traceback
quilt pop -a    # patched removed without issue
```
PPA for testing https://launchpad.net/~chad.smith/+archive/ubuntu/esm-test-pro-importlib
## Merge type

- [ ] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
- [x]  git merge from command line after approval.
