### PR TITLE
batch two fixes for integration tests on 26.10 lxd_vm

### DIFF
--- a/tests/integration_tests/modules/test_wireguard.py
+++ b/tests/integration_tests/modules/test_wireguard.py
@@ -8,9 +8,17 @@ from pycloudlib.lxd.instance import LXDInstance
 from cloudinit.subp import subp
 from tests.integration_tests.instances import IntegrationInstance
 from tests.integration_tests.integration_settings import PLATFORM
-from tests.integration_tests.releases import IS_UBUNTU
+from tests.integration_tests.releases import (
+    CURRENT_RELEASE,
+    IS_UBUNTU,
+    RESOLUTE,
+)
 
-ASCII_TEXT = "ASCII text"
+ASCII_TEXT = (
+    "ASCII text"
+    if CURRENT_RELEASE <= RESOLUTE
+    else "Generic INItialization configuration"
+)
 
 USER_DATA = """\
 #cloud-config

--- a/tests/integration_tests/releases.py
+++ b/tests/integration_tests/releases.py
@@ -100,6 +100,7 @@ NOBLE = Release("ubuntu", "noble", "24.04")
 ORACULAR = Release("ubuntu", "oracular", "24.10")
 PLUCKY = Release("ubuntu", "plucky", "25.04")
 QUESTING = Release("ubuntu", "questing", "25.10")
+RESOLUTE = Release("ubuntu", "resolute", "26.04")
 
 UBUNTU_STABLE = (FOCAL, JAMMY, MANTIC, NOBLE)
 

--- a/tests/integration_tests/test_networking.py
+++ b/tests/integration_tests/test_networking.py
@@ -251,12 +251,16 @@ def test_schema_warnings(net_config, session_cloud: IntegrationCloud):
         else:
             assert result.failed
             assert result.return_code == 2  # Warnings exit 2 after 23.4
+        # cloud-init's own v1 schema check still flags the too-long name;
+        # netplan 1.2+ no longer raises, so assert on cloud-init's messages.
         assert (
-            'eth01234567890123\\" is wrong: \\"name\\" not a valid ifname'
+            "network-config-v1 failed schema validation!"
             in result.stdout
         )
-        result = client.execute("cloud-init schema --system")
+        result = client.execute("cloud-init schema --system --annotate")
         assert "Invalid network-config " in result.stdout
+        assert "eth01234567890123" in result.stdout
+        assert "is too long" in result.stdout
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION

## Proposed Commit Messages
```
*    test(networking): assert on cloud-init schema output for too-long ifname
    
    netplan 1.2 no longer raises a NetplanParserException for a too-long
    interface name (17 chars), it instead ignores such named interfaces and
    emits warnings on netplan apply. So, the netplan-specific 'not a valid ifname'
    string never reaches cloud-init's recoverable_errors. cloud-init's
    own v1 schema check still flags it. Assert on cloud-init's version-stable
    output instead: 'network-config-v1 failed schema validation!' in status
    JSON, and the 'is too long' from stderr of 'cloud-init schema --system`.

*  test(wireguard): tolerate libmagic 26.10 INI classification of .conf files
    
    libmagic on 26.10 (file 5.46) reclassifies INI .conf files as
    'Generic INItialization configuration' instead of 'ASCII text'. Provide
    strict expected values <= RESOLUTE and newer expected output.
```

## Additional Context
[integration test failures seen on lxd_vm tests due to changes in behavior in cloud-init image dependencies](https://github.com/canonical/cloud-init/actions/runs/30314158711/job/90136041230)

## Test Steps
```
CLOUD_INIT_OS_IMAGE=stonking CLOUD_INIT_PLATFORM=lxd_vm .tox/integration-tests/bin/pytest --last-failed tests/integration_tests/modules/test_wireguard.py  tests/integration_tests/test_networking.py
```
## Merge type

- [ ] Squash merge using "Proposed Commit Message"
- [x] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
