### PR TITLE
Fix: DHCP lease warnings in CloudStack

### DIFF
--- a/tests/unittests/net/test_ephemeral.py
+++ b/tests/unittests/net/test_ephemeral.py
@@ -4,6 +4,7 @@ from unittest import mock
 
 import pytest
 
+from cloudinit.net.dhcp import NoDHCPLeaseError
 from cloudinit.net.ephemeral import EphemeralIPNetwork
 from cloudinit.subp import ProcessExecutionError
 from cloudinit.url_helper import UrlError
@@ -273,3 +274,20 @@ class TestEphemeralIPNetwork:
                 "No connectivity to IMDS, attempting DHCP setup."
                 in caplog.text
             )
+
+    def test_no_dhcp_lease_raises(self, mocker):
+        """Test that NoDHCPLeaseError is raised when no DHCP lease can be obtained."""
+        error = NoDHCPLeaseError()
+        mocker.patch.object(
+            EphemeralIPNetwork,
+            "_perform_ephemeral_network_setup",
+            return_value=(False, error),
+        )
+        mocker.patch(
+            M_PATH + "_check_connectivity_to_imds",
+            return_value=None,
+        )
+        distro = MockDistro()
+        with pytest.raises(NoDHCPLeaseError):
+            with EphemeralIPNetwork(distro, "eth0", ipv4=True, ipv6=False):
+                pass


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [ ] I have signed the CLA: https://ubuntu.com/legal/contributors
- [ ] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [ ] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e doc``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->

fix: DHCP lease warnings with valid lease in CloudStack

Fixes #6653


## Additional Context
- Fixes #6653 


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
