### PR TITLE
fix(stages): recover if /var/lib/cloud/instance is a directory

### DIFF
--- a/cloudinit/stages.py
+++ b/cloudinit/stages.py
@@ -228,11 +228,11 @@ class Init:
 
     def purge_cache(self, rm_instance_lnk=False):
         rm_list = [self.paths.boot_finished]
-        if rm_instance_lnk:
-            rm_list.append(self.paths.instance_link)
         for f in rm_list:
             util.del_file(f)
-        return len(rm_list)
+        if rm_instance_lnk:
+            self._remove_stale_instance_link()
+        return len(rm_list) + int(rm_instance_lnk)
 
     def initialize(self):
         self._initialize_filesystem()
@@ -397,7 +397,7 @@ class Init:
                     pkg_list,
                     self.reporter,
                 )
-                util.del_file(self.paths.instance_link)
+                self._remove_stale_instance_link()
                 LOG.info("Loaded datasource %s - %s", dsname, ds)
             except sources.DataSourceNotFoundException as e:
                 if existing != "check":
@@ -409,7 +409,7 @@ class Init:
                         ds,
                     )
                 else:
-                    util.del_file(self.paths.instance_link)
+                    self._remove_stale_instance_link()
                     raise e
         self.datasource = ds
         # Ensure we adjust our path members datasource
@@ -458,6 +458,77 @@ class Init:
         if not os.path.islink(network_link):
             util.sym_link(ncfg_instance_path, network_link)
 
+    def _remove_stale_instance_link(self):
+        """Best-effort removal of paths.instance_link.
+
+        paths.instance_link (/var/lib/cloud/instance by default) is only
+        ever supposed to be a symlink into instances/<iid>, or absent --
+        cloud-init itself never creates it as a plain directory. In
+        practice, though, it has been observed as a real directory in a
+        handful of separate reports over the years (GH-3710/LP:#1883903,
+        GH-4282), typically because something -- inside or outside
+        cloud-init -- wrote into a path nested under it (e.g. via
+        write_file(..., ensure_dir_exists=True), whose default silently
+        creates the missing parent as a plain directory) before the
+        symlink had been (re-)created for the current boot.
+
+        When that happens, a plain os.unlink() (what util.del_file does)
+        raises an uncaught IsADirectoryError, aborting the entire boot
+        stage before any further modules can run -- a disproportionate
+        failure mode for what is, by definition, always safe to remove
+        and recreate: nothing is meant to persist at this path itself,
+        only beneath the real instance directory it points to.
+
+        We cannot always prevent whatever caused the promotion (it may
+        originate outside cloud-init's control), but every consumer of
+        this invariant only ever needs the removal itself to succeed --
+        whether it goes on to immediately recreate the symlink (as
+        _reflect_cur_instance does) or deliberately leaves the path
+        absent until a later stage recreates it (as purge_cache and
+        _get_data_source do) -- so healing it at the point of removal is
+        sufficient to stop cloud-init itself from crashing on it,
+        regardless of which caller reaches it first. This does not
+        silence the underlying cause -- it is logged at WARNING so it
+        remains visible/greppable for anyone diagnosing why it happened.
+
+        Used by every place in this class that unconditionally relies on
+        the "symlink or absent" invariant: _get_data_source() (both after
+        a fresh find_source() and in the no-fallback exception path),
+        purge_cache(rm_instance_lnk=True), and _reflect_cur_instance().
+
+        Safety: util.del_dir() (shutil.rmtree()) never follows a
+        top-level symlink (raises instead -- and we've already excluded
+        that case via the islink() check below regardless), and never
+        follows any symlinks *nested inside* the directory being removed
+        into their targets -- it only unlinks the symlink entries
+        themselves, so a stray symlink planted inside this path cannot
+        cause anything outside of it to be deleted. The one case
+        deliberately excluded from the directory branch below is a
+        mount point: rmtree has no filesystem-boundary awareness and
+        would recurse into (and delete the contents of) whatever is
+        mounted there before failing on the mount point itself, which
+        would be a strictly larger blast radius than this function ever
+        had before. Falling through to the plain del_file() branch for
+        that case reproduces the original (safe, non-destructive,
+        loudly-failing) IsADirectoryError behavior instead.
+        """
+        path = self.paths.instance_link
+        if (
+            os.path.isdir(path)
+            and not os.path.islink(path)
+            and not os.path.ismount(path)
+        ):
+            LOG.warning(
+                "%s unexpectedly exists as a directory rather than a "
+                "symlink; removing it so it can be recreated. This "
+                "usually means something wrote into this path before "
+                "cloud-init (re-)created the instance symlink here.",
+                path,
+            )
+            util.del_dir(path)
+        else:
+            util.del_file(path)
+
     def _reflect_cur_instance(self):
         # Remove the old symlink and attach a new one so
         # that further reads/writes connect into the right location
@@ -467,7 +538,7 @@ class Init:
         if already_instancified:
             LOG.info("Instance link already exists, not recreating it.")
         else:
-            util.del_file(self.paths.instance_link)
+            self._remove_stale_instance_link()
             util.sym_link(idir, self.paths.instance_link)
 
         # Ensures these dirs exist

--- a/tests/unittests/test_stages.py
+++ b/tests/unittests/test_stages.py
@@ -655,6 +655,269 @@ class TestInit:
         )
 
 
+class TestInit_ReflectCurInstance:
+    """Tests for Init._reflect_cur_instance and Init._remove_stale_instance_link.
+
+    Regression coverage for the class of bug where paths.instance_link
+    (/var/lib/cloud/instance by default) is found to be a real directory
+    instead of the symlink cloud-init always expects it to be (or absent).
+    Previously this made the unconditional util.del_file() call in
+    _reflect_cur_instance raise an uncaught IsADirectoryError, aborting the
+    entire 'init' stage before any cloud-config modules could run. See
+    GH-3710/LP:#1883903 (a confirmed prior instance of this exact mechanism,
+    via cc_final_message) and GH-4282 (an unresolved recurrence of the same
+    symptom in a later cloud-init version).
+    """
+
+    @pytest.fixture
+    def init(self, paths):
+        """A stages.Init wired with a real (tmpdir-backed) Paths object and
+        a FakeDataSource, so _get_ipath()/_reflect_cur_instance() can run
+        end-to-end against real filesystem state.
+
+        Paths.get_ipath() (which _get_ipath()/_reflect_cur_instance() rely
+        on) reads paths.datasource directly, a separate attribute from
+        Init.datasource, so both must be set to the same datasource here.
+
+        _cfg is set to a non-empty dict rather than {}: Init.read_cfg()'s
+        guard is `if not self._cfg`, so an empty-but-set dict is still
+        treated as "not yet read" and would trigger a real (unmocked)
+        config load -- including a subp call -- the first time something
+        in _reflect_cur_instance()/_write_to_cache() touches self.cfg.
+        """
+        init = stages.Init()
+        init._cfg = {"i_dont_care": "about-this-value"}
+        init._paths = paths
+        ds = FakeDataSource(paths=paths)
+        init.datasource = ds
+        paths.datasource = ds
+        return init
+
+    # _remove_stale_instance_link is exercised end-to-end through both of
+    # its callers below, but it's also tested here in isolation: it's a
+    # single-responsibility helper with its own contract (heal a directory,
+    # otherwise behave exactly like the plain del_file it replaced), and
+    # testing it directly documents that contract independently of either
+    # caller's surrounding logic.
+    def test_remove_stale_instance_link_heals_real_directory(
+        self, init, caplog
+    ):
+        instance_link = init.paths.instance_link
+        os.makedirs(instance_link)
+
+        init._remove_stale_instance_link()
+
+        assert not os.path.exists(instance_link)
+        assert (
+            "unexpectedly exists as a directory rather than a symlink"
+            in caplog.text
+        )
+
+    def test_remove_stale_instance_link_removes_symlink_silently(
+        self, init, tmpdir, caplog
+    ):
+        """A valid symlink (even to a nonexistent target, as when a
+        previous instance directory was already cleaned up) is removed
+        via the original plain del_file path, with no warning logged."""
+        instance_link = init.paths.instance_link
+        os.symlink(str(tmpdir.join("some-instance-dir")), instance_link)
+
+        init._remove_stale_instance_link()
+
+        assert not os.path.exists(instance_link)
+        assert "unexpectedly exists as a directory" not in caplog.text
+
+    def test_remove_stale_instance_link_absent_is_a_noop(self, init, caplog):
+        instance_link = init.paths.instance_link
+        assert not os.path.exists(instance_link)
+
+        init._remove_stale_instance_link()
+
+        assert not os.path.exists(instance_link)
+        assert "unexpectedly exists as a directory" not in caplog.text
+
+    def test_remove_stale_instance_link_does_not_follow_nested_symlinks(
+        self, init, tmpdir
+    ):
+        """Safety property: healing a real directory at instance_link
+        must never delete anything a symlink *inside* it points to --
+        only the symlink entry itself. shutil.rmtree() already guarantees
+        this (verified independently against the stdlib), but this test
+        pins the guarantee against this specific code path so a future
+        change to how the directory is removed can't silently regress it.
+        """
+        important_elsewhere = tmpdir.mkdir("important_elsewhere")
+        important_elsewhere.join("precious.txt").write("precious data")
+
+        instance_link = init.paths.instance_link
+        os.makedirs(instance_link)
+        os.symlink(
+            str(important_elsewhere),
+            os.path.join(instance_link, "nested_symlink"),
+        )
+
+        init._remove_stale_instance_link()
+
+        assert not os.path.exists(instance_link)
+        assert important_elsewhere.exists()
+        assert important_elsewhere.join("precious.txt").exists()
+
+    def test_remove_stale_instance_link_refuses_to_rmtree_a_mount_point(
+        self, init
+    ):
+        """Safety property: a mount point at instance_link must never be
+        recursively deleted -- rmtree has no filesystem-boundary
+        awareness and would delete the mounted filesystem's *contents*
+        before failing on the mount point itself, a strictly larger
+        blast radius than this function is meant to have. Falls through
+        to the plain (non-destructive) del_file() path instead, which
+        reproduces the original IsADirectoryError for this one case --
+        a real mount point can't be created without root, so this is
+        exercised via a targeted mock instead."""
+        instance_link = init.paths.instance_link
+        os.makedirs(instance_link)
+
+        with mock.patch("os.path.ismount", return_value=True):
+            with pytest.raises(IsADirectoryError):
+                init._remove_stale_instance_link()
+
+        # Nothing was deleted: del_file's plain os.unlink() failed
+        # immediately and left the (simulated) mount point fully intact.
+        assert os.path.isdir(instance_link)
+
+    # _get_data_source() has two more call sites for the same instance_link
+    # removal, reached well before _reflect_cur_instance()/purge_cache() in
+    # a real boot. Exercising it end-to-end would require mocking the whole
+    # datasource-discovery machinery (_restore_from_checked_cache,
+    # sources.find_source, etc. -- none of which has any existing test
+    # coverage in this file to build on), which is disproportionate given
+    # _remove_stale_instance_link()'s own behavior is already fully covered
+    # above. Instead, these two tests only confirm each call site is wired
+    # to the shared, already-tested helper -- not full filesystem behavior.
+    def test_get_data_source_removes_stale_instance_link_after_new_source(
+        self, init
+    ):
+        init.datasource = None
+        with mock.patch.object(
+            init, "_restore_from_checked_cache", return_value=(None, "n/a")
+        ), mock.patch.object(
+            init, "_remove_stale_instance_link"
+        ) as m_remove, mock.patch.object(
+            sources, "find_source", return_value=(FakeDataSource(), "Fake")
+        ):
+            init._get_data_source(existing="trust")
+
+        m_remove.assert_called_once()
+
+    def test_get_data_source_removes_stale_instance_link_on_no_fallback(
+        self, init
+    ):
+        init.datasource = None
+        with mock.patch.object(
+            init, "_restore_from_checked_cache", return_value=(None, "n/a")
+        ), mock.patch.object(
+            init, "_remove_stale_instance_link"
+        ) as m_remove, mock.patch.object(
+            sources,
+            "find_source",
+            side_effect=sources.DataSourceNotFoundException(),
+        ), mock.patch.object(
+            init, "_restore_from_cache", return_value=None
+        ):
+            with pytest.raises(sources.DataSourceNotFoundException):
+                init._get_data_source(existing="check")
+
+        m_remove.assert_called_once()
+
+    def test_reflect_cur_instance_normal_case(self, init):
+        """Baseline: instance_link absent beforehand (the common case on a
+        VM's first boot) ends up as a symlink to the instance directory."""
+        instance_link = init.paths.instance_link
+        assert not os.path.exists(instance_link)
+        # Captured before the call: _reflect_cur_instance() resets cached
+        # cfg/paths at the end, so a *second* call to _get_ipath() after it
+        # would trigger a real (unmocked) config re-read.
+        expected_idir = init._get_ipath()
+
+        init._reflect_cur_instance()
+
+        assert os.path.islink(instance_link)
+        assert os.path.realpath(instance_link) == os.path.realpath(
+            expected_idir
+        )
+
+    def test_reflect_cur_instance_replaces_existing_symlink(
+        self, init, tmpdir
+    ):
+        """A pre-existing (stale, e.g. prior-instance) symlink is replaced
+        without error -- this is the expected steady-state behavior."""
+        instance_link = init.paths.instance_link
+        stale_target = tmpdir.mkdir("stale-target")
+        os.symlink(str(stale_target), instance_link)
+        expected_idir = init._get_ipath()
+
+        init._reflect_cur_instance()
+
+        assert os.path.islink(instance_link)
+        assert os.path.realpath(instance_link) == os.path.realpath(
+            expected_idir
+        )
+
+    def test_reflect_cur_instance_heals_stale_directory(self, init, caplog):
+        """Regression test: if instance_link is a real directory instead of
+        a symlink (the promotion bug -- e.g. from some code writing into a
+        path under it via ensure_dir_exists=True before the symlink was
+        (re)created), _reflect_cur_instance must heal it rather than crash
+        with IsADirectoryError."""
+        instance_link = init.paths.instance_link
+        os.makedirs(instance_link)
+        # Simulate a stray write that landed in the wrongly-promoted
+        # directory, matching real-world reports of this failure.
+        with open(os.path.join(instance_link, "some-stray-file"), "w") as f:
+            f.write("stray")
+        expected_idir = init._get_ipath()
+
+        init._reflect_cur_instance()
+
+        assert os.path.islink(instance_link)
+        assert os.path.realpath(instance_link) == os.path.realpath(
+            expected_idir
+        )
+        assert (
+            "unexpectedly exists as a directory rather than a symlink"
+            in caplog.text
+        )
+
+    def test_purge_cache_heals_stale_directory(self, init):
+        """purge_cache(rm_instance_lnk=True) exercises the same
+        instance_link removal path (this is the call site that a separate
+        real-world report, GH-4282, crashed in) and must be equally
+        tolerant of the directory case."""
+        instance_link = init.paths.instance_link
+        os.makedirs(instance_link)
+
+        count = init.purge_cache(rm_instance_lnk=True)
+
+        assert not os.path.exists(instance_link)
+        # 2 == len([boot_finished]) + 1 for instance_link: purge_cache's
+        # return value is a count of paths purged, unrelated to this
+        # fix's own behavior, but pinned here so a future change to that
+        # contract doesn't silently drift unnoticed.
+        assert count == 2
+
+    def test_purge_cache_missing_instance_link_is_a_noop(self, init):
+        """purge_cache(rm_instance_lnk=True) must not raise when
+        instance_link does not exist at all (the common case)."""
+        instance_link = init.paths.instance_link
+        assert not os.path.exists(instance_link)
+
+        count = init.purge_cache(rm_instance_lnk=True)
+
+        assert not os.path.exists(instance_link)
+        # See test_purge_cache_heals_stale_directory for why 2.
+        assert count == 2
+
+
 class TestInit_InitializeFilesystem:
     """Tests for cloudinit.stages.Init._initialize_filesystem.
 

--- a/tests/unittests/test_stages.py
+++ b/tests/unittests/test_stages.py
@@ -655,6 +655,270 @@ class TestInit:
         )
 
 
+class TestInit_ReflectCurInstance:
+    """Tests for Init._reflect_cur_instance and
+    Init._remove_stale_instance_link.
+
+    Regression coverage for the class of bug where paths.instance_link
+    (/var/lib/cloud/instance by default) is found to be a real directory
+    instead of the symlink cloud-init always expects it to be (or absent).
+    Previously this made the unconditional util.del_file() call in
+    _reflect_cur_instance raise an uncaught IsADirectoryError, aborting the
+    entire 'init' stage before any cloud-config modules could run. See
+    GH-3710/LP:#1883903 (a confirmed prior instance of this exact mechanism,
+    via cc_final_message) and GH-4282 (an unresolved recurrence of the same
+    symptom in a later cloud-init version).
+    """
+
+    @pytest.fixture
+    def init(self, paths):
+        """A stages.Init wired with a real (tmpdir-backed) Paths object and
+        a FakeDataSource, so _get_ipath()/_reflect_cur_instance() can run
+        end-to-end against real filesystem state.
+
+        Paths.get_ipath() (which _get_ipath()/_reflect_cur_instance() rely
+        on) reads paths.datasource directly, a separate attribute from
+        Init.datasource, so both must be set to the same datasource here.
+
+        _cfg is set to a non-empty dict rather than {}: Init.read_cfg()'s
+        guard is `if not self._cfg`, so an empty-but-set dict is still
+        treated as "not yet read" and would trigger a real (unmocked)
+        config load -- including a subp call -- the first time something
+        in _reflect_cur_instance()/_write_to_cache() touches self.cfg.
+        """
+        init = stages.Init()
+        init._cfg = {"i_dont_care": "about-this-value"}
+        init._paths = paths
+        ds = FakeDataSource(paths=paths)
+        init.datasource = ds
+        paths.datasource = ds
+        return init
+
+    # _remove_stale_instance_link is exercised end-to-end through both of
+    # its callers below, but it's also tested here in isolation: it's a
+    # single-responsibility helper with its own contract (heal a directory,
+    # otherwise behave exactly like the plain del_file it replaced), and
+    # testing it directly documents that contract independently of either
+    # caller's surrounding logic.
+    def test_remove_stale_instance_link_heals_real_directory(
+        self, init, caplog
+    ):
+        instance_link = init.paths.instance_link
+        os.makedirs(instance_link)
+
+        init._remove_stale_instance_link()
+
+        assert not os.path.exists(instance_link)
+        assert (
+            "unexpectedly exists as a directory rather than a symlink"
+            in caplog.text
+        )
+
+    def test_remove_stale_instance_link_removes_symlink_silently(
+        self, init, tmpdir, caplog
+    ):
+        """A valid symlink (even to a nonexistent target, as when a
+        previous instance directory was already cleaned up) is removed
+        via the original plain del_file path, with no warning logged."""
+        instance_link = init.paths.instance_link
+        os.symlink(str(tmpdir.join("some-instance-dir")), instance_link)
+
+        init._remove_stale_instance_link()
+
+        assert not os.path.exists(instance_link)
+        assert "unexpectedly exists as a directory" not in caplog.text
+
+    def test_remove_stale_instance_link_absent_is_a_noop(self, init, caplog):
+        instance_link = init.paths.instance_link
+        assert not os.path.exists(instance_link)
+
+        init._remove_stale_instance_link()
+
+        assert not os.path.exists(instance_link)
+        assert "unexpectedly exists as a directory" not in caplog.text
+
+    def test_remove_stale_instance_link_does_not_follow_nested_symlinks(
+        self, init, tmpdir
+    ):
+        """Safety property: healing a real directory at instance_link
+        must never delete anything a symlink *inside* it points to --
+        only the symlink entry itself. shutil.rmtree() already guarantees
+        this (verified independently against the stdlib), but this test
+        pins the guarantee against this specific code path so a future
+        change to how the directory is removed can't silently regress it.
+        """
+        important_elsewhere = tmpdir.mkdir("important_elsewhere")
+        important_elsewhere.join("precious.txt").write("precious data")
+
+        instance_link = init.paths.instance_link
+        os.makedirs(instance_link)
+        os.symlink(
+            str(important_elsewhere),
+            os.path.join(instance_link, "nested_symlink"),
+        )
+
+        init._remove_stale_instance_link()
+
+        assert not os.path.exists(instance_link)
+        assert important_elsewhere.exists()
+        assert important_elsewhere.join("precious.txt").exists()
+
+    def test_remove_stale_instance_link_refuses_to_rmtree_a_mount_point(
+        self, init
+    ):
+        """Safety property: a mount point at instance_link must never be
+        recursively deleted -- rmtree has no filesystem-boundary
+        awareness and would delete the mounted filesystem's *contents*
+        before failing on the mount point itself, a strictly larger
+        blast radius than this function is meant to have. Falls through
+        to the plain (non-destructive) del_file() path instead, which
+        reproduces the original IsADirectoryError for this one case --
+        a real mount point can't be created without root, so this is
+        exercised via a targeted mock instead."""
+        instance_link = init.paths.instance_link
+        os.makedirs(instance_link)
+
+        with mock.patch("os.path.ismount", return_value=True):
+            with pytest.raises(IsADirectoryError):
+                init._remove_stale_instance_link()
+
+        # Nothing was deleted: del_file's plain os.unlink() failed
+        # immediately and left the (simulated) mount point fully intact.
+        assert os.path.isdir(instance_link)
+
+    # _get_data_source() has two more call sites for the same instance_link
+    # removal, reached well before _reflect_cur_instance()/purge_cache() in
+    # a real boot. Exercising it end-to-end would require mocking the whole
+    # datasource-discovery machinery (_restore_from_checked_cache,
+    # sources.find_source, etc. -- none of which has any existing test
+    # coverage in this file to build on), which is disproportionate given
+    # _remove_stale_instance_link()'s own behavior is already fully covered
+    # above. Instead, these two tests only confirm each call site is wired
+    # to the shared, already-tested helper -- not full filesystem behavior.
+    def test_get_data_source_removes_stale_instance_link_after_new_source(
+        self, init
+    ):
+        init.datasource = None
+        with mock.patch.object(
+            init, "_restore_from_checked_cache", return_value=(None, "n/a")
+        ), mock.patch.object(
+            init, "_remove_stale_instance_link"
+        ) as m_remove, mock.patch.object(
+            sources, "find_source", return_value=(FakeDataSource(), "Fake")
+        ):
+            init._get_data_source(existing="trust")
+
+        m_remove.assert_called_once()
+
+    def test_get_data_source_removes_stale_instance_link_on_no_fallback(
+        self, init
+    ):
+        init.datasource = None
+        with mock.patch.object(
+            init, "_restore_from_checked_cache", return_value=(None, "n/a")
+        ), mock.patch.object(
+            init, "_remove_stale_instance_link"
+        ) as m_remove, mock.patch.object(
+            sources,
+            "find_source",
+            side_effect=sources.DataSourceNotFoundException(),
+        ), mock.patch.object(
+            init, "_restore_from_cache", return_value=None
+        ):
+            with pytest.raises(sources.DataSourceNotFoundException):
+                init._get_data_source(existing="check")
+
+        m_remove.assert_called_once()
+
+    def test_reflect_cur_instance_normal_case(self, init):
+        """Baseline: instance_link absent beforehand (the common case on a
+        VM's first boot) ends up as a symlink to the instance directory."""
+        instance_link = init.paths.instance_link
+        assert not os.path.exists(instance_link)
+        # Captured before the call: _reflect_cur_instance() resets cached
+        # cfg/paths at the end, so a *second* call to _get_ipath() after it
+        # would trigger a real (unmocked) config re-read.
+        expected_idir = init._get_ipath()
+
+        init._reflect_cur_instance()
+
+        assert os.path.islink(instance_link)
+        assert os.path.realpath(instance_link) == os.path.realpath(
+            expected_idir
+        )
+
+    def test_reflect_cur_instance_replaces_existing_symlink(
+        self, init, tmpdir
+    ):
+        """A pre-existing (stale, e.g. prior-instance) symlink is replaced
+        without error -- this is the expected steady-state behavior."""
+        instance_link = init.paths.instance_link
+        stale_target = tmpdir.mkdir("stale-target")
+        os.symlink(str(stale_target), instance_link)
+        expected_idir = init._get_ipath()
+
+        init._reflect_cur_instance()
+
+        assert os.path.islink(instance_link)
+        assert os.path.realpath(instance_link) == os.path.realpath(
+            expected_idir
+        )
+
+    def test_reflect_cur_instance_heals_stale_directory(self, init, caplog):
+        """Regression test: if instance_link is a real directory instead of
+        a symlink (the promotion bug -- e.g. from some code writing into a
+        path under it via ensure_dir_exists=True before the symlink was
+        (re)created), _reflect_cur_instance must heal it rather than crash
+        with IsADirectoryError."""
+        instance_link = init.paths.instance_link
+        os.makedirs(instance_link)
+        # Simulate a stray write that landed in the wrongly-promoted
+        # directory, matching real-world reports of this failure.
+        with open(os.path.join(instance_link, "some-stray-file"), "w") as f:
+            f.write("stray")
+        expected_idir = init._get_ipath()
+
+        init._reflect_cur_instance()
+
+        assert os.path.islink(instance_link)
+        assert os.path.realpath(instance_link) == os.path.realpath(
+            expected_idir
+        )
+        assert (
+            "unexpectedly exists as a directory rather than a symlink"
+            in caplog.text
+        )
+
+    def test_purge_cache_heals_stale_directory(self, init):
+        """purge_cache(rm_instance_lnk=True) exercises the same
+        instance_link removal path (this is the call site that a separate
+        real-world report, GH-4282, crashed in) and must be equally
+        tolerant of the directory case."""
+        instance_link = init.paths.instance_link
+        os.makedirs(instance_link)
+
+        count = init.purge_cache(rm_instance_lnk=True)
+
+        assert not os.path.exists(instance_link)
+        # 2 == len([boot_finished]) + 1 for instance_link: purge_cache's
+        # return value is a count of paths purged, unrelated to this
+        # fix's own behavior, but pinned here so a future change to that
+        # contract doesn't silently drift unnoticed.
+        assert count == 2
+
+    def test_purge_cache_missing_instance_link_is_a_noop(self, init):
+        """purge_cache(rm_instance_lnk=True) must not raise when
+        instance_link does not exist at all (the common case)."""
+        instance_link = init.paths.instance_link
+        assert not os.path.exists(instance_link)
+
+        count = init.purge_cache(rm_instance_lnk=True)
+
+        assert not os.path.exists(instance_link)
+        # See test_purge_cache_heals_stale_directory for why 2.
+        assert count == 2
+
+
 class TestInit_InitializeFilesystem:
     """Tests for cloudinit.stages.Init._initialize_filesystem.
 


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [ ] I have signed the CLA: https://ubuntu.com/legal/contributors
- [x] I have included a comprehensive commit message using the guide below
- [x] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [x] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [x] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e doc``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix(stages): recover if /var/lib/cloud/instance is a directory

/var/lib/cloud/instance is only ever supposed to be a symlink into
instances/<iid>, or absent. Several places in Init unconditionally
call util.del_file() on it -- a plain os.unlink() -- which raises an
uncaught IsADirectoryError if the path is ever found to be a real
directory instead, aborting the boot stage before any further
modules can run.

This exact symptom has recurred more than once (GH-3710 /
LP:#1883903, fixed narrowly for one call site in 20.3; GH-4282, an
unresolved recurrence closed for lack of a reproduction). Rather
than chasing every possible writer that could promote this path,
this hardens every call site in Init that consumes the "symlink or
absent" invariant (purge_cache(), _get_data_source(), and
_reflect_cur_instance()) through one shared helper: if the path is
found to be a directory, log a warning and remove it recursively so
it can be recreated, instead of crashing.

The removal is scoped defensively: it never touches a mount point
(falls back to the original, non-destructive del_file() for that one
case instead of recursing into it), and shutil.rmtree() itself already
guarantees it won't follow a top-level symlink or any symlink nested
inside the directory being removed into its target.

Fixes GH-6979
```

## Additional Context

Filed as GH-6979 first, with the full symptom writeup (traceback,
`status.json`, and a structural observation about when in the boot the
directory-promotion must occur, since `init-local`'s own
`_reflect_cur_instance()` call always succeeds moments before the
crashing one). This PR is the candidate fix offered at the end of that
issue.

While investigating, I found the same "unguarded `write_file()` under
the not-yet-created `instance_link`" anti-pattern that caused GH-3710
still exists today in `cc_snap.py`'s `snapd.assertions` write (it never
got the `ensure_dir_exists=False` fix `cc_final_message` received in
20.3). Not fixed here since it's an independent, narrower issue and I
have no evidence it's actually implicated in GH-6979 specifically --
flagging it here in case a maintainer wants a separate small PR for it,
or wants it folded into this one instead.

This PR intentionally does not identify or fix whatever causes the
directory promotion in the first place -- seeing that mechanism was
already effectively out of scope for GH-4282's own multi-year, never-
resolved attempt at the same question. It makes cloud-init resilient
to the *symptom* regardless of cause, at the one place in the codebase
that can make that guarantee for the whole bug class.

**Safety review of the removal itself:** the new helper uses
`shutil.rmtree()` (via `util.del_dir()`) rather than `os.unlink()` for
the directory case, so I specifically checked it can't be tricked into
deleting more than intended. Confirmed independently that `rmtree()`
already refuses to operate on a top-level symlink and never follows
symlinks nested *inside* the directory being removed into their
targets (only the symlink entries themselves are unlinked) -- both
pinned with regression tests now. Also found and fixed one real gap:
`rmtree()` has no filesystem-boundary awareness, so if
`instance_link` were ever a mount point rather than an ordinary
directory, it would have recursed into and deleted the *mounted
filesystem's contents* before failing on the mount point itself -- a
strictly larger blast radius than the crash this PR replaces. Added an
`os.path.ismount()` guard so that case falls through to the original
`del_file()` behavior instead (the same `IsADirectoryError` as before,
for that one case, rather than deleting anything).

## Test Steps

Added regression tests in `tests/unittests/test_stages.py`
(`TestInit_ReflectCurInstance`) that:

- Reproduce the exact reported traceback against the unpatched code
  (verified locally: both `_reflect_cur_instance()` and
  `purge_cache(rm_instance_lnk=True)` fail with `IsADirectoryError:
  [Errno 21] Is a directory: '.../instance'` without this change,
  matching the field report byte for byte) and confirm the fix heals
  them.
- Cover the shared helper (`_remove_stale_instance_link`) directly and
  in isolation: real-directory (heals + warns), valid symlink including
  a dangling one (silent, unchanged behavior), and absent (no-op).
- Cover both `_get_data_source()` call sites via lighter "is it wired to
  the tested helper" tests (mocking the datasource-discovery machinery
  those call sites depend on, rather than re-deriving full filesystem
  behavior that's already covered above).
- Add baseline coverage for the normal cases, none of which had any
  direct test coverage before this change.
- Pin the two safety properties above: a nested symlink inside the
  healed directory survives untouched, and a (mocked) mount point at
  `instance_link` is never recursed into.

Run with:
```console
tox -e py3 -- tests/unittests/test_stages.py -v -k ReflectCurInstance
```

Full suite comparison against an unmodified `main`: **5754 passed** with
this change vs. **5742 passed** on baseline -- exactly the 12 tests added
here, zero regressions. `black`, `isort`, and `pylint` (this repo's
currently pinned versions) all clean; `pylint` 10.00/10.

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)

