### PR TITLE
feat(helpers): support custom datasource vendor merge strategies

### DIFF
--- a/cloudinit/helpers.py
+++ b/cloudinit/helpers.py
@@ -220,7 +220,17 @@ class ConfigMerger:
             cc_fn = self._paths.get_ipath_cur(cc_p)
             if cc_fn and os.path.isfile(cc_fn):
                 try:
-                    i_cfgs.append(util.read_conf(cc_fn))
+                    cfg = util.read_conf(cc_fn)
+                    if cc_p in (
+                        "vendor_cloud_config",
+                        "vendor2_cloud_config",
+                    ):
+                        vendor_merge = getattr(
+                            self._ds, "vendor_merge_how", None
+                        )
+                        if vendor_merge:
+                            cfg.setdefault("merge_how", vendor_merge)
+                    i_cfgs.append(cfg)
                 except PermissionError:
                     LOG.debug(
                         "Skipped loading cloud-config from %s due to"

--- a/cloudinit/helpers.py
+++ b/cloudinit/helpers.py
@@ -220,7 +220,24 @@ class ConfigMerger:
             cc_fn = self._paths.get_ipath_cur(cc_p)
             if cc_fn and os.path.isfile(cc_fn):
                 try:
-                    i_cfgs.append(util.read_conf(cc_fn))
+                    cfg = util.read_conf(cc_fn)
+                    if cc_p in (
+                        "vendor_cloud_config",
+                        "vendor2_cloud_config",
+                    ):
+                        if getattr(self._ds, "append_vendor_list_data", False):
+                            LOG.debug(
+                                "Datasource %s requested appending"
+                                " vendor-data lists to user-data;"
+                                " setting non-default vendor"
+                                " merge strategy.",
+                                getattr(self._ds, "name", self._ds),
+                            )
+                            cfg.setdefault(
+                                "merge_how",
+                                "list(append)+dict(no_replace,recurse_list)+str()",
+                            )
+                    i_cfgs.append(cfg)
                 except PermissionError:
                     LOG.debug(
                         "Skipped loading cloud-config from %s due to"

--- a/cloudinit/sources/DataSourceMAAS.py
+++ b/cloudinit/sources/DataSourceMAAS.py
@@ -43,6 +43,11 @@ class DataSourceMAAS(sources.DataSource):
     id_hash = None
     _oauth_helper = None
 
+    # When merging vendor-data with user-data, append list values
+    # (e.g. write_files, runcmd) so that vendor networking config
+    # is not silently dropped when user-data defines the same key.
+    vendor_merge_how = "list(append)+dict(no_replace,recurse_list)+str()"
+
     # Setup read_url parameters per get_url_params.
     url_max_wait = 120
     url_timeout = 50

--- a/cloudinit/sources/DataSourceMAAS.py
+++ b/cloudinit/sources/DataSourceMAAS.py
@@ -43,6 +43,10 @@ class DataSourceMAAS(sources.DataSource):
     id_hash = None
     _oauth_helper = None
 
+    # Tell ConfigMerger to append vendor-data lists (e.g. write_files, runcmd)
+    # to user-data lists so MAAS networking configuration is not dropped.
+    append_vendor_list_data = True
+
     # Setup read_url parameters per get_url_params.
     url_max_wait = 120
     url_timeout = 50

--- a/tests/unittests/test_data.py
+++ b/tests/unittests/test_data.py
@@ -302,6 +302,66 @@ run:
         assert "z" in cfg["run"]
 
     @pytest.mark.usefixtures("fake_filesystem")
+    def test_vendor_user_yaml_cloud_config_with_vendor_merge_how(self):
+        """When datasource sets vendor_merge_how, vendor list values
+        are appended to user list values instead of being dropped."""
+        vendor_blob = """
+#cloud-config
+write_files:
+ - path: /etc/netplan/50-vendor.yaml
+   content: network-config
+run:
+ - vendor_cmd
+"""
+
+        user_blob = """
+#cloud-config
+vendor_data:
+  enabled: true
+  prefix: /bin/true
+write_files:
+ - path: /user.txt
+   content: hello
+run:
+ - user_cmd
+"""
+
+        class FakeDataSourceWithMerge(FakeDataSource):
+            vendor_merge_how = (
+                "list(append)+dict(no_replace,recurse_list)+str()"
+            )
+
+        initer = stages.Init()
+        initer.datasource = FakeDataSourceWithMerge(
+            user_blob, vendordata=vendor_blob
+        )
+        initer.read_cfg()
+        initer.initialize()
+        initer.fetch()
+        initer.instancify()
+        initer.update()
+        initer.cloudify().run(
+            "consume_data",
+            initer.consume_data,
+            args=[PER_INSTANCE],
+            freq=PER_INSTANCE,
+        )
+        mods = Modules(initer)
+        (_which_ran, _failures) = mods.run_section("cloud_init_modules")
+        cfg = mods.cfg
+        # User scalar values still win
+        assert "vendor_data" in cfg
+        # List values are appended: user entries first, then vendor
+        assert cfg["run"] == ["user_cmd", "vendor_cmd"]
+        assert cfg["write_files"] == [
+            {"path": "/user.txt", "content": "hello"},
+            {
+                "path": "/etc/netplan/50-vendor.yaml",
+                "content": "network-config",
+            },
+        ]
+
+    @pytest.mark.usefixtures("fake_filesystem")
     def test_vendordata_script(self):
         vendor_blob = """
 #!/bin/bash

--- a/tests/unittests/test_data.py
+++ b/tests/unittests/test_data.py
@@ -135,7 +135,7 @@ class TestConsumeUserData:
             freq=PER_INSTANCE,
         )
         mods = Modules(initer)
-        (_which_ran, _failures) = mods.run_section("cloud_init_modules")
+        _which_ran, _failures = mods.run_section("cloud_init_modules")
         cfg = mods.cfg
         assert "vendor_data" in cfg
         assert "vendor_data2" in cfg
@@ -181,7 +181,7 @@ class TestConsumeUserData:
             freq=PER_INSTANCE,
         )
         mods = Modules(initer)
-        (_which_ran, _failures) = mods.run_section("cloud_init_modules")
+        _which_ran, _failures = mods.run_section("cloud_init_modules")
         cfg = mods.cfg
         assert cfg["baz"] == "qux"
         assert cfg["bar"] == "qux2"
@@ -292,7 +292,7 @@ run:
             freq=PER_INSTANCE,
         )
         mods = Modules(initer)
-        (_which_ran, _failures) = mods.run_section("cloud_init_modules")
+        _which_ran, _failures = mods.run_section("cloud_init_modules")
         cfg = mods.cfg
         assert "vendor_data" in cfg
         assert cfg["a"] == "c"
@@ -300,6 +300,141 @@ run:
         assert "x" not in cfg["run"]
         assert "y" not in cfg["run"]
         assert "z" in cfg["run"]
+
+    @pytest.mark.usefixtures("fake_filesystem")
+    def test_vendor_user_yaml_cloud_config_with_append_vendor_list_data(
+        self, caplog
+    ):
+        """When datasource sets append_vendor_list_data=True,
+        vendor list values are appended to user list values
+        and a debug message is logged."""
+        vendor_blob = """
+#cloud-config
+write_files:
+ - path: /etc/netplan/50-vendor.yaml
+   content: network-config
+run:
+ - vendor_cmd
+"""
+
+        user_blob = """
+#cloud-config
+vendor_data:
+  enabled: true
+  prefix: /bin/true
+write_files:
+ - path: /user.txt
+   content: hello
+run:
+ - user_cmd
+"""
+
+        class FakeDataSourceWithAppend(FakeDataSource):
+            append_vendor_list_data = True
+
+        initer = stages.Init()
+        initer.datasource = FakeDataSourceWithAppend(
+            user_blob, vendordata=vendor_blob
+        )
+        initer.read_cfg()
+        initer.initialize()
+        initer.fetch()
+        initer.instancify()
+        initer.update()
+        initer.cloudify().run(
+            "consume_data",
+            initer.consume_data,
+            args=[PER_INSTANCE],
+            freq=PER_INSTANCE,
+        )
+        mods = Modules(initer)
+        _which_ran, _failures = mods.run_section("cloud_init_modules")
+        cfg = mods.cfg
+
+        # Verify debug log was emitted
+        assert "requested appending vendor-data lists" in caplog.text
+
+        # List values are appended: user entries first, then vendor
+        assert cfg["run"] == ["user_cmd", "vendor_cmd"]
+        assert cfg["write_files"] == [
+            {"path": "/user.txt", "content": "hello"},
+            {
+                "path": "/etc/netplan/50-vendor.yaml",
+                "content": "network-config",
+            },
+        ]
+
+    @pytest.mark.usefixtures("fake_filesystem")
+    def test_vendor_vendor2_append_vendor_list_data(self, caplog):
+        """With append_vendor_list_data=True and both vendor-data and
+        vendor2-data, vendor2 lists are appended to vendor lists.
+        Vendor2 scalars win over vendor scalars."""
+        vendor_blob = """
+#cloud-config
+write_files:
+ - path: /vendor.yaml
+   content: vendor-net
+run:
+ - vendor_cmd
+name: vendor
+origin: vendor
+"""
+
+        vendor2_blob = """
+#cloud-config
+write_files:
+ - path: /vendor2.yaml
+   content: vendor2-net
+run:
+ - vendor2_cmd
+name: vendor2
+"""
+
+        user_blob = """
+#cloud-config
+vendor_data:
+  enabled: true
+  prefix: /bin/true
+"""
+
+        class FakeDataSourceWithAppend(FakeDataSource):
+            append_vendor_list_data = True
+
+        initer = stages.Init()
+        initer.datasource = FakeDataSourceWithAppend(
+            user_blob,
+            vendordata=vendor_blob,
+            vendordata2=vendor2_blob,
+        )
+        initer.read_cfg()
+        initer.initialize()
+        initer.fetch()
+        initer.instancify()
+        initer.update()
+        initer.cloudify().run(
+            "consume_data",
+            initer.consume_data,
+            args=[PER_INSTANCE],
+            freq=PER_INSTANCE,
+        )
+        mods = Modules(initer)
+        _which_ran, _failures = mods.run_section("cloud_init_modules")
+        cfg = mods.cfg
+
+        # Debug log emitted for both vendor configs
+        assert caplog.text.count("requested appending vendor-data lists") >= 2
+
+        # Vendor2 scalar wins over vendor scalar
+        assert cfg["name"] == "vendor2"
+        # Scalar only in vendor: preserved
+        assert cfg["origin"] == "vendor"
+
+        # Lists appended: vendor2 first, then vendor
+        assert cfg["run"] == ["vendor2_cmd", "vendor_cmd"]
+        assert cfg["write_files"] == [
+            {"path": "/vendor2.yaml", "content": "vendor2-net"},
+            {"path": "/vendor.yaml", "content": "vendor-net"},
+        ]
 
     @pytest.mark.usefixtures("fake_filesystem")
     def test_vendordata_script(self):
@@ -334,7 +469,7 @@ vendor_data:
             freq=PER_INSTANCE,
         )
         mods = Modules(initer)
-        (_which_ran, _failures) = mods.run_section("cloud_init_modules")
+        _which_ran, _failures = mods.run_section("cloud_init_modules")
         vendor_script = initer.paths.get_ipath_cur("vendor_scripts")
         vendor_script_fns = "%s/part-001" % vendor_script
         assert os.path.exists(vendor_script_fns) is True
@@ -677,7 +812,7 @@ c: 4
             freq=PER_INSTANCE,
         )
         mods = Modules(init)
-        (_which_ran, _failures) = mods.run_section("cloud_init_modules")
+        _which_ran, _failures = mods.run_section("cloud_init_modules")
         cfg = mods.cfg
         assert "vendor_data" in cfg
         assert cfg["baz"] == "quxA"


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [x] I have signed the CLA: https://ubuntu.com/legal/contributors
- [x] I have included a comprehensive commit message using the guide below
- [x] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [x] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [x] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [x] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e doc``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
feat(helpers): support custom datasource vendor merge strategies

When deploying a MAAS node with custom user-data, top-level lists
in vendor-data (e.g., `write_files`) are dropped if user-data defines
the same keys. This breaks networking by dropping the MAAS Netplan
configuration (`/etc/netplan/50-maas.yaml`).

To fix this without affecting other cloud providers, this change
allows datasources to specify custom merge strategies:

- `ConfigMerger` checks the active datasource (`self._ds`) for a
  `vendor_merge_how` attribute when loading vendor cloud config.
- `DataSourceMAAS` sets `vendor_merge_how` to append list values.

Signed-off-by: Leah Goldberg <leah.goldberg@canonical.com>

Fixes GH-6268
LP: #2158442
```

## Additional Context

This PR fixes an issue where top-level lists in vendor-data (such as `write_files`) are silently dropped when user-data defines the same keys, which breaks MAAS deployments by wiping out the Netplan network configuration (`/etc/netplan/50-maas.yaml`). 

To resolve this without altering global merge behavior across other cloud providers, `ConfigMerger` now inspects the active datasource for a `vendor_merge_how` attribute. `DataSourceMAAS` sets this attribute to `list(append)+dict(no_replace,recurse_list)+str()`, ensuring MAAS-generated vendor lists are appended to user lists.

For example:

**user-data** 
```
{
    "write_files": [
        {"path": "/leah.txt", "content": "hello leah", "permissions": "0644"}
    ]
}
```
**vendor-data**
```

{
    "write_files": [
        {"path": "/etc/netplan/50-maas.yaml", "content": "network:\n...", "permissions": "0600"}
    ],
    "runcmd": ["netplan apply"]
}
```

The current way of merging is:
```
{
    "write_files": [
        {"path": "/leah.txt", "content": "hello leah", "permissions": "0644"}
    ],
    "runcmd": ["netplan apply"] 
}
```

Notice how the `write_files` from the vendor-data is ignored since the user-data already defined `write_files`.

This PR would change the merge for DataSourceMAAS to be:
```
{
    "write_files": [
        {"path": "/leah.txt", "content": "hello leah", "permissions": "0644"},
        {"path": "/etc/netplan/50-maas.yaml", "content": "network:\n...", "permissions": "0600"} 
    ],
    "runcmd": ["netplan apply"]
}
```
This ensures list values are appended instead of dropped.

## Test Steps

**How to reproduce the bug**
1. Deploy MAAS (3.4 or 3.6 - deb or snap) and add a VM.
2. Customize the VM network so it's non-default (e.g. add a VLAN).

<img width="1818" height="836" alt="image" src="https://github.com/user-attachments/assets/4fb57a42-8f03-4fa3-a946-f0a8f10d3d8c" />


3. Deploy the machine to memory with a custom cloud-init config:
```
#cloud-config

write_files:
  - path: /dave.txt
    content: "hello"
    owner: root:root
    permissions: '0644'
```
4. Once the VM is deployed, note the network config. It will only have the PXE config and drop the custom config you added.

**Actual behavior**

| Name | State | IPv4 | IPv6 | Type | Snapshots |
|------|-------|------|------|------|----------:|
| octopus-memory | RUNNING | 10.239.17.2 (enp5s0) | | VIRTUAL-MACHINE | 0 |

The deployed machine only has the PXE interface (`enp5s0`) configured.

**Expected behavior**

| Name | State | IPv4 | IPv6 | Type | Snapshots |
|------|-------|------|------|------|----------:|
| octopus-memory | RUNNING | 10.239.17.2 (enp5s0)<br>10.20.0.1 (enp5s0.100) | | VIRTUAL-MACHINE | 0 |

The expected behavior is for both the PXE interface (`enp5s0`) and the MAAS-configured VLAN interface (`enp5s0.100`) to remain configured after deployment.

**How to test this fix**

Note: I tested this on MAAS 3.5.12 (snap) which uses Ubuntu 22.04 (Jammy). 

1. Create a custom image with [packer-maas](https://github.com/canonical/packer-maas) that includes this cloud-init patch (or you can download [this one](https://drive.google.com/file/d/1KiZdTHo1jbMvUyb5kECIA4Hb_HV7Ivdu/view?usp=sharing)).
2. Upload it to your MAAS environment.
```
maas $PROFILE boot-resources create \
    name='custom/packer-custom-ubuntu' \
    title='Ubuntu 22.04 (patched: cloud-init vendor-merge)' \
    architecture='amd64/generic' \
    filetype='tgz' \
    content@=ubuntu-jammy-cloudinit-merge-user-vendor-fix.tar.gz
```
3. Deploy a VM with the custom image to memory and the custom cloud config.
4. SSH into machine and check that networking is set up properly.

You should see networking is set up properly now:
```
ubuntu@octopus-memory:~$ ip a
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
    inet6 ::1/128 scope host 
       valid_lft forever preferred_lft forever
2: enp5s0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP group default qlen 1000
    link/ether 00:16:3e:2d:fb:b3 brd ff:ff:ff:ff:ff:ff
    inet 10.239.17.2/24 brd 10.239.17.255 scope global enp5s0
       valid_lft forever preferred_lft forever
    inet6 fe80::216:3eff:fe2d:fbb3/64 scope link 
       valid_lft forever preferred_lft forever
3: enp5s0.100@enp5s0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
    link/ether 00:16:3e:2d:fb:b3 brd ff:ff:ff:ff:ff:ff
    inet 10.20.0.1/24 brd 10.20.0.255 scope global enp5s0.100
       valid_lft forever preferred_lft forever
    inet6 fe80::216:3eff:fe2d:fbb3/64 scope link 
       valid_lft forever preferred_lft forever
```


**Related Links**
-  #6268
- [LP 2158442: custom cloud-config conflicts with MAAS-generated vendor-data in deploy-to-memory workflows](https://bugs.launchpad.net/maas/+bug/2158442)
- Replaces #6933

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)