### PR TITLE
fix: declare referencing as a direct dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,8 @@ jsonpatch
 
 # For validating cloud-config sections per schema definitions
 jsonschema
+
+# Used directly by cloudinit/config/schema.py to build a jsonschema
+# Registry. Currently pulled in transitively by jsonschema, but not
+# guaranteed to remain so.
+referencing


### PR DESCRIPTION
## Summary
- `cloudinit/config/schema.py` imports `referencing` directly to build a `jsonschema` `Registry`, but it was only ever pulled into the environment transitively via `jsonschema`.
- Distro packaging that requires explicit direct dependencies (e.g. Arch Linux) breaks as a result.
- Adds `referencing` to `requirements.txt` alongside `jsonschema`.

Fixes #6986

## Test plan
- [x] Verified `referencing` resolves and installs cleanly from PyPI
- [x] No code changes, only a declared dependency addition