### PR TITLE
fix(util): skip jinja config files which fail to render

### DIFF
--- a/cloudinit/config/schema.py
+++ b/cloudinit/config/schema.py
@@ -1027,9 +1027,13 @@ def _get_config_type_and_rendered_userdata(
     schema_position = "format-l1.c1"
     if user_data_type == "text/jinja2":
         try:
-            content = render_jinja_payload_from_file(
+            rendered = render_jinja_payload_from_file(
                 content, config_path, instance_data_path
             )
+            if rendered is None:
+                error("Failed to render templated user-data.", sys_exit=True)
+            else:
+                content = rendered
         except NotJinjaError as e:
             raise SchemaValidationError(
                 [

--- a/cloudinit/handlers/jinja_template.py
+++ b/cloudinit/handlers/jinja_template.py
@@ -85,7 +85,7 @@ class JinjaTemplatePartHandler(handlers.Handler):
 
 def render_jinja_payload_from_file(
     payload, payload_fn, instance_data_file, debug=False
-):
+) -> Optional[str]:
     r"""Render a jinja template sourcing variables from jinja_vars_path.
 
     @param payload: String of jinja template content. Should begin with
@@ -128,7 +128,9 @@ def render_jinja_payload_from_file(
     return rendered_payload
 
 
-def render_jinja_payload(payload, payload_fn, instance_data, debug=False):
+def render_jinja_payload(
+    payload, payload_fn, instance_data, debug=False
+) -> Optional[str]:
     instance_jinja_vars = convert_jinja_instance_data(
         instance_data,
         decode_paths=instance_data.get("base64-encoded-keys", []),

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -327,11 +327,19 @@ def read_conf(fname, *, instance_data_file=None) -> Dict:
 
     if instance_data_file and os.path.exists(instance_data_file):
         try:
-            config_file = render_jinja_payload_from_file(
+            rendered = render_jinja_payload_from_file(
                 config_file,
                 fname,
                 instance_data_file,
             )
+            if rendered is None:
+                LOG.warning(
+                    "Skipping jinja config file '%s'. "
+                    "Failed to render template.",
+                    fname,
+                )
+                return {}
+            config_file = rendered
             LOG.debug(
                 "Applied instance data in '%s' to "
                 "configuration loaded from '%s'",

--- a/tests/unittests/test_util.py
+++ b/tests/unittests/test_util.py
@@ -551,6 +551,25 @@ class TestUtil:
         )
         assert conf == {}
 
+    def test_read_conf_with_config_unrendered_template(self, mocker, caplog):
+        """If a jinja config fails to render, it is skipped.
+
+        The rendering functions return None value for failed
+        templates. This value shouldn't be passed down to load_yaml().
+        """
+        mocker.patch("os.path.exists", return_value=True)
+        mocker.patch(
+            "cloudinit.util.load_text_file",
+            return_value='## template: jinja\n{"a": "{{ b.c.d }}"}',
+        )
+        mocker.patch(
+            "cloudinit.handlers.jinja_template.load_text_file",
+            return_value='{"b": {}}',
+        )
+        conf = util.read_conf("cfg_path", instance_data_file="vars_path")
+        assert "Skipping jinja config file 'cfg_path'" in caplog.text
+        assert conf == {}
+
     @mock.patch(
         M_PATH + "read_conf",
         side_effect=(OSError(errno.EACCES, "Not allowed"), {"0": "0"}),


### PR DESCRIPTION

## Proposed Commit Message
```
fix(util): skip jinja template config files which fail to render

read_conf doesn't handle the None return value 
from render_jinja_payload_from_file() when a
template render fails. This gets passed into
load_yaml which results in an AttributeError on 
NoneType and crashes the running service.

This check was removed from #5350 as unreachable 
due to the render functions not having any return 
annotations. Adding Optional[str] toavoid this being 
caught again and fix the schema to check None return.

Fixes GH-7007
```

## Additional Context

- Filed as an issue in GH-7007

- I followed the previous removed code and returned an empty {} as but I don't know if there is another expectation here.

## Test Validation
Reproducer in GH issue above. 

Test output with current branch
```
~/cloud-init fix-config-crash ?1 ❯ tox -e py3 -- tests/unittests/test_util.py -k unrendered 

tests/unittests/test_util.py::TestUtil::test_read_conf_with_config_unrendered_template FAILED                                                                                                                  [100%]

====================================================================================================== FAILURES ======================================================================================================
______________________________________________________________________________ TestUtil.test_read_conf_with_config_unrendered_template _______________________________________________________________________________

self = <tests.unittests.test_util.TestUtil object at 0x10537a780>, mocker = <pytest_mock.plugin.MockerFixture object at 0x1053b9a90>, caplog = <_pytest.logging.LogCaptureFixture object at 0x1053b9e80>

>   ???

tests/unittests/test_util.py:569:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
cloudinit/util.py:369: in read_conf
    return load_yaml(config_file, default={})  # pyright: ignore
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cloudinit/util.py:983: in load_yaml
    blob = decode_binary(blob)
           ^^^^^^^^^^^^^^^^^^^
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

blob = None, encoding = 'utf-8'

    def decode_binary(blob: Union[str, bytes], encoding="utf-8") -> str:
        # Converts a binary type into a text type using given encoding.
>       return blob if isinstance(blob, str) else blob.decode(encoding=encoding)
                                                  ^^^^^^^^^^^
E       AttributeError: 'NoneType' object has no attribute 'decode'

cloudinit/util.py:143: AttributeError
------------------------------------------------------------------------------------------------- Captured log call --------------------------------------------------------------------------------------------------
2026-08-16 13:46:55 WARNING   cloudinit.handlers.jinja_template:jinja_template.py:150 Ignoring jinja template for cfg_path: 'dict object' has no attribute 'c'
2026-08-16 13:46:55 DEBUG     cloudinit.util:util.py:345 Applied instance data in 'vars_path' to configuration loaded from 'cfg_path'


```
After fix
```
tests/unittests/test_util.py::TestUtil::test_read_conf_with_config_unrendered_template PASSED    [100%]
```


Fixes #7007
## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
