### PR TITLE
fix(alpine): Use Alpine CDN as default APK mirror

### DIFF
--- a/cloudinit/config/cc_apk_configure.py
+++ b/cloudinit/config/cc_apk_configure.py
@@ -18,7 +18,7 @@ LOG = logging.getLogger(__name__)
 
 
 # If no mirror is specified then use this one
-DEFAULT_MIRROR = "https://alpine.global.ssl.fastly.net/alpine"
+DEFAULT_MIRROR = "https://dl-cdn.alpinelinux.org/alpine"
 
 
 REPOSITORIES_TEMPLATE = """\

--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -1052,8 +1052,8 @@
               "properties": {
                 "base_url": {
                   "type": "string",
-                  "default": "https://alpine.global.ssl.fastly.net/alpine",
-                  "description": "The base URL of an Alpine repository, or mirror, to download official packages from. If not specified then it defaults to ``https://alpine.global.ssl.fastly.net/alpine``."
+                  "default": "https://dl-cdn.alpinelinux.org/alpine",
+                  "description": "The base URL of an Alpine repository, or mirror, to download official packages from. If not specified then it defaults to ``https://dl-cdn.alpinelinux.org/alpine``."
                 },
                 "community_enabled": {
                   "type": "boolean",

--- a/tests/unittests/config/test_cc_apk_configure.py
+++ b/tests/unittests/config/test_cc_apk_configure.py
@@ -20,7 +20,7 @@ from tests.unittests.helpers import SCHEMA_EMPTY_ERROR, skipUnlessJsonSchema
 from tests.unittests.util import get_cloud
 
 REPO_FILE = "/etc/apk/repositories"
-DEFAULT_MIRROR_URL = "https://alpine.global.ssl.fastly.net/alpine"
+DEFAULT_MIRROR_URL = "https://dl-cdn.alpinelinux.org/alpine"
 CC_APK = "cloudinit.config.cc_apk_configure"
 
 


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [x] I have signed the CLA: https://ubuntu.com/legal/contributors
- [x] I have included a comprehensive commit message using the guide below
- [x] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [x] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e doc``.
-->

## Additional Context

This is the default URL used for millions of docker images and the preferred from upstream Alpine.

```console
$ docker run --rm alpine:3.24 cat /etc/apk/repositories
https://dl-cdn.alpinelinux.org/alpine/v3.24/main
https://dl-cdn.alpinelinux.org/alpine/v3.24/community
```

I believe the current `https://alpine.global.ssl.fastly.net/alpine` was picked before the dl-cdn.alpinelinux.org had https support.

## Merge type

- [ ] Squash merge using "Proposed Commit Message"
- [x] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
