### PR TITLE
chore: add type annotations to cloudinit.net.cmdline

### DIFF
--- a/cloudinit/net/cmdline.py
+++ b/cloudinit/net/cmdline.py
@@ -13,6 +13,7 @@ import io
 import logging
 import os
 import shlex
+from typing import Any, Dict
 
 from cloudinit import util
 from cloudinit.net import get_devicelist, read_sys_net_safe
@@ -201,7 +202,7 @@ def config_from_klibc_net_cfg(files=None, mac_addrs=None):
         files = _get_klibc_net_cfg_files()
 
     entries = []
-    names = {}
+    names: Dict[str, Dict[str, Any]] = {}
     for cfg_file in files:
         name, entry = _klibc_to_config_entry(
             util.load_text_file(cfg_file), mac_addrs=mac_addrs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,6 @@ module = [
     "cloudinit.distros.parsers.resolv_conf",
     "cloudinit.distros.ug_util",
     "cloudinit.helpers",
-    "cloudinit.net.cmdline",
     "cloudinit.net.ephemeral",
     "cloudinit.net.freebsd",
     "cloudinit.net.netbsd",


### PR DESCRIPTION
## Proposed Commit Message
```
chore: add type annotations to cloudinit.net.cmdline

config_from_klibc_net_cfg seeds an empty dict before filling it in the
loop below, which mypy cannot infer a type for once check_untyped_defs
is enabled. Annotate it as Dict[str, Dict[str, Any]], matching the
{"files": [...], "entry": {...}} value the loop stores against each
device name.

Drop cloudinit.net.cmdline from the mypy override list in
pyproject.toml.

Refs GH-5445
```

## Additional Context

Refs GH-5445. This one is marked as a priority module in the issue checklist.

`config_from_klibc_net_cfg` starts with `names = {}` and fills it further down
the same function. mypy cannot infer element types from an empty literal, so it
needs an explicit annotation once the module is checked.

The type comes from what the loop actually stores. Each key is the device name
returned by `_klibc_to_config_entry`, and each value is
`{"files": [cfg_file], "entry": entry}`. That value mixes a list of file paths
under `files` with a config entry dict under `entry`, so the inner mapping is
`Dict[str, Any]`, giving `Dict[str, Dict[str, Any]]` overall.

I used `typing.Dict` and `typing.Any` rather than the builtin generics to stay
consistent with the surrounding code and the 3.9 floor.

That is the whole change. `config_from_klibc_net_cfg` keeps its existing
signature, so no caller is affected, and `tests.unittests.net.test_cmdline` is
already outside the override list so there was nothing to remove for it.

## Test Steps

Annotation only, with no runtime behaviour change, so no new tests.
`tests/unittests/net/test_cmdline.py` already covers
`config_from_klibc_net_cfg`, including the duplicate device name path that
reads back through `names`.

Local runs on this branch:

```
$ tox -e py3
5742 passed, 5 skipped, 13 xfailed, 10 warnings in 164.11s

$ tox -e check_format
ruff: All checks passed!
pylint: Your code has been rated at 10.00/10
black: 595 files would be left unchanged.
isort: Skipped 5 files
mypy: Success: no issues found in 591 source files
congratulations :)
```

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
