### PR TITLE
feat(subp): Support subprocess user and group credentials

### DIFF
--- a/cloudinit/sources/DataSourceOpenNebula.py
+++ b/cloudinit/sources/DataSourceOpenNebula.py
@@ -365,10 +365,6 @@ def find_candidate_devs():
     return combined
 
 
-def switch_user_cmd(user):
-    return ["sudo", "-u", user]
-
-
 def varprinter():
     """print the shell environment variables within delimiters to be parsed"""
     return textwrap.dedent(
@@ -420,12 +416,21 @@ def parse_shell_config(
         + "\n"
     )
 
-    cmd = []
+    kwargs: Dict[str, Any] = {}
     if asuser is not None:
-        cmd = switch_user_cmd(asuser)
-    cmd.extend(["sh", "-e"])
+        try:
+            pw = pwd.getpwnam(asuser)
+        except KeyError as e:
+            raise BrokenContextDiskDir(
+                "configured user '{user}' does not exist".format(user=asuser)
+            ) from e
+        kwargs = {
+            "user": pw.pw_uid,
+            "group": pw.pw_gid,
+            "extra_groups": (),
+        }
 
-    output = subp.subp(cmd, data=bcmd).stdout
+    output = subp.subp(["sh", "-e"], data=bcmd, **kwargs).stdout
 
     # exclude vars that change on their own or that we used
     ret = {}
@@ -480,15 +485,6 @@ def read_context_disk_dir(
     results: Dict[str, Any] = {"userdata": None, "metadata": {}}
 
     if "context.sh" in found:
-        if asuser is not None:
-            try:
-                pwd.getpwnam(asuser)
-            except KeyError as e:
-                raise BrokenContextDiskDir(
-                    "configured user '{user}' does not exist".format(
-                        user=asuser
-                    )
-                ) from e
         try:
             path = os.path.join(source_dir, "context.sh")
             content = util.load_text_file(path)

--- a/cloudinit/subp.py
+++ b/cloudinit/subp.py
@@ -174,6 +174,9 @@ def subp(
     update_env=None,
     cwd=None,
     timeout=None,
+    user=None,
+    group=None,
+    extra_groups=None,
 ) -> SubpResult:
     """Run a subprocess.
 
@@ -202,6 +205,9 @@ def subp(
         change the working directory to cwd before executing the command.
     :param timeout: maximum time for the subprocess to run, passed directly to
         the timeout parameter of Popen.communicate()
+    :param user: user ID or name for the subprocess.
+    :param group: group ID or name for the subprocess.
+    :param extra_groups: extra group IDs or names for the subprocess.
 
     :return
         if not capturing, return is (None, None)
@@ -256,6 +262,13 @@ def subp(
         bytes_args = [
             x if isinstance(x, bytes) else x.encode("utf-8") for x in args
         ]
+    popen_kwargs = {}
+    if user is not None:
+        popen_kwargs["user"] = user
+    if group is not None:
+        popen_kwargs["group"] = group
+    if extra_groups is not None:
+        popen_kwargs["extra_groups"] = extra_groups
     try:
         with performance.Timed(
             "Running {!r}".format(logstring if logstring else args)
@@ -268,6 +281,7 @@ def subp(
                 env=env,
                 shell=shell,
                 cwd=cwd,
+                **popen_kwargs,
             )
             out, err = sp.communicate(data, timeout=timeout)
     except OSError as e:

--- a/tests/unittests/sources/test_opennebula.py
+++ b/tests/unittests/sources/test_opennebula.py
@@ -44,25 +44,14 @@ IP6_PREFIX = "48"
 DS_PATH = "cloudinit.sources.DataSourceOpenNebula"
 
 
-@pytest.mark.allow_subp_for("bash", "sh")
+@pytest.mark.allow_subp_for("sh")
 class TestOpenNebulaDataSource:
-    parsed_user = None
-
     @pytest.fixture(autouse=True)
     def fixtures(self, paths):
         # defaults for few tests
         self.seed_dir = os.path.join(paths.seed_dir, "opennebula")
         self.sys_cfg = {"datasource": {"OpenNebula": {"dsmode": "local"}}}
-
-        # we don't want 'sudo' called in tests. so we patch switch_user_cmd
-        def my_switch_user_cmd(user):
-            self.parsed_user = user
-            return []
-
-        self.switch_user_cmd_real = ds.switch_user_cmd
-        ds.switch_user_cmd = my_switch_user_cmd
         yield
-        ds.switch_user_cmd = self.switch_user_cmd_real
 
     @pytest.fixture
     def dsrc(self, paths):
@@ -103,9 +92,26 @@ class TestOpenNebulaDataSource:
     @mock.patch(DS_PATH + ".util.find_devs_with", return_value=[])
     def test_get_data(self, m_find_devs_with, dsrc, paths):
         populate_context_dir(self.seed_dir, {"KEY1": "val1"})
-        with mock.patch(DS_PATH + ".pwd.getpwnam") as getpwnam:
+        with mock.patch(DS_PATH + ".pwd.getpwnam") as getpwnam, mock.patch(
+            DS_PATH + ".subp.subp",
+            return_value=ds.subp.SubpResult(
+                "_start_\x00_start_\x00_start_\x00KEY1=val1\n_start_\x00",
+                "",
+            ),
+        ) as m_subp:
+            getpwnam.return_value.pw_uid = 123
+            getpwnam.return_value.pw_gid = 456
             ret = dsrc.get_data()
         assert [mock.call("nobody")] == getpwnam.call_args_list
+        assert [
+            mock.call(
+                ["sh", "-e"],
+                data=mock.ANY,
+                user=123,
+                group=456,
+                extra_groups=(),
+            )
+        ] == m_subp.call_args_list
         assert ret
         assert "opennebula" == dsrc.cloud_name
         assert "opennebula" == dsrc.platform_type
@@ -1142,7 +1148,7 @@ class TestOpenNebulaNetwork:
 
 
 class TestParseShellConfig:
-    @pytest.mark.allow_subp_for("bash", "sh")
+    @pytest.mark.allow_subp_for("sh")
     def test_no_seconds(self):
         cfg = "\n".join(["foo=bar", "SECONDS=2", "xx=foo"])
         # we could test 'sleep 2', but that would make the test run slower.

--- a/tests/unittests/test_subp.py
+++ b/tests/unittests/test_subp.py
@@ -214,6 +214,23 @@ class TestSubp:
             set(out.splitlines())
         )
 
+    def test_subp_runs_as_user_group_and_extra_groups(self):
+        with mock.patch.object(
+            subp.subprocess,
+            "Popen",
+            autospec=True,
+        ) as m_popen:
+            m_popen.return_value.communicate.return_value = ("", "")
+            m_popen.return_value.returncode = 0
+
+            subp.subp(["true"], user=123, group=456, extra_groups=())
+
+        assert {
+            "user": 123,
+            "group": 456,
+            "extra_groups": (),
+        }.items() <= m_popen.call_args.kwargs.items()
+
     def test_subp_warn_missing_shebang(self, tmp_path):
         """Warn on no #! in script"""
         noshebang = str(tmp_path / "noshebang")


### PR DESCRIPTION
## Proposed Commit Message

fix(opennebula): avoid sudo when parsing context.sh

OpenNebula parses context.sh as the configured parse user. Previously
this was done by spawning sudo -u, which can block during early boot and
cause cloud-init-local.service to wait for the sudo timeout.

Resolve the parse user with pwd.getpwnam and pass the target uid, gid,
and empty supplemental groups directly through subp.subp to
subprocess.Popen. This preserves the existing sh-based parser while
avoiding sudo during datasource detection.

Add unit coverage for the new subp uid/gid passthrough and for the
OpenNebula parser invocation.

Fixes GH-4078
LP: #2007149
```markdown
## Additional Context

This change does not alter OpenNebula context.sh semantics. The parser
still runs through `sh -e`; only the user switching mechanism changes
from `sudo -u <user>` to subprocess uid/gid handling.

Documentation update skipped: this is an internal implementation change
and does not change user-facing datasource configuration.
```

```markdown
## Test Steps

Static validation performed locally:

- `python3 -m py_compile cloudinit/subp.py cloudinit/sources/DataSourceOpenNebula.py tests/unittests/sources/test_opennebula.py tests/unittests/test_subp.py`
- `git diff --check`

Focused unit test command attempted:

- `pytest -q tests/unittests/sources/test_opennebula.py tests/unittests/test_subp.py`

The pytest run did not start in this local environment because PyYAML is
not installed:

`ModuleNotFoundError: No module named 'yaml'`

A direct local check verified that `subp.subp(..., user=..., group=...,
extra_groups=...)` passes those values through to `subprocess.Popen`.
```

Checkboxes you can mark based on your state:

- [x] I have signed the CLA: https://ubuntu.com/legal/contributors
- [x] I have included a comprehensive commit message using the guide below
- [x] I have added unit tests to cover the new behavior under `tests/unittests/`
- [x] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [x] I have added a reference to issues that this PR relates to in the PR message
- [ ] I have updated the documentation with the changed behavior.