### PR TITLE
doc: fix ambiguous octal/string value in example

### DIFF
--- a/doc/examples/cloud-config-ansible-controller.txt
+++ b/doc/examples/cloud-config-ansible-controller.txt
@@ -79,7 +79,7 @@ ansible:
 write_files:
   - path: /home/ansible/.ssh/known_hosts
     owner: ansible:ansible
-    permissions: 0o600
+    permissions: "0o600"
     defer: true
     content: |
       |1|YJEFAk6JjnXpUjUSLFiBQS55W9E=|OLNePOn3eBa1PWhBBmt5kXsbGM4= ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl
@@ -88,7 +88,7 @@ write_files:
 
   - path: /home/ansible/.ssh/id_rsa
     owner: ansible:ansible
-    permissions: 0o600
+    permissions: "0o600"
     defer: true
     encoding: base64
     content: |


### PR DESCRIPTION
This works around an ambiguity with respect to YAML 1.1 (as used by PyYAML) and YAML 1.2 (as used by many other YAML parsers).

Fixes #6984

<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [x] I have signed the CLA: https://ubuntu.com/legal/contributors
- [x] I have included a comprehensive commit message using the guide below
- [x] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [x] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [x] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [x] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e doc``.
-->


## Proposed Commit Message
```
doc: fix ambiguous octal/string value in example

This works around an ambiguity with respect to YAML 1.1 (as used by
PyYAML) and YAML 1.2 (as used by many other YAML parsers).

Fixes #6984
```

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
