### PR TITLE
docs: define vendor-data and meta-data in QEMU tutorial

### DIFF
--- a/doc/rtd/tutorial/qemu.rst
+++ b/doc/rtd/tutorial/qemu.rst
@@ -77,9 +77,11 @@ configure the virtual machine instance. There are three major types:
 
 * :ref:`user-data <user_data_formats>` is provided by the user, and cloud-init
   recognizes many different formats.
-* :ref:`vendor-data <vendor-data>` is provided by the cloud provider.
-* :ref:`meta-data <instance-data>` contains the platform data, including
-  things like machine ID, hostname, etc.
+* :ref:`vendor-data <vendor-data>` is provided by the cloud provider and
+  supplies provider-specific defaults. User-data can override these defaults.
+* :ref:`meta-data <instance-data>` identifies and describes the instance,
+  including its instance ID and hostname. When the instance ID changes,
+  cloud-init treats the next boot as the first boot of a new instance.
 
 There is a specific user-data format called "*cloud-config*" that is probably
 the most commonly used, so we will create an example of this (and examples of


### PR DESCRIPTION
## Proposed Commit Message

```
docs: Define QEMU vendor-data and meta-data

Explain how provider defaults interact with user-data and how changes to
the instance ID affect first-boot detection.

Fixes GH-4947
```

## Additional Context

The QEMU tutorial already names the three configuration data sources, but it
does not explain the operational role of vendor-data or why the instance ID in
meta-data matters. This adds those details where the data files are introduced.

## Test Steps

- `PATH="$PWD/.tox/doc/bin:$PATH" READTHEDOCS=True .tox/doc/bin/python -m sphinx -W --keep-going -n --jobs=auto doc/rtd doc/rtd_html`
- `.tox/doc/bin/python -m doc8 doc/rtd`
- `git diff --check`

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
