### PR TITLE
ci: add twice weekly azure integration test workflows

### DIFF
--- a/.github/workflows/100-dispatch-common.yml
+++ b/.github/workflows/100-dispatch-common.yml
@@ -18,9 +18,10 @@ on:
         required: true
         type: choice
         options:
+        - azure
+        - ec2
         - lxd_container
         - lxd_vm
-        - ec2
       image_type:
         required: true
         type: choice
@@ -93,7 +94,7 @@ jobs:
       - name: Setup LXD
         # This shared workflow supports manual dispatch with platform choices including
         # lxd_vm and lxd_container. Only install the lxd snap for those platforms;
-        # cloud platforms such as EC2 do not need it.
+        # cloud platforms such as EC2 and Azure do not need it.
         if: ${{ contains(fromJSON('["lxd_vm", "lxd_container"]'), env.CLOUD_INIT_PLATFORM ) }}
         uses: canonical/setup-lxd@8c6a87bfb56aa48f3fb9b830baa18562d8bfd4ee # v1
         with:

--- a/.github/workflows/100-dispatch-common.yml
+++ b/.github/workflows/100-dispatch-common.yml
@@ -4,37 +4,6 @@
 name: "Dispatch: Integration"
 
 on:
-  workflow_dispatch:
-    inputs:
-      release:
-        required: true
-        type: choice
-        options:
-        - stonking
-        - resolute
-        - jammy
-        - noble
-      platform:
-        required: true
-        type: choice
-        options:
-        - azure
-        - ec2
-        - lxd_container
-        - lxd_vm
-      image_type:
-        required: true
-        type: choice
-        options:
-        - generic
-        - minimal
-      install_source:
-        required: false
-        type: string
-        default: 'ppa:cloud-init-dev/daily'
-      filter_tests:
-        required: false
-        type: string
   workflow_call:
     inputs:
       release:

--- a/.github/workflows/140-daily-integration-22.04-azure.yml
+++ b/.github/workflows/140-daily-integration-22.04-azure.yml
@@ -1,0 +1,35 @@
+name: "Twice weekly 22.04: azure"
+
+on:
+  workflow_dispatch:
+    inputs:
+      install_source:
+        required: false
+        type: string
+        default: 'ppa:cloud-init-dev/daily'
+      image_type:
+        required: true
+        type: choice
+        options:
+        - generic
+        - minimal
+      filter_tests:
+        required: false
+        type: string
+  schedule:
+    # Run Mon & Thurs to reduce additional cost on shared external tokens
+    - cron: '2 22 * * 1,4'
+
+jobs:
+  jammy-azure:
+    uses: ./.github/workflows/100-dispatch-common.yml
+    with:
+      release: jammy
+      platform: azure
+      install_source: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
+      image_type: ${{ inputs.image_type || 'generic' }}
+      filter_tests: ${{ inputs.filter_tests }}
+    secrets:
+      PYCLOUDLIB_TOML_B64: ${{ secrets.PYCLOUDLIB_TOML_B64 }}
+      SSH_PUBLIC_KEY: ${{ secrets.SSH_PUBLIC_KEY }}
+      SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}

--- a/.github/workflows/141-daily-integration-24.04-azure.yml
+++ b/.github/workflows/141-daily-integration-24.04-azure.yml
@@ -1,0 +1,35 @@
+name: "Twice weekly 24.04: azure"
+
+on:
+  workflow_dispatch:
+    inputs:
+      install_source:
+        required: false
+        type: string
+        default: 'ppa:cloud-init-dev/daily'
+      image_type:
+        required: true
+        type: choice
+        options:
+        - generic
+        - minimal
+      filter_tests:
+        required: false
+        type: string
+  schedule:
+    # Run Mon & Thurs to reduce additional cost on shared external tokens
+    - cron: '2 22 * * 1,4'
+
+jobs:
+  noble-azure:
+    uses: ./.github/workflows/100-dispatch-common.yml
+    with:
+      release: noble
+      platform: azure
+      install_source: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
+      image_type: ${{ inputs.image_type || 'generic' }}
+      filter_tests: ${{ inputs.filter_tests }}
+    secrets:
+      PYCLOUDLIB_TOML_B64: ${{ secrets.PYCLOUDLIB_TOML_B64 }}
+      SSH_PUBLIC_KEY: ${{ secrets.SSH_PUBLIC_KEY }}
+      SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}

--- a/.github/workflows/143-daily-integration-26.04-azure.yml
+++ b/.github/workflows/143-daily-integration-26.04-azure.yml
@@ -1,0 +1,35 @@
+name: "Twice weekly 26.04: azure"
+
+on:
+  workflow_dispatch:
+    inputs:
+      install_source:
+        required: false
+        type: string
+        default: 'ppa:cloud-init-dev/daily'
+      image_type:
+        required: true
+        type: choice
+        options:
+        - generic
+        - minimal
+      filter_tests:
+        required: false
+        type: string
+  schedule:
+    # Run Mon & Thurs to reduce additional cost on shared external tokens
+    - cron: '2 22 * * 1,4'
+
+jobs:
+  resolute-azure:
+    uses: ./.github/workflows/100-dispatch-common.yml
+    with:
+      release: resolute
+      platform: azure
+      install_source: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
+      image_type: ${{ inputs.image_type || 'generic' }}
+      filter_tests: ${{ inputs.filter_tests }}
+    secrets:
+      PYCLOUDLIB_TOML_B64: ${{ secrets.PYCLOUDLIB_TOML_B64 }}
+      SSH_PUBLIC_KEY: ${{ secrets.SSH_PUBLIC_KEY }}
+      SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}

--- a/.github/workflows/144-daily-integration-26.10-azure.yml
+++ b/.github/workflows/144-daily-integration-26.10-azure.yml
@@ -1,0 +1,35 @@
+name: "Twice weekly 26.10: azure"
+
+on:
+  workflow_dispatch:
+    inputs:
+      install_source:
+        required: false
+        type: string
+        default: 'ppa:cloud-init-dev/daily'
+      image_type:
+        required: true
+        type: choice
+        options:
+        - generic
+        - minimal
+      filter_tests:
+        required: false
+        type: string
+  schedule:
+    # Run Mon & Thurs to reduce additional cost on shared external tokens
+    - cron: '2 22 * * 1,4'
+
+jobs:
+  stonking-azure:
+    uses: ./.github/workflows/100-dispatch-common.yml
+    with:
+      release: stonking
+      platform: azure
+      install_source: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
+      image_type: ${{ inputs.image_type || 'generic' }}
+      filter_tests: ${{ inputs.filter_tests }}
+    secrets:
+      PYCLOUDLIB_TOML_B64: ${{ secrets.PYCLOUDLIB_TOML_B64 }}
+      SSH_PUBLIC_KEY: ${{ secrets.SSH_PUBLIC_KEY }}
+      SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}


### PR DESCRIPTION
Add Azure integration test coverage aligned with release coverage we have in Ec2, lxd_container and lxd_vm.


## Proposed Commit Message
```
    ci: add twice weekly azure integration test workflows
```

## Additional Context
[Success run on my own remote](https://github.com/blackboxsw/cloud-init/actions/runs/29955165798/job/89042270885)

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
