### PR TITLE
docs: clarify hotplug-hook subcommands in CLI reference

### DIFF
--- a/doc/rtd/reference/cli.rst
+++ b/doc/rtd/reference/cli.rst
@@ -95,27 +95,58 @@ Logs collected include:
    Ubuntu users can file bugs using :command:`ubuntu-bug cloud-init` to
    automatically attach these logs to a bug report.
 
+ 
 :command:`query`
-----------------
-
-Query if hotplug is enabled for a given subsystem.
-
-:command:`handle`
 -----------------
-
+.. _cli_devel_hotplug_hook:
+ 
+Query if hotplug is enabled for a given subsystem.
+:command:`devel hotplug-hook`
+------------------------------
+ 
+:command:`handle`
+------------------
+These are subcommands of :command:`devel hotplug-hook`, not top-level
+``cloud-init`` commands, and each requires ``-s/--subsystem`` on the parent
+command:
+ 
 Respond to newly added system devices by retrieving updated system meta-data
 and bringing up/down the corresponding device.
-
+.. code-block:: shell-session
+ 
 :command:`enable`
------------------
+------------------
+   $ cloud-init devel hotplug-hook --subsystem <subsystem> <query|handle|enable> [options]
 
+* :command:`query`: Query if hotplug is enabled for a given subsystem.
+
+  .. code-block:: shell-session
+
+     $ cloud-init devel hotplug-hook --subsystem net query
+
+* :command:`handle`: Respond to newly added system devices by retrieving
+  updated system meta-data and bringing up/down the corresponding device.
+  Requires ``-d/--devpath`` (sysfs path to the hotplugged device) and
+  ``-u/--udevaction``.
+
+  .. code-block:: shell-session
+
+     $ cloud-init devel hotplug-hook --subsystem net handle --devpath /sys/class/net/eth1 --udevaction add
+
+* :command:`enable`: Enable hotplug for a given subsystem. This is a last
+  resort command for administrators to enable hotplug in running instances.
+  The recommended method is configuring :ref:`events`, if not enabled by
+  default in the active datasource.
+
+  .. code-block:: shell-session
+ 
 Enable hotplug for a given subsystem. This is a last resort command for
 administrators to enable hotplug in running instances. The recommended
 method is configuring :ref:`events`, if not enabled by default in the active
 datasource.
-
-.. _cli_query:
-
+     $ cloud-init devel hotplug-hook --subsystem net enable
+ 
+ .. _cli_query:
 :command:`query`
 ----------------
 


### PR DESCRIPTION
The CLI reference lists query, handle, and enable as top-level cloud-init subcommands, but they're actually subcommands of devel hotplug-hook (see cloudinit/cmd/devel/hotplug_hook.py), each requiring --subsystem. This also caused the doc's query heading to collide with the real top-level query command later on the same page. This PR nests them correctly under devel hotplug-hook with accurate example invocations.

<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [ ] I have signed the CLA: https://ubuntu.com/legal/contributors
- [ ] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [ ] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e doc``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
<type>(optional scope): <summary>  # no more than 72 characters

A description of what the change being made is and why it is being
made if the summary line is insufficient.  This should be wrapped at
72 characters.

If you need to write multiple paragraphs, feel free.

Fixes GH-NNNNN (GitHub Issue number. Remove line if irrelevant)
LP: #NNNNNN (Launchpad bug number. Remove line if irrelevant)
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
