### PR TITLE
doc: update LXD docs URLs

### DIFF
--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -2049,7 +2049,7 @@
             },
             "preseed": {
               "type": "string",
-              "description": "Opaque LXD preseed YAML config passed via stdin to the command: lxd init --preseed. See: https://documentation.ubuntu.com/lxd/en/latest/howto/initialize/#non-interactive-configuration or lxd init --dump for viable config. Can not be combined with either **lxd.init** or **lxd.bridge**."
+              "description": "Opaque LXD preseed YAML config passed via stdin to the command: lxd init --preseed. See: https://canonical.com/lxd/docs/latest/howto/initialize/#non-interactive-configuration or lxd init --dump for viable config. Can not be combined with either **lxd.init** or **lxd.bridge**."
             }
           }
         }

--- a/cloudinit/sources/DataSourceLXD.py
+++ b/cloudinit/sources/DataSourceLXD.py
@@ -5,7 +5,7 @@ Notes:
  * Older LXD images may not have updates for cloud-init so NoCloud may
    still be detected on those images.
  * Detect LXD datasource when /dev/lxd/sock is an active socket file.
- * Info on dev-lxd API: https://documentation.ubuntu.com/lxd/en/latest/dev-lxd/
+ * Info on dev-lxd API: https://canonical.com/lxd/docs/latest/dev-lxd/
 """
 
 import logging

--- a/doc/module-docs/cc_lxd/data.yaml
+++ b/doc/module-docs/cc_lxd/data.yaml
@@ -22,7 +22,7 @@ cc_lxd:
       ``lxd init --preseed``.
 
       See the
-      `LXD non-interactive configuration <https://documentation.ubuntu.com/lxd/en/latest/howto/initialize/#non-interactive-configuration>`_
+      `LXD non-interactive configuration <https://canonical.com/lxd/docs/latest/howto/initialize/#non-interactive-configuration>`_
       or run ``lxd init --dump`` to see viable preseed YAML allowed.
 
       Preseed settings configuring the LXD daemon for HTTPS connections on

--- a/doc/rtd/howto/launch_lxd.rst
+++ b/doc/rtd/howto/launch_lxd.rst
@@ -70,5 +70,5 @@ custom network config and using LXD with cloud-init.
 
 .. LINKS
 .. _LXD: https://ubuntu.com/lxd
-.. _Instance Configuration: https://documentation.ubuntu.com/lxd/en/latest/instances/
-.. _Custom Network Configuration: https://documentation.ubuntu.com/lxd/en/latest/cloud-init/
+.. _Instance Configuration: https://canonical.com/lxd/docs/latest/instances/
+.. _Custom Network Configuration: https://canonical.com/lxd/docs/latest/cloud-init/

--- a/doc/rtd/reference/datasources/lxd.rst
+++ b/doc/rtd/reference/datasources/lxd.rst
@@ -103,4 +103,4 @@ DHCP configuration of ``eth1``:
     $ lxc config device add my-lxd eth1 nic name=eth1 nictype=bridged parent=my-bridge
     Device eth1 added to my-lxd
 
-.. _LXD socket device: https://documentation.ubuntu.com/lxd/en/latest/dev-lxd/
+.. _LXD socket device: https://canonical.com/lxd/docs/latest/dev-lxd/

--- a/doc/rtd/reference/network-config.rst
+++ b/doc/rtd/reference/network-config.rst
@@ -311,7 +311,7 @@ Example output:
    USERCTL=no
 
 
-.. _LXD: https://documentation.ubuntu.com/lxd/en/latest/cloud-init/#how-to-specify-network-configuration-data
+.. _LXD: https://canonical.com/lxd/docs/latest/cloud-init/#how-to-specify-network-configuration-data
 .. _NetworkManager: https://networkmanager.dev
 .. _Netplan: https://netplan.io/
 .. _DigitalOcean JSON meta-data: https://developers.digitalocean.com/documentation/metadata/

--- a/doc/rtd/reference/yaml_examples/lxd.rst
+++ b/doc/rtd/reference/yaml_examples/lxd.rst
@@ -55,4 +55,4 @@ behavior for sub-projects.
    :linenos:
 
 .. LINKS
-.. _non-interactive LXD configuration: https://documentation.ubuntu.com/lxd/en/latest/howto/initialize/#non-interactive-configuration
+.. _non-interactive LXD configuration: https://canonical.com/lxd/docs/latest/howto/initialize/#non-interactive-configuration

--- a/doc/rtd/tutorial/lxd.rst
+++ b/doc/rtd/tutorial/lxd.rst
@@ -159,4 +159,4 @@ You can also head over to the :ref:`examples page<yaml_examples>` for
 examples of more common use cases.
 
 .. _LXD: https://ubuntu.com/lxd
-.. _other installation options: https://documentation.ubuntu.com/lxd/en/latest/installing/
+.. _other installation options: https://canonical.com/lxd/docs/latest/installing/

--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -981,7 +981,7 @@ get_single_line_flow_sequence() {
 }
 
 # LXD datasource requires active /dev/lxd/sock
-# https://documentation.ubuntu.com/lxd/en/latest/dev-lxd/
+# https://canonical.com/lxd/docs/latest/dev-lxd/
 dscheck_LXD() {
     if is_socket_file /dev/lxd/sock; then
         return ${DS_FOUND}


### PR DESCRIPTION
Updates LXD docs URLs following the docs migration to canonical.com/lxd/docs.

This PR primarily updates URLs in the documentation, but also in other portions of the repo as well.