### PR TITLE
chore: add type annotations to cloudinit.sources.DataSourceOracle

### DIFF
--- a/cloudinit/sources/DataSourceOracle.py
+++ b/cloudinit/sources/DataSourceOracle.py
@@ -19,7 +19,15 @@ import ipaddress
 import json
 import logging
 import time
-from typing import Any, Dict, List, NamedTuple, Optional, Tuple
+from typing import (
+    Any,
+    ContextManager,
+    Dict,
+    List,
+    NamedTuple,
+    Optional,
+    Tuple,
+)
 
 from cloudinit import atomic_helper, dmi, net, sources, util
 from cloudinit.distros.networking import NetworkConfig
@@ -205,7 +213,7 @@ class DataSourceOracle(sources.DataSource):
 
         self.system_uuid = _read_system_uuid()
 
-        connectivity_urls_data = (
+        connectivity_urls_data: List[Dict[str, Any]] = [
             {
                 "url": IPV4_METADATA_PATTERN.format(
                     version=2, path="instance"
@@ -228,8 +236,9 @@ class DataSourceOracle(sources.DataSource):
                     version=1, path="instance"
                 ),
             },
-        )
+        ]
 
+        network_context: ContextManager
         if self.perform_dhcp_setup:
             nic_name = net.find_fallback_nic()
             network_context = ephemeral.EphemeralIPNetwork(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,6 @@ module = [
     "cloudinit.sources.DataSourceNoCloud",
     "cloudinit.sources.DataSourceOVF",
     "cloudinit.sources.DataSourceOpenStack",
-    "cloudinit.sources.DataSourceOracle",
     "cloudinit.sources.DataSourceRbxCloud",
     "cloudinit.sources.DataSourceScaleway",
     "cloudinit.sources.DataSourceSmartOS",

--- a/tests/unittests/sources/test_oracle.py
+++ b/tests/unittests/sources/test_oracle.py
@@ -233,7 +233,7 @@ ipv4_v2_instance_url = oracle.IPV4_METADATA_PATTERN.format(
     path="instance",
     version=2,
 )
-connectivity_urls_data = (
+connectivity_urls_data = [
     {
         "url": oracle.IPV4_METADATA_PATTERN.format(version=2, path="instance"),
         "headers": oracle.V2_HEADERS,
@@ -248,7 +248,7 @@ connectivity_urls_data = (
     {
         "url": oracle.IPV6_METADATA_PATTERN.format(version=1, path="instance"),
     },
-)
+]
 
 
 @pytest.fixture


### PR DESCRIPTION
## Proposed Commit Message

```
chore: add type annotations to cloudinit.sources.DataSourceOracle

Annotate connectivity_urls_data as List[Dict[str, Any]] and declare
network_context as a ContextManager so the module passes mypy's
check_untyped_defs, then drop it from the override list in
pyproject.toml.

connectivity_urls_data was built as a tuple while EphemeralIPNetwork
expects a list; building it as a list also fixes the inferred type.

Refs GH-5445
```

## Additional Context

Part of the incremental mypy adoption tracked in GH-5445 (one module per PR, as requested there).

Verified with the project's pinned mypy (1.19.1): `mypy cloudinit/ tests/ tools/` reports no issues in 591 source files, and the full unit suite passes (5,742 tests) via `python -m pytest tests/unittests/`.

## Test Steps

```
tox -e py3 -- tests/unittests/sources/test_oracle.py
mypy cloudinit/sources/DataSourceOracle.py
```

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
