### PR TITLE
test: fix wait_for_cloud_init logic bug and tolerate degraded boot

### DIFF
--- a/tests/integration_tests/cmd/test_status.py
+++ b/tests/integration_tests/cmd/test_status.py
@@ -158,7 +158,7 @@ def test_status_block_through_all_boot_status(client):
     )
     client.instance.clean()
     client.instance.restart()
-    wait_for_cloud_init(client).stdout.strip()
+    wait_for_cloud_init(client, num_retries=120).stdout.strip()
     client.execute("cloud-init status --wait")
 
     # Assert that before-cloud-init-local.service started before

--- a/tests/integration_tests/modules/test_ansible.py
+++ b/tests/integration_tests/modules/test_ansible.py
@@ -284,7 +284,7 @@ def _test_ansible_pull_from_local_server(my_client):
     assert not setup.return_code
     my_client.execute("cloud-init clean --logs")
     my_client.restart()
-    wait_for_cloud_init(my_client)
+    wait_for_cloud_init(my_client, num_retries=120)
     log = my_client.read_from_file("/var/log/cloud-init.log")
     verify_clean_log(log)
     verify_clean_boot(my_client)

--- a/tests/integration_tests/test_ds_identify.py
+++ b/tests/integration_tests/test_ds_identify.py
@@ -29,7 +29,7 @@ def test_ds_identify(client: IntegrationInstance):
     assert client.execute(f"rm {DATASOURCE_LIST_FILE}")
     assert client.execute("cloud-init clean --logs")
     client.restart()
-    wait_for_cloud_init(client)
+    wait_for_cloud_init(client, num_retries=120)
     verify_clean_log(client.execute("cat /var/log/cloud-init.log"))
     verify_clean_boot(client)
     assert client.execute("cloud-init status --wait")

--- a/tests/integration_tests/test_kernel_command_line_match.py
+++ b/tests/integration_tests/test_kernel_command_line_match.py
@@ -92,7 +92,13 @@ def test_lxd_datasource_kernel_override_nocloud_net(
     ) as client:
         # We know this will be an LXD instance due to our pytest mark
         client.instance.execute_via_ssh = False  # pyright: ignore
-        assert wait_for_cloud_init(client, num_retries=60).ok
+        result = wait_for_cloud_init(client, num_retries=60)
+        # With security.devlxd: False the /dev/lxd/sock socket is absent, so
+        # DataSourceLXD's ds_detect logs a warning and the boot is legitimately
+        # degraded (exit 2). Tolerate that, mirroring the sibling test in
+        # datasources/test_lxd_discovery.py.
+        if not result.ok and result.return_code != 2:
+            raise AssertionError(f"cloud-init failed:\n{result.stderr}")
         if source.installs_new_version():
             client.install_new_cloud_init(source, clean=False)
         override_kernel_command_line(ds_str, client)

--- a/tests/integration_tests/util.py
+++ b/tests/integration_tests/util.py
@@ -541,13 +541,21 @@ def get_test_rsa_keypair(key_name: str = "test1") -> key_pair:
 
 # We're implementing our own here in case cloud-init status --wait
 # isn't working correctly (LP: #1966085)
+_TERMINAL_STATUS = (
+    "status: done",
+    "status: disabled",
+    "status: error",
+    "status: degraded",  # degraded == done w/ warnings
+)
+
+
 def wait_for_cloud_init(client: "IntegrationInstance", num_retries: int = 30):
     last_exception = None
     for _ in range(num_retries):
         try:
             result = client.execute("cloud-init status")
-            if result.return_code in (0, 2) and (
-                "running" not in result or "not started" not in result
+            if result.return_code in (0, 1, 2) and any(
+                terminal in result for terminal in _TERMINAL_STATUS
             ):
                 return result
         except Exception as e:


### PR DESCRIPTION

## Proposed Commit Message
```
test: fix wait_for_cloud_init logic bug and tolerate degraded boot

The wait_for_cloud_init helper (util.py) never actually waited: its
condition ('running' not in result or 'not started' not in result) is
always True since a single status string can't contain both 'running'
and 'not started', so it returned on the first 0/2 exit regardless of
whether cloud-init had finished. On 26.04+ a degraded boot exits 2
before the first successful exec, so the helper returned a 'running'
status and test_lxd_datasource_kernel_override_nocloud_net's bare
.ok assertion failed.

Correct the helper to wait for a genuinely terminal status
(done/disabled/error/degraded) via _TERMINAL_STATUS, treating rc 1
(hard error) as terminal too; the caller decides whether degraded/2 is
acceptable. Because the helper now genuinely waits through a full
reboot, bump the three reboot-following call sites
(test_ds_identify, test_ansible, test_status) to num_retries=120.

Add exit-2 tolerance to test_lxd_datasource_kernel_override_nocloud_net,
mirroring test_lxd_discovery.py: with security.devlxd:False
the /dev/lxd/sock socket is absent, so DataSourceLXD's ds_detect logs a
warning and the boot is degraded.
```

## Additional Context
Potential impact of this fix is that certain integration tests may block for extended periods of time when they didn't previously correctly wait.

## Test Steps
```
# Assert no regressions on integration tests waiting on cloud-init 
tox -e integration-tests  -- tests/integration_tests/cmd/test_status.py tests/integration_tests/datasources/test_lxd_discovery.py tests/integration_tests/modules/test_ansible.py tests/integration_tests/modules/test_apt_functionality.py tests/integration_tests/modules/test_hotplug.py tests/integration_tests/modules/test_hotplug.py tests/integration_tests/test_ds_identify.py tests/integration_tests/test_kernel_command_line_match.py
```

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
