### PR TITLE
net: ignore Intel's default unprogrammed MAC on igc NICs

### DIFF
--- a/cloudinit/net/__init__.py
+++ b/cloudinit/net/__init__.py
@@ -25,6 +25,11 @@ IPV6_DYNAMIC_TYPES = [
     "ipv6_dhcpv6-stateless",
     "ipv6_dhcpv6-stateful",
 ]
+# Default/unprogrammed MAC address shipped on Intel i225 (NVM >= 1.53) and
+# all i226 NICs (igc driver) until the device is flashed with a real MAC
+# address in manufacturing. Not unique to a given NIC, so it must never be
+# treated as a real MAC address.
+INTEL_UNPROGRAMMED_MAC = "00:a0:c9:00:00:00"
 OVS_INTERNAL_INTERFACE_LOOKUP_CMD = [
     "ovs-vsctl",
     "--format",
@@ -1080,9 +1085,20 @@ def get_interfaces(
         if not mac:
             filtered_logger("Ignoring interface without mac: %s", name)
             continue
-        # skip nics that have no mac (00:00....)
-        if filter_zero_mac and name != "lo" and mac == zero_mac[: len(mac)]:
-            continue
+        # skip nics that have no real per-device mac assigned yet: either
+        # an all-zero mac (00:00...), or a known vendor placeholder mac
+        # that ships on unprogrammed hardware
+        if filter_zero_mac and name != "lo":
+            if mac == zero_mac[: len(mac)]:
+                continue
+            if mac == INTEL_UNPROGRAMMED_MAC:
+                filtered_logger(
+                    "Ignoring interface '%s' with unprogrammed "
+                    "placeholder mac '%s'.",
+                    name,
+                    mac,
+                )
+                continue
         if filter_openvswitch_internal and is_openvswitch_internal_interface(
             name
         ):

--- a/tests/unittests/test_net.py
+++ b/tests/unittests/test_net.py
@@ -5628,6 +5628,25 @@ class TestGetInterfacesByMac:
         ret = net.get_interfaces_by_mac()
         assert "lo" == ret["00:00:00:00:00:00"]
 
+    def test_skip_intel_unprogrammed_placeholder_mac(self, mocks):
+        placeholder_mac = net.INTEL_UNPROGRAMMED_MAC
+        addnics = ("enp4s0", "enp5s0")
+        self.data["macs"].update(dict((k, placeholder_mac) for k in addnics))
+        self.data["devices"].update(set(addnics))
+        self.data["own_macs"].extend(addnics)
+        self.data["drivers"].update(dict((k, "igc") for k in addnics))
+        ret = net.get_interfaces_by_mac()
+        assert placeholder_mac not in ret
+
+    def test_real_duplicate_igc_macs_still_raise(self, mocks):
+        real_mac = "3c:52:82:aa:bb:cc"
+        addnics = ("enp4s0", "enp5s0")
+        self.data["macs"].update(dict((k, real_mac) for k in addnics))
+        self.data["devices"].update(set(addnics))
+        self.data["own_macs"].extend(addnics)
+        self.data["drivers"].update(dict((k, "igc") for k in addnics))
+        pytest.raises(RuntimeError, net.get_interfaces_by_mac)
+
     def test_ib(self, mocks):
         ib_addr = "80:00:00:28:fe:80:00:00:00:00:00:00:00:11:22:03:00:33:44:56"
         ib_addr_eth_format = "00:11:22:33:44:56"


### PR DESCRIPTION

Some Intel i225 (NVM >= 1.53) and all i226 NICs ship with an unprogrammed placeholder MAC (00:a0:c9:00:00:00) until manufacturing flashes a real one. When two such NICs are present, cloud-init crashed with "duplicate mac found!" during networking setup.

Rather than ignoring all duplicate MACs for the igc driver (which would also hide genuine duplicate-MAC hardware faults on this common NIC), filter out this specific known placeholder value the same way the existing all-zero MAC placeholder is already filtered. Fixes GH-6782.

There was a prior attempt at this in #6784, which added `igc` to the existing driver-based duplicate-MAC ignore list (alongside `fsl_enetc`, `mscc_felix`, `qmi_wwan`). That approach is broader than needed here:
those other drivers are niche (automotive switches, cellular modems), but `igc` backs common consumer/server NICs (Intel I225/I226), so blanket-ignoring duplicate MACs for that driver would also silently hide a genuine duplicate-MAC hardware fault on such a board, rather than surfacing it as the RuntimeError does today. #6784 also had no test coverage and went stale.

Per Intel's own documentation, I225 (NVM >= 1.53) and all I226 parts ship with a specific, known default/placeholder MAC (`00:a0:c9:00:00:00`) until the manufacturing line programs a real one, this is exactly the MAC address in the linked bug report. This PR instead filters that specific sentinel value, the same way `get_interfaces()` already filters the all-zero MAC placeholder as "no real per-device MAC assigned yet." Real, distinct MACs that happen to collide on igc NICs still raise `RuntimeError` as before.

## Test Steps

Added unit tests:
- `test_skip_intel_unprogrammed_placeholder_mac`: two igc interfaces sharing the Intel placeholder MAC no longer raise, and are excluded from `get_interfaces_by_mac()`.
- `test_real_duplicate_igc_macs_still_raise`: two igc interfaces sharing a real (non-placeholder) MAC still raise `RuntimeError`.

`tox -e py3 -- tests/unittests/test_net.py` passes (273 passed, 12 xfailed).