### PR TITLE
fix(ec2): use correct IMDS field for IPv6 subnet CIDRs

### DIFF
--- a/cloudinit/sources/DataSourceEc2.py
+++ b/cloudinit/sources/DataSourceEc2.py
@@ -1205,7 +1205,7 @@ def get_secondary_addresses(nic_metadata, mac):
     if bool(isinstance(ipv6s, list) and len(ipv6s) > 1):
         addresses.extend(
             _get_secondary_addresses(
-                nic_metadata, "subnet-ipv6-cidr-block", mac, ipv6s, "128"
+                nic_metadata, "subnet-ipv6-cidr-blocks", mac, ipv6s, "128"
             )
         )
     return sorted(addresses)

--- a/tests/unittests/sources/test_ec2.py
+++ b/tests/unittests/sources/test_ec2.py
@@ -1078,7 +1078,7 @@ class TestGetSecondaryAddresses:
         """Any invalid subnet-ipv(4|6)-cidr-block values use defaults"""
         invalid_cidr_md = copy.deepcopy(NIC1_MD_IPV4_IPV6_MULTI_IP)
         invalid_cidr_md["subnet-ipv4-cidr-block"] = "something-unexpected"
-        invalid_cidr_md["subnet-ipv6-cidr-block"] = "not/sure/what/this/is"
+        invalid_cidr_md["subnet-ipv6-cidr-blocks"] = "not/sure/what/this/is"
         assert [
             "172.31.45.70/24",
             "2600:1f16:292:100:f152:2222:3333:4444/128",
@@ -1095,7 +1095,7 @@ class TestGetSecondaryAddresses:
             (
                 mock.ANY,
                 logging.WARNING,
-                "Could not parse subnet-ipv6-cidr-block"
+                "Could not parse subnet-ipv6-cidr-blocks"
                 " not/sure/what/this/is for mac 06:17:04:d7:26:ff."
                 " ipv6 network config prefix defaults to /128",
             ),


### PR DESCRIPTION
This change fixes broken reference to `subnet-ipv6-cidr-blocks` in NIC metadata while obtaining IPv6 CIDRs via get_secondary_addresses().

Related changesets:
 - 6600c64 is where the wrong name was 1st introduced,
 - a3aa44f contains a few fixes in surrounding code, but is incomplete.

Reference documentation:
"network/interfaces/macs/mac/subnet-ipv6-cidr-blocks - The IPv6 CIDR block of the subnet in which the interface resides." [1]

[1] https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html

<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [ ] I have signed the CLA: https://ubuntu.com/legal/contributors
- [ ] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [ ] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e doc``.
-->


## Proposed Commit Message
```
fix(ec2): use correct IMDS field for IPv6 subnet CIDRs

This change fixes broken reference to `subnet-ipv6-cidr-blocks` in NIC
metadata while obtaining IPv6 CIDRs via get_secondary_addresses().

Related changesets:
 - 6600c64 is where the wrong name was 1st introduced,
 - a3aa44f contains a few fixes in surrounding code, but is incomplete.

Reference documentation:
"network/interfaces/macs/mac/subnet-ipv6-cidr-blocks - The IPv6 CIDR block
of the subnet in which the interface resides." [1]

[1] https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html
```

## Additional Context

Before this change, the `cloud-init-hotplugd.service` complains about being unable to fetch corresponding data through invalid key (field name):

```
root@ip-10-0-0-31:/var/log# journalctl -u cloud-init-hotplugd.service | grep -i -- "could not parse"
Jul 27 23:36:32 ip-10-0-0-31 cloud-init-hotplugd[1108]: 2026-07-27 23:36:32,227 - DataSourceEc2.py[WARNING]: Could not parse subnet-ipv6-cidr-block None for mac 0a:ff:fa:94:e1:0d. ipv6 network config prefix defaults to /128
Jul 27 23:36:35 ip-10-0-0-31 cloud-init-hotplugd[1108]: 2026-07-27 23:36:35,317 - DataSourceEc2.py[WARNING]: Could not parse subnet-ipv6-cidr-block None for mac 0a:ff:fa:94:e1:0d. ipv6 network config prefix defaults to /128
Jul 27 23:36:39 ip-10-0-0-31 cloud-init-hotplugd[1108]: 2026-07-27 23:36:39,800 - DataSourceEc2.py[WARNING]: Could not parse subnet-ipv6-cidr-block None for mac 0a:ff:fa:94:e1:0d. ipv6 network config prefix defaults to /128
Jul 27 23:36:45 ip-10-0-0-31 cloud-init-hotplugd[1108]: 2026-07-27 23:36:45,708 - DataSourceEc2.py[WARNING]: Could not parse subnet-ipv6-cidr-block None for mac 0a:ff:fa:94:e1:0d. ipv6 network config prefix defaults to /128
Jul 27 23:36:57 ip-10-0-0-31 cloud-init-hotplugd[1108]: 2026-07-27 23:36:57,515 - DataSourceEc2.py[WARNING]: Could not parse subnet-ipv6-cidr-block None for mac 0a:ff:fa:94:e1:0d. ipv6 network config prefix defaults to /128
```

## Test Steps

TBA

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
