### PR TITLE
test: isolate ssh_import_id to its own class and tolerate GH rate limits

### DIFF
--- a/tests/integration_tests/modules/test_combined.py
+++ b/tests/integration_tests/modules/test_combined.py
@@ -832,17 +832,10 @@ class TestSshImportId:
         rather than hard-failing (the failure is environmental, not a
         cloud-init regression).
         """
-        output_log = ""
-        try:
-            output_log = class_client.read_from_file(
-                "/var/log/cloud-init-output.log"
-            )
-        except IOError:
-            pass
-        if (
-            "GitHub REST API rate-limited" in output_log
-            or "status_code=403" in output_log
-        ):
+        output_log = class_client.read_from_file(
+            "/var/log/cloud-init-output.log"
+        )
+        if "GitHub REST API rate-limited" in output_log:
             pytest.skip("skipped: GitHub API rate-limited")
         ssh_output = class_client.read_from_file(
             "/home/ubuntu/.ssh/authorized_keys"

--- a/tests/integration_tests/modules/test_combined.py
+++ b/tests/integration_tests/modules/test_combined.py
@@ -22,7 +22,6 @@ import cloudinit.config
 from cloudinit import lifecycle
 from cloudinit.util import is_true
 from tests.integration_tests.clouds import Ec2Cloud
-from tests.integration_tests.decorators import retry
 from tests.integration_tests.instances import IntegrationInstance
 from tests.integration_tests.integration_settings import (
     OS_IMAGE_TYPE,
@@ -111,8 +110,6 @@ runcmd:
 snap:
   commands:
     - snap install hello-world
-ssh_import_id:
-  - gh:blackboxsw
 
 timezone: Europe/Madrid
 """
@@ -393,7 +390,6 @@ class TestCombined:
                 "rsyslog",
                 "runcmd",
                 "snap",
-                "ssh_import_id",
                 "timezone",
             }
         )
@@ -814,22 +810,44 @@ class TestCombined:
     # cloud-init devel net-convert
 
 
-@pytest.mark.user_data(USER_DATA)
-class TestCombinedNoCI:
-    @retry(tries=30, delay=1)
-    @pytest.mark.skipif(IS_RHEL, reason="rhel skips ssh_import_id module")
+SSH_IMPORT_ID_USER_DATA = """\
+#cloud-config
+ssh_import_id:
+  - gh:blackboxsw
+"""
+
+
+@pytest.mark.user_data(SSH_IMPORT_ID_USER_DATA)
+@pytest.mark.skipif(IS_RHEL, reason="rhel skips ssh_import_id module")
+class TestSshImportId:
     def test_ssh_import_id(self, class_client: IntegrationInstance):
         """Integration test for the ssh_import_id module.
 
         This test specifies ssh keys to be imported by the ``ssh_import_id``
-        module and then checks that if the ssh keys were successfully imported.
+        module and then checks that the ssh keys were successfully imported.
 
-        TODO:
-        * This test assumes that SSH keys will be imported into the
-        /home/ubuntu; this will need modification to run on other OSes.
+        ssh-import-id calls the GitHub REST API, which rate-limits (HTTP 403)
+        the CI runners' shared IP on an hourly window. When that happens the
+        key is never written, so detect the rate-limit signature and skip
+        rather than hard-failing (the failure is environmental, not a
+        cloud-init regression).
         """
-        client = class_client
-        ssh_output = client.read_from_file("/home/ubuntu/.ssh/authorized_keys")
+        output_log = ""
+        try:
+            output_log = class_client.read_from_file(
+                "/var/log/cloud-init-output.log"
+            )
+        except IOError:
+            pass
+        if (
+            "GitHub REST API rate-limited" in output_log
+            or "status_code=403" in output_log
+        ):
+            pytest.skip("skipped: GitHub API rate-limited")
+        ssh_output = class_client.read_from_file(
+            "/home/ubuntu/.ssh/authorized_keys"
+        )
+
         assert "# ssh-import-id gh:blackboxsw" in ssh_output
 
 

--- a/tests/integration_tests/modules/test_combined.py
+++ b/tests/integration_tests/modules/test_combined.py
@@ -20,7 +20,6 @@ import cloudinit.config
 from cloudinit import lifecycle
 from cloudinit.util import is_true
 from tests.integration_tests.clouds import Ec2Cloud
-from tests.integration_tests.decorators import retry
 from tests.integration_tests.instances import IntegrationInstance
 from tests.integration_tests.integration_settings import (
     OS_IMAGE_TYPE,
@@ -89,8 +88,6 @@ runcmd:
 snap:
   commands:
     - snap install hello-world
-ssh_import_id:
-  - gh:blackboxsw
 
 timezone: Europe/Madrid
 """
@@ -371,7 +368,6 @@ class TestCombined:
                 "rsyslog",
                 "runcmd",
                 "snap",
-                "ssh_import_id",
                 "timezone",
             }
         )
@@ -661,21 +657,42 @@ class TestCombined:
         )
 
 
-@pytest.mark.user_data(USER_DATA)
-class TestCombinedNoCI:
-    @retry(tries=30, delay=1)
-    @pytest.mark.skipif(IS_RHEL, reason="rhel skips ssh_import_id module")
+SSH_IMPORT_ID_USER_DATA = """\
+#cloud-config
+ssh_import_id:
+  - gh:blackboxsw
+"""
+
+
+@pytest.mark.user_data(SSH_IMPORT_ID_USER_DATA)
+@pytest.mark.skipif(IS_RHEL, reason="rhel skips ssh_import_id module")
+class TestSshImportId:
     def test_ssh_import_id(self, class_client: IntegrationInstance):
         """Integration test for the ssh_import_id module.
 
         This test specifies ssh keys to be imported by the ``ssh_import_id``
-        module and then checks that if the ssh keys were successfully imported.
+        module and then checks that the ssh keys were successfully imported.
 
-        TODO:
-        * This test assumes that SSH keys will be imported into the
-        /home/ubuntu; this will need modification to run on other OSes.
+        ssh-import-id calls the GitHub REST API, which rate-limits (HTTP 403)
+        the CI runners' shared IP on an hourly window. When that happens the
+        key is never written, so detect the rate-limit signature and skip
+        rather than hard-failing (the failure is environmental, not a
+        cloud-init regression).
         """
-        client = class_client
-        ssh_output = client.read_from_file("/home/ubuntu/.ssh/authorized_keys")
+        output_log = ""
+        try:
+            output_log = class_client.read_from_file(
+                "/var/log/cloud-init-output.log"
+            )
+        except IOError:
+            pass
+        if (
+            "GitHub REST API rate-limited" in output_log
+            or "status_code=403" in output_log
+        ):
+            pytest.skip("skipped: GitHub API rate-limited")
+        ssh_output = class_client.read_from_file(
+            "/home/ubuntu/.ssh/authorized_keys"
+        )
 
         assert "# ssh-import-id gh:blackboxsw" in ssh_output


### PR DESCRIPTION
## Proposed Commit Message
```
test: isolate ssh_import_id to its own class and tolerate GH rate limits

ssh_import_id was in the shared USER_DATA used by both TestCombined and
TestCombinedNoCI, so a single GitHub REST API 403 rate limit cascaded
into three failures (test_ssh_import_id, test_no_problems,
test_deprecated_message via verify_clean_boot).

Move ssh_import_id into a dedicated TestSshImportId class with its own
user-data to limit the blast radius of a GitHub rate limiting to one test.
Remove from the shared USER_DATA and from test_no_problems.

The isolated test detects the rate-limit signature
('GitHub REST API rate-limited' / 'status_code=403') in
cloud-init-output.log and pytest.skips instead of hard-failing.
```

## Additional Context
[Intermittent failed  ssh-import-id workflows on scheduled GH workfow runs](https://github.com/canonical/cloud-init/actions/runs/30314158711/job/90136041230)


## Test Steps
```
CLOUD_INIT_CLOUD_INIT_SOURCE=ppa:cloud-init-dev/daily CLOUD_INIT_PLATFORM=lxd_vm CLOUD_INIT_OS_IMAGE=stonking tox -e integration-tests -- tests/integration_tests/modules/test_combined.py
```
## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
