### PR TITLE
feat: multiple deb822 files--closes #6696

### DIFF
--- a/cloudinit/config/cc_apt_configure.py
+++ b/cloudinit/config/cc_apt_configure.py
@@ -681,10 +681,16 @@ def add_apt_sources(
         'source': 'deb [signed-by=$KEY_FILE] $MIRROR $RELEASE main',
         'keyid': 'B59D 5F15 97A5 04B7 E230  6DCA 0620 BBCF 0368 3F77',
         'keyserver': 'pgp.mit.edu'
+        },
+    'microsoft-vscode': {
+        'source': "Types: deb" \
+            "\nURIs: https://packages.microsoft.com/repos/code" \
+            "\nSigned-By: /usr/share/keyrings/microsoft.gpg" \
+            "\nSuites: stable" \
+            "\nComponents: main" \
+            "\nArchitectures: amd64,arm64,armhf"
         }
     }
-
-    Note: Deb822 format is not supported
     """
     if template_params is None:
         template_params = {}
@@ -716,8 +722,11 @@ def add_apt_sources(
             ent["filename"] = os.path.join(
                 "/etc/apt/sources.list.d/", ent["filename"]
             )
-        if not ent["filename"].endswith(".list"):
+        is_deb822 = is_deb822_sources_format(source)
+        if not is_deb822 and not ent["filename"].endswith(".list"):
             ent["filename"] += ".list"
+        if is_deb822 and not ent["filename"].endswith(".sources"):
+            ent["filename"] += ".sources"
 
         if aa_repo_match(source):
             try:

--- a/doc/module-docs/cc_apt_configure/example1.yaml
+++ b/doc/module-docs/cc_apt_configure/example1.yaml
@@ -63,3 +63,9 @@ apt:
               ------BEGIN PGP PUBLIC KEY BLOCK-------
               <key data>
               ------END PGP PUBLIC KEY BLOCK-------
+      source5:
+          source: |
+              Types: deb
+              URIs: http://archive.ubuntu.com/ubuntu/
+              Suites: karmic-backports
+              Components: main universe multiverse restricted

--- a/tests/unittests/config/test_apt_source_v3.py
+++ b/tests/unittests/config/test_apt_source_v3.py
@@ -61,6 +61,8 @@ class TestAptSourceConfig:
         self.aptlistfile = tmpdir.join("src1.list").strpath
         self.aptlistfile2 = tmpdir.join("src2.list").strpath
         self.aptlistfile3 = tmpdir.join("src3.list").strpath
+        self.aptsourcesfile4 = tmpdir.join("src4.sources").strpath
+        self.aptsourcesfile5 = tmpdir.join("src5.sources").strpath
         self.matcher = re.compile(ADD_APT_REPO_MATCH).search
 
     @staticmethod
@@ -177,6 +179,61 @@ class TestAptSourceConfig:
             contents,
             flags=re.IGNORECASE,
         ), f"Unexpected APT format of {self.aptlistfile3}: contents"
+
+    def test_apt_v3_src_deb822(self, tmpdir, m_gpg):
+        """test_apt_v3_src_deb822 - Test source string in deb822 format"""
+        source3_name = os.path.splitext(self.aptlistfile3)[0]
+        source4_name = os.path.splitext(self.aptsourcesfile4)[0]
+        source5_name = self.aptsourcesfile5
+        cfg = {
+            source3_name: {
+                "source": (
+                    "deb http://test.ubuntu.com/ubuntu"
+                    " lucid-backports"
+                    " main universe multiverse restricted"
+                )
+            },
+            source4_name: {
+                "source": (
+                    "Types: deb"
+                    "\nURIs: http//test.ubuntu.com/ubuntu"
+                    "\nSuites: karmic-backports"
+                    "\nComponents: main universe multiverse restricted"
+                )
+            },
+            source5_name: {
+                "source": (
+                    "Types: deb"
+                    "\nURIs: http//test.ubuntu.com/ubuntu"
+                    "\nSuites: precise-backports"
+                    "\nComponents: main universe multiverse restricted"
+                )
+            },
+        }
+
+        params = self._get_default_params()
+
+        self._add_apt_sources(
+            cfg,
+            cloud=mock.Mock(),
+            gpg=m_gpg,
+            template_params=params,
+            aa_repo_match=self.matcher,
+        )
+
+        for source_name, file_path in [
+            (source5_name, self.aptsourcesfile5),
+            (source4_name, self.aptsourcesfile4),
+            (source3_name, self.aptlistfile3),
+        ]:
+            assert (
+                os.path.isfile(file_path) is True
+            ), f"Missing expected file {file_path}"
+
+            contents = util.load_text_file(file_path)
+            assert re.search(
+                cfg[source_name]["source"], contents, flags=re.IGNORECASE
+            ), f"Unexpected APT config in {file_path}: {contents}"
 
     def _apt_src_replacement(self, filename, cfg, tmpdir, gpg):
         """apt_src_replace


### PR DESCRIPTION

- [x] I have signed the CLA: https://ubuntu.com/legal/contributors
- [x] I have included a comprehensive commit message using the guide below
- [x] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [x] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [x] I have added a reference to issues that this PR relates to in the PR message (Fixes #6696 )
- [x] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e doc``.

## Proposed Commit Message
```
feat(debian): Allow apt sources to use deb822 format
Fixes GH-6696 
```

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
