### PR TITLE
fix(schema): accept an integer netmask in network config v1

### DIFF
--- a/cloudinit/config/schemas/schema-network-config-v1.json
+++ b/cloudinit/config/schemas/schema-network-config-v1.json
@@ -477,8 +477,11 @@
           "description": "IPv4 network address with CIDR netmask notation or IPv6 with prefix length. Alias for ``network`` and preferred above the ``network`` key."
         },
         "netmask": {
-          "type": "string",
-          "description": "IPv4 subnet mask in dotted format or CIDR notation"
+          "type": [
+            "integer",
+            "string"
+          ],
+          "description": "Subnet mask in dotted format, or prefix length. A prefix length may be given as an integer or a string."
         },
         "gateway": {
           "type": "string",
@@ -522,8 +525,11 @@
           "description": "IPv4 or IPv6 address. It may include CIDR netmask notation."
         },
         "netmask": {
-          "type": "string",
-          "description": "IPv4 subnet mask in dotted format or CIDR notation"
+          "type": [
+            "integer",
+            "string"
+          ],
+          "description": "Subnet mask in dotted format, or prefix length. A prefix length may be given as an integer or a string."
         },
         "broadcast": {
           "type": "string",

--- a/tests/unittests/config/test_schema.py
+++ b/tests/unittests/config/test_schema.py
@@ -1877,6 +1877,49 @@ class TestNetworkSchema:
                 "",
                 id="subnet_metric_validation",
             ),
+            pytest.param(
+                {
+                    "network": {
+                        "version": 1,
+                        "config": [
+                            {
+                                "type": "physical",
+                                "name": "eth0",
+                                "subnets": [
+                                    {
+                                        "type": "static",
+                                        "address": "10.0.0.2",
+                                        "netmask": 24,
+                                        "routes": [
+                                            {
+                                                "network": "192.168.23.0",
+                                                "netmask": 24,
+                                                "gateway": "10.0.0.1",
+                                            }
+                                        ],
+                                    },
+                                    {
+                                        "type": "static6",
+                                        "address": "2001:db8::1",
+                                        "netmask": 64,
+                                        "routes": [
+                                            {
+                                                "network": "2001:db8:1::",
+                                                "netmask": 128,
+                                                "gateway": "2001:db8::2",
+                                            }
+                                        ],
+                                    },
+                                ],
+                            }
+                        ],
+                    }
+                },
+                SchemaType.NETWORK_CONFIG_V1,
+                does_not_raise(),
+                "",
+                id="netmask_as_integer_prefix",
+            ),
         ),
     )
     @mock.patch("cloudinit.net.netplan.available", return_value=False)


### PR DESCRIPTION
## Proposed Commit Message

~~~
fix(schema): accept an integer netmask in network config v1

A config drive setting an IPv6 route netmask as an integer produces this,
even though the route is applied correctly:
```
schema.py[WARNING]: network-config-v1 failed schema validation! You may run 'sudo cloud-init schema --system' to check the details.
```
```
# cloud-init schema --system
Error: Cloud config schema errors: config.0.subnets.1.routes.0.netmask: 128 is not of type 'string'
```

Nothing that reads the value requires a string:

- `_normalize_net_keys()` passes `netmask`, for subnets and routes, to
  `ipv4_mask_to_net_prefix()` or `ipv6_mask_to_net_prefix()`, which document
  accepting an integer or a string representation of one.
- `test_ipv6_static_routes_ip_cmd` renders a v1 config containing both
  `"netmask": 24` as an integer and `"netmask": "32"` as a string.

Accept an integer alongside a string, for subnets and routes, and reword the
description to cover IPv6.
~~~

## Test Steps

```yaml
# /tmp/net-v1.yaml
network:
  version: 1
  config:
    - type: physical
      name: eth0
      subnets:
        - type: static6
          address: "2001:db8::1/128"
          gateway: "2001:db8::2"
          routes:
            - network: "2001:db8:1::"
              netmask: 128
              gateway: "2001:db8::2"
```

Before:

```
$ cloud-init schema -t network-config -c /tmp/net-v1.yaml
Error: Cloud config schema errors: network.config.0.subnets.0.routes.0.netmask: 128 is not of type 'string'
Error: Invalid schema: network-config
```

After:

```
$ cloud-init schema -t network-config -c /tmp/net-v1.yaml
Valid schema /tmp/net-v1.yaml
```

Unit tests:

```
$ tox -e py3 -- tests/unittests/config/test_schema.py
156 passed, 2 skipped
```

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
