### PR TITLE
typing: add type hints to cloudinit.distros.parsers.hostname

### DIFF
--- a/cloudinit/distros/parsers/hostname.py
+++ b/cloudinit/distros/parsers/hostname.py
@@ -5,50 +5,58 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
 from io import StringIO
+from typing import List, Optional, Set, Tuple
 
 from cloudinit.distros.parsers import chop_comment
+
+# A single parsed line: its type ("blank", "all_comment" or "hostname") and the
+# string components that make it up.
+_ParsedLine = Tuple[str, List[str]]
 
 
 # Parser that knows how to work with /etc/hostname format
 class HostnameConf:
-    def __init__(self, text):
+    def __init__(self, text: str) -> None:
         self._text = text
-        self._contents = None
+        self._contents: Optional[List[_ParsedLine]] = None
 
-    def parse(self):
+    def parse(self) -> None:
         if self._contents is None:
             self._contents = self._parse(self._text)
 
-    def __str__(self):
+    def __str__(self) -> str:
         self.parse()
-        contents = StringIO()
+        assert self._contents is not None
+        out = StringIO()
         for line_type, components in self._contents:
             if line_type == "blank":
-                contents.write("%s\n" % (components[0]))
+                out.write("%s\n" % (components[0]))
             elif line_type == "all_comment":
-                contents.write("%s\n" % (components[0]))
+                out.write("%s\n" % (components[0]))
             elif line_type == "hostname":
                 (hostname, tail) = components
-                contents.write("%s%s\n" % (hostname, tail))
+                out.write("%s%s\n" % (hostname, tail))
         # Ensure trailing newline
-        contents = contents.getvalue()
+        contents = out.getvalue()
         if not contents.endswith("\n"):
             contents += "\n"
         return contents
 
     @property
-    def hostname(self):
+    def hostname(self) -> Optional[str]:
         self.parse()
+        assert self._contents is not None
         for line_type, components in self._contents:
             if line_type == "hostname":
                 return components[0]
         return None
 
-    def set_hostname(self, your_hostname):
+    def set_hostname(self, your_hostname: str) -> None:
         your_hostname = your_hostname.strip()
         if not your_hostname:
             return
         self.parse()
+        assert self._contents is not None
         replaced = False
         for line_type, components in self._contents:
             if line_type == "hostname":
@@ -57,9 +65,9 @@ class HostnameConf:
         if not replaced:
             self._contents.append(("hostname", [str(your_hostname), ""]))
 
-    def _parse(self, contents):
-        entries = []
-        hostnames_found = set()
+    def _parse(self, contents: str) -> List[_ParsedLine]:
+        entries: List[_ParsedLine] = []
+        hostnames_found: Set[str] = set()
         for line in contents.splitlines():
             if not len(line.strip()):
                 entries.append(("blank", [line]))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,6 @@ module = [
     "cloudinit.distros.azurelinux",
     "cloudinit.distros.bsd",
     "cloudinit.distros.opensuse",
-    "cloudinit.distros.parsers.hostname",
     "cloudinit.distros.parsers.resolv_conf",
     "cloudinit.distros.ug_util",
     "cloudinit.helpers",


### PR DESCRIPTION
Enables `check_untyped_defs` for `cloudinit.distros.parsers.resolv_conf` by annotating `ResolvConf` and removing it from the mypy override list in `pyproject.toml`.

`self._contents` is `Optional`; it is now narrowed with an `assert` after `parse()` before it is iterated or appended to. Behaviour is unchanged.

Refs GH-5445

- [x] I have signed the CLA
- [x] I have included a comprehensive commit message
- [ ] I have added unit tests — N/A: typing-only, no behaviour change; the class is already covered by `tests/unittests/distros/test_resolv.py`
- [x] I have kept the change small
- [x] I have added a reference to the related issue (Refs GH-5445)
- [ ] I have updated the documentation — N/A: no user-facing change

## Proposed Commit Message
```
typing: add type hints to cloudinit.distros.parsers.resolv_conf

Annotate ResolvConf and enable check_untyped_defs for the module by
removing it from the mypy override list in p

self._contents is Optional; it is now narrow
parse() before it is iterated or appended to. Behaviour is unchanged.

Refs GH-5445
```

## Additional Context
Part of the incremental effort in GH-5445 to enable `check_untyped_defs` module-by-module.

## Test Steps
```
tox -e mypy    # clean (270 files, --platform linux)
tox -e py3 -- tests/unittests/distros/test_rig/test_cc_resolv_conf.py   # 30 passed
tox -e ruff && tox -e black && tox -e isort   # clean
```

## Merge type
- [x] Squash merge using "Proposed Commit Message" 