### PR TITLE
Feat alpine apk repositories

### DIFF
--- a/cloudinit/config/cc_apk_configure.py
+++ b/cloudinit/config/cc_apk_configure.py
@@ -7,6 +7,7 @@
 """Apk Configure: Configures apk repositories file."""
 
 import logging
+import re
 
 from cloudinit import temp_utils, templater, util
 from cloudinit.cloud import Cloud
@@ -19,6 +20,16 @@ LOG = logging.getLogger(__name__)
 
 # If no mirror is specified then use this one
 DEFAULT_MIRROR = "https://dl-cdn.alpinelinux.org/alpine"
+REPO_FILE = "/etc/apk/repositories"
+
+REPOSITORIES_HEADER = """\
+#
+# Created by cloud-init
+#
+# This file is written on first boot of an instance
+#
+
+"""
 
 
 REPOSITORIES_TEMPLATE = """\
@@ -55,13 +66,13 @@ meta: MetaSchema = {
     "id": "cc_apk_configure",
     "distros": ["alpine"],
     "frequency": PER_INSTANCE,
-    "activate_by_schema_keys": ["apk_repos"],
+    "activate_by_schema_keys": ["apk", "apk_repos"],
 }
 
 
 def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     """
-    Call to handle apk_repos sections in cloud-config file.
+    Configure APK repositories from an ``apk`` or ``apk_repos`` section.
 
     @param name: The module name "apk_configure" from cloud.cfg
     @param cfg: A nested dict containing the entire cloud config contents.
@@ -70,9 +81,15 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     @param _args: Any module arguments from cloud.cfg
     """
 
-    # If there is no "apk_repos" section in the configuration
-    # then do nothing.
-    apk_section = cfg.get("apk_repos")
+    apk_section = cfg.get("apk")
+    legacy_apk_section = cfg.get("apk_repos")
+    if apk_section and _handle_apk_section(
+        name, apk_section, legacy_apk_section
+    ):
+        return
+
+    # apk_repos is retained for backwards compatibility.
+    apk_section = legacy_apk_section
     if not apk_section:
         LOG.debug(
             "Skipping module named %s, no 'apk_repos' section found", name
@@ -112,6 +129,67 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     _write_repositories_file(alpine_repo, alpine_version, local_repo)
 
 
+def _handle_apk_section(name, apk_section, legacy_apk_section):
+    """Handle repository configuration using the ``apk`` schema."""
+    if util.get_cfg_option_bool(apk_section, "preserve_repositories", False):
+        LOG.debug(
+            "Skipping module named %s, 'preserve_repositories' is set", name
+        )
+        return True
+
+    repositories = apk_section.get("repositories")
+    if not repositories:
+        LOG.debug("No 'apk.repositories' found in module named %s", name)
+        return False
+
+    if legacy_apk_section:
+        LOG.warning(
+            "Both 'apk.repositories' and 'apk_repos' are configured; "
+            "using 'apk.repositories'"
+        )
+
+    _write_repository_entries(_repository_entries(repositories))
+    return True
+
+
+def _repository_entries(repositories):
+    """Convert apk repository configuration into repository URLs."""
+    entries = []
+    for repository in repositories:
+        if isinstance(repository, str):
+            entries.append(repository)
+            continue
+
+        base_url = repository.get("base_url", DEFAULT_MIRROR).rstrip("/")
+        version = repository.get("version") or _get_alpine_version()
+        for repo in repository["repos"]:
+            entries.append(f"{base_url}/{version}/{repo}")
+    return entries
+
+
+def _get_alpine_version():
+    """Return the Alpine repository branch derived from /etc/alpine-release."""
+    release = util.load_text_file("/etc/alpine-release").strip()
+    if release.startswith("edge") or re.search(r"_(alpha|beta|pre)", release):
+        return "edge"
+
+    match = re.fullmatch(r"(\d+)\.(\d+)\.\d+", release)
+    if not match:
+        raise ValueError(
+            "Unable to derive an Alpine repository version from "
+            "/etc/alpine-release; set apk.repositories[].version explicitly"
+        )
+    return f"v{match.group(1)}.{match.group(2)}"
+
+
+def _write_repository_entries(entries):
+    """Write repository URLs to /etc/apk/repositories."""
+    unique_entries = list(dict.fromkeys(entries))
+    content = REPOSITORIES_HEADER + "\n".join(unique_entries) + "\n\n"
+    LOG.debug("Generating Alpine repository configuration file: %s", REPO_FILE)
+    util.write_file(REPO_FILE, content)
+
+
 def _write_repositories_file(alpine_repo, alpine_version, local_repo):
     """
     Write the /etc/apk/repositories file with the specified entries.
@@ -120,8 +198,6 @@ def _write_repositories_file(alpine_repo, alpine_version, local_repo):
     @param alpine_version: A string of the Alpine version to use.
     @param local_repo: A string containing the base URL of a local repo.
     """
-
-    repo_file = "/etc/apk/repositories"
 
     alpine_baseurl = alpine_repo.get("base_url", DEFAULT_MIRROR)
 
@@ -137,7 +213,7 @@ def _write_repositories_file(alpine_repo, alpine_version, local_repo):
     template_fn = tfile[1]  # Filepath is second item in tuple
     util.write_file(template_fn, content=REPOSITORIES_TEMPLATE)
 
-    LOG.debug("Generating Alpine repository configuration file: %s", repo_file)
-    templater.render_to_file(template_fn, repo_file, params)
+    LOG.debug("Generating Alpine repository configuration file: %s", REPO_FILE)
+    templater.render_to_file(template_fn, REPO_FILE, params)
     # Clean up temporary template
     util.del_file(template_fn)

--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -1033,6 +1033,57 @@
     "cc_apk_configure": {
       "type": "object",
       "properties": {
+        "apk": {
+          "type": "object",
+          "minProperties": 1,
+          "additionalProperties": false,
+          "properties": {
+            "preserve_repositories": {
+              "type": "boolean",
+              "default": false,
+              "description": "Preserve the repositories file from the pristine image instead of writing ``/etc/apk/repositories``. This overrides both ``apk.repositories`` and ``apk_repos``."
+            },
+            "repositories": {
+              "type": "array",
+              "minItems": 1,
+              "description": "Repository URLs or repository definitions to write to ``/etc/apk/repositories``. The list replaces the file contents.",
+              "items": {
+                "oneOf": [
+                  {
+                    "type": "string",
+                    "description": "A complete APK repository URL."
+                  },
+                  {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                      "base_url": {
+                        "type": "string",
+                        "default": "https://dl-cdn.alpinelinux.org/alpine",
+                        "description": "The base URL of an Alpine repository mirror."
+                      },
+                      "repos": {
+                        "type": "array",
+                        "minItems": 1,
+                        "items": {
+                          "type": "string"
+                        },
+                        "description": "Alpine repository names to enable, such as ``main`` and ``community``."
+                      },
+                      "version": {
+                        "type": "string",
+                        "description": "The Alpine version to use. If omitted, cloud-init derives the repository branch from ``/etc/alpine-release``."
+                      }
+                    },
+                    "required": [
+                      "repos"
+                    ]
+                  }
+                ]
+              }
+            }
+          }
+        },
         "apk_repos": {
           "type": "object",
           "minProperties": 1,
@@ -4189,6 +4240,7 @@
   "properties": {
     "allow_public_ssh_keys": {},
     "ansible": {},
+    "apk": {},
     "apk_repos": {},
     "apt": {},
     "apt_pipelining": {},

--- a/doc/module-docs/cc_apk_configure/data.yaml
+++ b/doc/module-docs/cc_apk_configure/data.yaml
@@ -3,6 +3,20 @@ cc_apk_configure:
     This module handles configuration of the Alpine Package Keeper (APK)
     ``/etc/apk/repositories`` file.
 
+    Use the ``apk.repositories`` list to define repository URLs. Entries can
+    be complete repository URLs or structured definitions with ``base_url``,
+    ``version``, and ``repos``. The legacy ``apk_repos`` configuration is
+    retained for backwards compatibility.
+
+    The ``apk.repositories`` list replaces ``/etc/apk/repositories``. Duplicate
+    repository URLs are written only once, in their first configured order.
+
+    When both forms configure repositories, ``apk.repositories`` takes
+    precedence and cloud-init logs a warning. An ``apk`` section without
+    ``repositories`` falls back to ``apk_repos``. Setting
+    ``apk.preserve_repositories`` to ``true`` preserves the existing file and
+    overrides both forms.
+
     .. note::
        To ensure that APK configuration is valid YAML, any strings
        containing special characters, especially colons, should be quoted
@@ -13,11 +27,11 @@ cc_apk_configure:
     file: cc_apk_configure/example1.yaml
   - comment: >
       Example 2: Create repositories file for Alpine v3.12 main and community
-      using default mirror site.
+      using the default mirror site.
     file: cc_apk_configure/example2.yaml
   - comment: >
       Example 3: Create repositories file for Alpine Edge main, community, and
-      testing using a specified mirror site and also a local repo.
+      testing using a specified mirror site and a custom repository URL.
     file: cc_apk_configure/example3.yaml
   name: APK Configure
   title: Configure APK repositories file

--- a/doc/module-docs/cc_apk_configure/example1.yaml
+++ b/doc/module-docs/cc_apk_configure/example1.yaml
@@ -1,3 +1,3 @@
 #cloud-config
-apk_repos:
+apk:
   preserve_repositories: true

--- a/doc/module-docs/cc_apk_configure/example2.yaml
+++ b/doc/module-docs/cc_apk_configure/example2.yaml
@@ -1,5 +1,5 @@
 #cloud-config
-apk_repos:
-  alpine_repo:
-    community_enabled: true
-    version: 'v3.12'
+apk:
+  repositories:
+    - version: v3.24
+      repos: [main, community]

--- a/doc/module-docs/cc_apk_configure/example3.yaml
+++ b/doc/module-docs/cc_apk_configure/example3.yaml
@@ -1,8 +1,7 @@
 #cloud-config
-apk_repos:
-  alpine_repo:
-    base_url: https://some-alpine-mirror/alpine
-    community_enabled: true
-    testing_enabled: true
-    version: edge
-  local_repo_base_url: https://my-local-server/local-alpine
+apk:
+  repositories:
+    - base_url: https://some-alpine-mirror/alpine
+      version: edge
+      repos: [main, community, testing]
+    - https://my-local-server/local-alpine

--- a/doc/rtd/reference/yaml_examples/apk_repo.rst
+++ b/doc/rtd/reference/yaml_examples/apk_repo.rst
@@ -7,6 +7,17 @@ These examples show how to configure the ``/etc/apk/repositories`` file. For a
 full list of keys, refer to the
 :ref:`APK configure module <mod_cc_apk_configure>` schema.
 
+Use ``apk.repositories`` for new configurations. The older ``apk_repos``
+format remains available for backwards compatibility.
+
+The ``apk.repositories`` list replaces ``/etc/apk/repositories``. Duplicate
+repository URLs are written only once, in their first configured order.
+
+When both forms configure repositories, ``apk.repositories`` takes precedence
+and cloud-init logs a warning. An ``apk`` section without ``repositories``
+falls back to ``apk_repos``. Set ``apk.preserve_repositories`` to ``true`` to
+preserve the existing file and override both forms.
+
 Keep the existing ``/etc/apk/repositories`` file unaltered.
 
 .. literalinclude:: ../../../module-docs/cc_apk_configure/example1.yaml
@@ -27,7 +38,7 @@ Alpine Edge
 ===========
 
 Create the repositories file for Alpine Edge main, community, and testing,
-using a specified mirror site and a local repo.
+using a specified mirror site and a custom repository URL.
 
 .. literalinclude:: ../../../module-docs/cc_apk_configure/example3.yaml
    :language: yaml

--- a/tests/unittests/config/test_cc_apk_configure.py
+++ b/tests/unittests/config/test_cc_apk_configure.py
@@ -278,6 +278,141 @@ class TestApkConfigure:
         assert util.load_text_file(REPO_FILE) == expected_content
 
 
+class TestApkConfigureTinyCloudStyle:
+    def test_structured_and_raw_repositories(self, fake_filesystem):
+        config = {
+            "apk": {
+                "repositories": [
+                    {
+                        "base_url": "https://dl-cdn.alpinelinux.org/alpine",
+                        "version": "v3.24",
+                        "repos": ["main", "community"],
+                    },
+                    "https://packages.example.net/alpine/custom",
+                ]
+            }
+        }
+
+        cc_apk_configure.handle("", config, get_cloud(), [])
+
+        expected_content = textwrap.dedent(
+            """\
+            #
+            # Created by cloud-init
+            #
+            # This file is written on first boot of an instance
+            #
+
+            https://dl-cdn.alpinelinux.org/alpine/v3.24/main
+            https://dl-cdn.alpinelinux.org/alpine/v3.24/community
+            https://packages.example.net/alpine/custom
+
+            """
+        )
+
+        assert util.load_text_file(REPO_FILE) == expected_content
+
+    def test_duplicate_repositories_are_written_once(self, fake_filesystem):
+        repository_url = "https://packages.example.net/custom"
+        config = {"apk": {"repositories": [repository_url, repository_url]}}
+
+        cc_apk_configure.handle("", config, get_cloud(), [])
+
+        assert util.load_text_file(REPO_FILE).count(repository_url) == 1
+
+    def test_apk_without_repositories_falls_back_to_apk_repos(
+        self, fake_filesystem
+    ):
+        config = {
+            "apk": {"preserve_repositories": False},
+            "apk_repos": {"alpine_repo": {"version": "v3.24"}},
+        }
+
+        cc_apk_configure.handle("", config, get_cloud(), [])
+
+        assert f"{DEFAULT_MIRROR_URL}/v3.24/main" in util.load_text_file(
+            REPO_FILE
+        )
+
+    def test_apk_repositories_take_precedence_over_apk_repos(
+        self, fake_filesystem, caplog
+    ):
+        config = {
+            "apk": {"repositories": ["https://packages.example.net/custom"]},
+            "apk_repos": {"alpine_repo": {"version": "v3.24"}},
+        }
+
+        cc_apk_configure.handle("", config, get_cloud(), [])
+
+        repository_file = util.load_text_file(REPO_FILE)
+        assert "https://packages.example.net/custom" in repository_file
+        assert f"{DEFAULT_MIRROR_URL}/v3.24/main" not in repository_file
+        assert "Both 'apk.repositories' and 'apk_repos'" in caplog.text
+
+    def test_apk_preserve_repositories_overrides_apk_repos(self, mocker):
+        config = {
+            "apk": {
+                "preserve_repositories": True,
+                "repositories": ["https://packages.example.net/custom"],
+            },
+            "apk_repos": {"alpine_repo": {"version": "v3.24"}},
+        }
+        m_write_legacy = mocker.patch(CC_APK + "._write_repositories_file")
+        m_write_repositories = mocker.patch(
+            CC_APK + "._write_repository_entries"
+        )
+
+        cc_apk_configure.handle("", config, get_cloud(), [])
+
+        m_write_legacy.assert_not_called()
+        m_write_repositories.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "release, repository_version",
+        (
+            ("3.24.0", "v3.24"),
+            ("edge", "edge"),
+            ("3.25.0_alpha20260724", "edge"),
+            ("3.25.0_beta20260724", "edge"),
+            ("3.25.0_pre20260724", "edge"),
+        ),
+    )
+    def test_infers_repository_version_from_alpine_release(
+        self, fake_filesystem, release, repository_version
+    ):
+        util.write_file("/etc/alpine-release", f"{release}\n")
+        config = {
+            "apk": {
+                "repositories": [
+                    {
+                        "base_url": "https://dl-cdn.alpinelinux.org/alpine",
+                        "repos": ["main"],
+                    }
+                ]
+            }
+        }
+
+        cc_apk_configure.handle("", config, get_cloud(), [])
+
+        expected_url = (
+            "https://dl-cdn.alpinelinux.org/alpine/"
+            f"{repository_version}/main"
+        )
+        assert expected_url in util.load_text_file(REPO_FILE)
+
+    def test_requires_version_when_alpine_release_is_unrecognized(
+        self, fake_filesystem
+    ):
+        util.write_file("/etc/alpine-release", "unknown\n")
+        config = {"apk": {"repositories": [{"repos": ["main"]}]}}
+
+        with pytest.raises(
+            ValueError,
+            match=r"set apk.repositories\[\].version explicitly",
+        ):
+            cc_apk_configure.handle("", config, get_cloud(), [])
+
+
 class TestApkConfigureSchema:
     @pytest.mark.parametrize(
         "config, error_msg",
@@ -285,7 +420,7 @@ class TestApkConfigureSchema:
             # Valid schemas
             ({"apk_repos": {"preserve_repositories": True}}, None),
             ({"apk_repos": {"alpine_repo": None}}, None),
-            ({"apk_repos": {"alpine_repo": {"version": "v3.21"}}}, None),
+            ({"apk_repos": {"alpine_repo": {"version": "v3.24"}}}, None),
             (
                 {
                     "apk_repos": {
@@ -293,7 +428,7 @@ class TestApkConfigureSchema:
                             "base_url": "http://yep",
                             "community_enabled": True,
                             "testing_enabled": True,
-                            "version": "v3.21",
+                            "version": "v3.24",
                         }
                     }
                 },
@@ -348,3 +483,40 @@ class TestApkConfigureSchema:
         else:
             with pytest.raises(SchemaValidationError, match=error_msg):
                 validate_cloudconfig_schema(config, schema, strict=True)
+
+
+class TestApkConfigureTinyCloudStyleSchema:
+    @skipUnlessJsonSchema()
+    def test_schema_validation(self):
+        schema = get_schema()
+        validate_cloudconfig_schema(
+            {
+                "apk": {
+                    "repositories": [
+                        {
+                            "base_url": "https://dl-cdn.alpinelinux.org/alpine",
+                            "version": "v3.24",
+                            "repos": ["main", "community"],
+                        },
+                        "https://packages.example.net/alpine/custom",
+                    ]
+                }
+            },
+            schema,
+            strict=True,
+        )
+        with pytest.raises(SchemaValidationError):
+            validate_cloudconfig_schema(
+                {
+                    "apk": {
+                        "repositories": [
+                            {
+                                "base_url": "https://dl-cdn.alpinelinux.org/alpine",
+                                "repos": "main",
+                            }
+                        ]
+                    }
+                },
+                schema,
+                strict=True,
+            )


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [x] I have signed the CLA: https://ubuntu.com/legal/contributors
- [ ] I have included a comprehensive commit message using the guide below
- [x] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [x] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [x] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [x] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e doc``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
feat(alpine): Add APK repository configuration

Add the preferred apk.repositories interface for configuring
/etc/apk/repositories on Alpine.

The list-based syntax supports structured repository groups and raw
repository URLs. It derives stable and edge repository branches,
deduplicates URLs, and replaces the repositories file.

When both formats configure repositories, apk.repositories takes
precedence with a warning. apk_repos remains a fallback when apk does
not define repositories, and preserve_repositories overrides both.

Document the new configuration format, replacement behavior, duplicate
handling, precedence, and examples.

Fixes GH-6946
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
