### PR TITLE
Add type annotations to functions in hostname.py

### DIFF
--- a/cloudinit/distros/parsers/hostname.py
+++ b/cloudinit/distros/parsers/hostname.py
@@ -11,15 +11,15 @@ from cloudinit.distros.parsers import chop_comment
 
 # Parser that knows how to work with /etc/hostname format
 class HostnameConf:
-    def __init__(self, text):
+    def __init__(self, text: str) -> None:
         self._text = text
         self._contents = None
 
-    def parse(self):
+    def parse(self) -> None:
         if self._contents is None:
             self._contents = self._parse(self._text)
 
-    def __str__(self):
+    def __str__(self) -> str:
         self.parse()
         contents = StringIO()
         for line_type, components in self._contents:
@@ -37,14 +37,14 @@ class HostnameConf:
         return contents
 
     @property
-    def hostname(self):
+    def hostname(self) -> str | None:
         self.parse()
         for line_type, components in self._contents:
             if line_type == "hostname":
                 return components[0]
         return None
 
-    def set_hostname(self, your_hostname):
+    def set_hostname(self, your_hostname: str) -> None:
         your_hostname = your_hostname.strip()
         if not your_hostname:
             return
@@ -57,7 +57,7 @@ class HostnameConf:
         if not replaced:
             self._contents.append(("hostname", [str(your_hostname), ""]))
 
-    def _parse(self, contents):
+    def _parse(self, contents: str) -> list[tuple[str, list[str]]]:
         entries = []
         hostnames_found = set()
         for line in contents.splitlines():

--- a/cloudinit/distros/parsers/hostname.py
+++ b/cloudinit/distros/parsers/hostname.py
@@ -5,6 +5,7 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
 from io import StringIO
+from typing import Optional
 
 from cloudinit.distros.parsers import chop_comment
 
@@ -37,7 +38,7 @@ class HostnameConf:
         return contents
 
     @property
-    def hostname(self) -> str | None:
+    def hostname(self) -> Optional[str]:
         self.parse()
         for line_type, components in self._contents:
             if line_type == "hostname":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,6 @@ module = [
     "cloudinit.distros.azurelinux",
     "cloudinit.distros.bsd",
     "cloudinit.distros.opensuse",
-    "cloudinit.distros.parsers.hostname",
     "cloudinit.distros.parsers.resolv_conf",
     "cloudinit.distros.ug_util",
     "cloudinit.helpers",

--- a/tests/unittests/distros/test_hostname.py
+++ b/tests/unittests/distros/test_hostname.py
@@ -1,4 +1,5 @@
 # This file is part of cloud-init. See LICENSE file for license information.
+import pytest
 from cloudinit.distros.parsers import hostname
 
 BASE_HOSTNAME = """
@@ -8,6 +9,20 @@ blahblah
 
 """
 BASE_HOSTNAME = BASE_HOSTNAME.strip()
+COMMENT_ONLY = """
+#SUPER-COOL-HOSTNAME
+
+
+"""
+COMMENT_ONLY = COMMENT_ONLY.strip()
+MORE_HOSTNAME = """
+#SUPER-COOL-HOSTNAME-MOREMORE
+iamhostnameone
+iamhostnametwo
+wearefriends
+inthispythonfile
+"""
+MORE_HOSTNAME = MORE_HOSTNAME.strip()
 
 
 class TestHostnameHelper:
@@ -34,3 +49,24 @@ class TestHostnameHelper:
 bbbbd
 """
         assert str(hn).strip() == expected_out.strip()
+
+    def test_no_hostname_returns_none(self):
+        hn = hostname.HostnameConf(COMMENT_ONLY)
+        assert hn.hostname is None
+
+    def test_set_hostname_appends_when_missing(self):
+        hn = hostname.HostnameConf(COMMENT_ONLY)
+        hn.set_hostname("newhost")
+        assert hn.hostname == "newhost"
+        line = str(hn).splitlines()
+        assert line[-1] == "newhost"
+
+    def test_multiple_hostnames_raises_ioerror(self):
+        hn = hostname.HostnameConf(MORE_HOSTNAME)
+        with pytest.raises(IOError):
+            _ = hn.hostname
+
+    def test_set_hostname_strips_whitespace(self):
+        hn = hostname.HostnameConf(BASE_HOSTNAME)
+        hn.set_hostname("    bbbbd   ")
+        assert hn.hostname == "bbbbd"


### PR DESCRIPTION
Add type annotations (parameter types and return types) to all functions in hostname.py, so a reader can tell at a glance what each function expects and returns.