### PR TITLE
fix(ec2): ignore all-zero /sys/hypervisor/uuid

### DIFF
--- a/cloudinit/sources/DataSourceEc2.py
+++ b/cloudinit/sources/DataSourceEc2.py
@@ -31,6 +31,7 @@ LOG = logging.getLogger(__name__)
 
 STRICT_ID_PATH = ("datasource", "Ec2", "strict_id")
 STRICT_ID_DEFAULT = "warn"
+NULL_UUID = "00000000-0000-0000-0000-000000000000"
 
 
 class CloudNames:
@@ -878,6 +879,11 @@ def _collect_platform_data():
     uuid = None
     with suppress(OSError, UnicodeDecodeError):
         uuid = util.load_text_file("/sys/hypervisor/uuid").strip()
+
+    # A Xen dom0 reports an all-zero uuid here, which carries no platform
+    # information but is truthy, so ignore it and fall back to DMI.
+    if uuid == NULL_UUID:
+        uuid = None
 
     uuid = uuid or dmi.read_dmi_data("system-uuid") or ""
     serial = dmi.read_dmi_data("system-serial-number") or ""

--- a/tests/unittests/sources/test_ec2.py
+++ b/tests/unittests/sources/test_ec2.py
@@ -1807,6 +1807,26 @@ class TestIdentifyPlatform:
         )
         assert expected == ec2.identify_platform()
 
+    def test_identify_aws_null_hypervisor_uuid(self, mocker):
+        """a null /sys/hypervisor/uuid must fall back to the dmi uuid.
+
+        A Xen dom0 reports an all-zero uuid there, which identifies no
+        platform but is truthy, so AWS was never detected.
+        """
+        mocker.patch(
+            "cloudinit.util.load_text_file",
+            return_value="00000000-0000-0000-0000-000000000000\n",
+        )
+        mocker.patch(
+            "cloudinit.dmi.read_dmi_data",
+            side_effect=lambda key: (
+                "EC2E1916-9099-7CAF-FD21-012345ABCDEF"
+                if key == "system-uuid"
+                else ""
+            ),
+        )
+        assert ec2.CloudNames.AWS == ec2.identify_platform()
+
     @mock.patch("cloudinit.sources.DataSourceEc2._collect_platform_data")
     def test_identify_aws_endian(self, m_collect):
         """aws should be identified if uuid starts with ec2"""


### PR DESCRIPTION
## Proposed Commit Message
```
fix(ec2): ignore all-zero /sys/hypervisor/uuid

On a Xen dom0 /sys/hypervisor/uuid reads all zeros.
_collect_platform_data() prefers that file over DMI and an all-zero
uuid is truthy, so the DMI fallback never ran and AWS was not
identified. No IMDSv2 token was then requested, and with
HttpTokens=required the tokenless IMDSv1 requests failed for the full
240 second wait before the datasource gave up.

Treat the null uuid as absent so the DMI system-uuid is used.

Fixes GH-6937
```

## Additional Context
Fixes #6937\
\
Reported in #6937 with logs from an Ubuntu 24.04 EC2 instance booted as a Xen dom0.

## Test Steps
`tests/unittests/sources/test_ec2.py::TestIdentifyPlatform::test_identify_aws_null_hypervisor_uuid` mocks the null `/sys/hypervisor/uuid` and an `ec2...` DMI system-uuid; it fails on the current code (`unknown`) and passes with this change (`aws`). The rest of `tests/unittests/sources/test_ec2.py` is unchanged and green (67 passed).

On a live system: boot an EC2 instance with `--metadata-options HttpTokens=required` as a Xen dom0, then check that `cloud-init` identifies the AWS datasource instead of waiting out the 240 second IMDSv1 timeout and falling back to `DataSourceNone`.

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
