### PR TITLE
mypy: enable check_untyped_defs for net.freebsd

### DIFF
--- a/cloudinit/net/freebsd.py
+++ b/cloudinit/net/freebsd.py
@@ -1,9 +1,10 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
 import logging
+from typing import cast
 
 import cloudinit.net.bsd
-from cloudinit import distros, net, subp, util
+from cloudinit import net, subp, util
 
 LOG = logging.getLogger(__name__)
 
@@ -16,7 +17,7 @@ class Renderer(cloudinit.net.bsd.BSDRenderer):
     def rename_interface(self, cur_name, device_name):
         self.set_rc_config_value("ifconfig_%s_name" % cur_name, device_name)
 
-    def write_config(self):
+    def write_config(self, target=None):
         for device_name, v in self.interface_configurations.items():
             if isinstance(v, dict):
                 net_config = "inet %s netmask %s" % (
@@ -25,7 +26,7 @@ class Renderer(cloudinit.net.bsd.BSDRenderer):
                 )
                 mtu = v.get("mtu")
                 if mtu:
-                    net_config += " mtu %d" % mtu
+                    net_config += " mtu %d" % cast(int, mtu)
             elif v == "DHCP":
                 net_config = "DHCP"
             self.set_rc_config_value("ifconfig_" + device_name, net_config)
@@ -34,11 +35,11 @@ class Renderer(cloudinit.net.bsd.BSDRenderer):
             if isinstance(v, dict):
                 net_config = "inet6 %s/%d" % (
                     v.get("address"),
-                    v.get("prefix"),
+                    cast(int, v.get("prefix")),
                 )
                 mtu = v.get("mtu")
                 if mtu:
-                    net_config += " mtu %d" % mtu
+                    net_config += " mtu %d" % cast(int, mtu)
             self.set_rc_config_value(
                 "ifconfig_%s_ipv6" % device_name, net_config
             )
@@ -48,11 +49,13 @@ class Renderer(cloudinit.net.bsd.BSDRenderer):
             LOG.debug("freebsd generate postcmd disabled")
             return
 
+        import cloudinit.distros.freebsd
+
         for dhcp_interface in self.dhcp_interfaces():
             # Observed on DragonFlyBSD 6. If we use the "restart" parameter,
             # the routes are not recreated.
             net.dhcp.IscDhclient.stop_service(
-                dhcp_interface, distros.freebsd.Distro
+                dhcp_interface, cloudinit.distros.freebsd.Distro
             )
 
         subp.subp(["service", "netif", "restart"], capture=True)
@@ -66,7 +69,7 @@ class Renderer(cloudinit.net.bsd.BSDRenderer):
 
         for dhcp_interface in self.dhcp_interfaces():
             net.dhcp.IscDhclient.start_service(
-                dhcp_interface, distros.freebsd.Distro
+                dhcp_interface, cloudinit.distros.freebsd.Distro
             )
 
     def set_route(self, network, netmask, gateway):

--- a/cloudinit/net/freebsd.py
+++ b/cloudinit/net/freebsd.py
@@ -1,7 +1,6 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
 import logging
-from typing import cast
 
 import cloudinit.net.bsd
 from cloudinit import net, subp, util
@@ -26,20 +25,17 @@ class Renderer(cloudinit.net.bsd.BSDRenderer):
                 )
                 mtu = v.get("mtu")
                 if mtu:
-                    net_config += " mtu %d" % cast(int, mtu)
+                    net_config += f" mtu {mtu}"
             elif v == "DHCP":
                 net_config = "DHCP"
             self.set_rc_config_value("ifconfig_" + device_name, net_config)
 
         for device_name, v in self.interface_configurations_ipv6.items():
             if isinstance(v, dict):
-                net_config = "inet6 %s/%d" % (
-                    v.get("address"),
-                    cast(int, v.get("prefix")),
-                )
+                net_config = f"inet6 {v.get('address')}/{v.get('prefix')}"
                 mtu = v.get("mtu")
                 if mtu:
-                    net_config += " mtu %d" % cast(int, mtu)
+                    net_config += f" mtu {mtu}"
             self.set_rc_config_value(
                 "ifconfig_%s_ipv6" % device_name, net_config
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,6 @@ module = [
     "cloudinit.helpers",
     "cloudinit.net.cmdline",
     "cloudinit.net.ephemeral",
-    "cloudinit.net.freebsd",
     "cloudinit.net.netbsd",
     "cloudinit.net.network_manager",
     "cloudinit.net.network_state",


### PR DESCRIPTION
Enable check_untyped_defs for cloudinit.net.freebsd as part of #5445.

This fixes the type errors exposed when the module is checked with check_untyped_defs enabled and removes the module from the corresponding mypy override.

Tests:

tox -e check_format
tox -e py3 -- tests/unittests/test_net_freebsd.py
tox -e py3 -- tests/unittests/distros/test_netconfig.py

The full mypy check still reports two unrelated missing crypt stubs in cloudinit/distros/netbsd.py and cloudinit/sources/DataSourceAzure.py.