### PR TITLE
chore: make isort skip gitignored files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ profile = "black"
 line_length = 79
 # We patch logging in main.py before certain imports
 skip = ["cloudinit/cmd/main.py", ".tox", "packages", "tools"]
+skip_gitignore = true
 
 [tool.mypy]
 follow_imports = "silent"


### PR DESCRIPTION
## Proposed Commit Message
```
chore: make isort skip gitignored files

ruff and black both skip files matched by .gitignore, but isort does
not, so it walks into generated build directories.

Following the build steps in doc/rtd/development/build_system.rst:

    meson setup builddir

leaves a builddir/ containing meson-private/pycompile.py, and
tox -e check_format then fails on a file that is not part of the
repository:

    ERROR: builddir/meson-private/pycompile.py Imports are
    incorrectly sorted and/or formatted.

git itself is unaffected, because meson writes a builddir/.gitignore
containing '*'. Only isort sees the file.

Set skip_gitignore so isort behaves like ruff and black. No tracked
file matches a .gitignore pattern, so nothing checked today stops
being checked.
```

## Additional Context

I hit this while working on something unrelated. It reproduces from the
project's own build instructions, on a clean checkout:

```
$ meson setup builddir -Dinit_system=systemd   # per doc/rtd/development/build_system.rst
$ tox -e check_format
...
ERROR: builddir/meson-private/pycompile.py Imports are incorrectly sorted
and/or formatted.
```

`git status` stays clean throughout, because meson writes its own
`builddir/.gitignore` containing `*`. ruff and black both pass, since they
skip gitignored files by default. isort is the only one of the three that
does not, so it is the only tool that sees the generated file.

Before and after on the same tree:

```
before:  ERROR: builddir/meson-private/pycompile.py ...
         Skipped 5 files
after:   Skipped 8 files          (clean)
```

Things I checked rather than assumed:

- isort still catches real problems. I deliberately misordered the imports in
  a tracked file and it was flagged as expected.
- Coverage does not shrink. `git ls-files | git check-ignore --stdin` returns
  nothing, so no tracked file matches a `.gitignore` pattern and nothing that
  is checked today stops being checked.
- Outside a git repository isort still works correctly, though `git ls-files`
  prints `fatal: not a git repository` on stderr. That only shows up if isort
  is run from an unpacked tarball, which is not something the tox envs do.

A narrower alternative would be adding `builddir` to the existing `skip`
list. I went with `skip_gitignore` because the same problem applies to other
entries already in `.gitignore` that can contain Python files after a build,
such as `build`, `dist`, `parts`, `prime`, `stage` and `.venv/`, and because
it makes isort consistent with ruff and black. Happy to switch to the
targeted version if you would rather keep the change minimal.

## Test Steps

```
$ tox -e check_format
ruff: All checks passed!
pylint: Your code has been rated at 10.00/10
black: 595 files would be left unchanged.
isort: Skipped 8 files
mypy: Success: no issues found in 591 source files
congratulations :)

$ tox -e py3
5742 passed, 5 skipped, 13 xfailed, 10 warnings in 150.15s
```

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
