### PR TITLE
chore: add type annotations to cloudinit.sources.helpers.ec2

### DIFF
--- a/cloudinit/sources/helpers/ec2.py
+++ b/cloudinit/sources/helpers/ec2.py
@@ -9,6 +9,7 @@
 import functools
 import json
 import logging
+from typing import Dict, List
 
 from cloudinit import url_helper, util
 
@@ -63,8 +64,8 @@ class MetadataMaterializer:
             self._leaf_decoder = leaf_decoder
 
     def _parse(self, blob):
-        leaves = {}
-        children = []
+        leaves: Dict[str, str] = {}
+        children: List[str] = []
         blob = util.decode_binary(blob)
 
         if not blob:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,6 @@ module = [
     "cloudinit.sources.DataSourceSmartOS",
     "cloudinit.sources.DataSourceVMware",
     "cloudinit.sources.helpers.azure",
-    "cloudinit.sources.helpers.ec2",
     "cloudinit.sources.helpers.netlink",
     "cloudinit.sources.helpers.openstack",
     "cloudinit.sources.helpers.vmware.imc.config_file",


### PR DESCRIPTION
## Proposed Commit Message
```
chore: add type annotations to cloudinit.sources.helpers.ec2

MetadataMaterializer._parse seeds an empty dict and list before
filling them in the loop below, which mypy cannot infer a type for
once check_untyped_defs is enabled. Annotate them as Dict[str, str]
and List[str], matching what the loop actually stores.

Drop cloudinit.sources.helpers.ec2 from the mypy override list in
pyproject.toml.

Refs GH-5445
```

## Additional Context

Refs GH-5445.

`MetadataMaterializer._parse` starts with `leaves = {}` and `children = []` and
fills both further down the same function. mypy cannot infer element types from
an empty literal, so each one needs an explicit annotation once the module is
checked.

The types come from what the loop actually stores:

- `children` only ever receives `field_name`, which `get_name` returns as a str,
  so it is `List[str]`.
- `leaves` is keyed by `field_name` and its value is `resource`, which is either
  `field_name` or `"%s/openssh-key" % ident`. Both are str, so it is
  `Dict[str, str]`.

I used `typing.Dict` and `typing.List` rather than the builtin generics to stay
consistent with the surrounding code and the 3.9 floor.

That is the whole change. `_parse` keeps its existing signature, so there is no
effect on any caller. I also left the return type off `_parse` on purpose:
annotating it would be accurate, but it turns `_parse` into a typed def and
widens what mypy checks inside the body, which is more than this issue needs.
Happy to do that separately if it's wanted.

`tests.unittests.sources.helpers.test_ec2` is already outside the override list,
so there is no test entry to remove and it stays green.

## Test Steps

Annotation only, with no runtime behaviour change, so no new tests.
`tests/unittests/sources/helpers/test_ec2.py` already covers
`MetadataMaterializer`.

Local runs on this branch:

```
$ tox -e py3
5742 passed, 5 skipped, 13 xfailed, 10 warnings in 161.98s

$ tox -e check_format
ruff: All checks passed!
pylint: Your code has been rated at 10.00/10
black: 595 files would be left unchanged.
isort: Skipped 5 files
mypy: Success: no issues found in 591 source files
congratulations :)
```

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
