### PR TITLE
fix: prevent traceback in util.get_hostname_fqdn when hostname is numeric

### DIFF
--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -1219,6 +1219,13 @@ def get_hostname_fqdn(cfg, cloud, metadata_only=False):
         fqdn = str(cfg["fqdn"])
         hostname = get_cfg_option_str(cfg, "hostname", fqdn.split(".")[0])
     else:
+        if "hostname" in cfg and not isinstance(cfg["hostname"], str):
+            LOG.warning(
+                "Invalid hostname type: expected string, got %s",
+                type(cfg["hostname"]).__name__,
+            )
+            return HostnameFqdnInfo("", "", False)
+
         if "hostname" in cfg and cfg["hostname"].find(".") > 0:
             # user specified hostname, and it had '.' in it
             # be nice to them.  set fqdn and hostname from that

--- a/tests/unittests/test_util.py
+++ b/tests/unittests/test_util.py
@@ -820,6 +820,15 @@ class TestGetHostnameFqdn:
             mock.call(metadata_only=True),
         ] == cloud.get_hostname.call_args_list
 
+    def test_get_hostname_fqdn_with_numeric_hostname(self):
+        """When hostname is numeric, return empty values."""
+        (hostname, fqdn, is_default) = util.get_hostname_fqdn(
+            cfg={"hostname": 12345}, cloud=None
+        )
+        assert hostname == ""
+        assert fqdn == ""
+        assert is_default is False
+
 
 class TestBlkid:
     ids = {


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [.] I have signed the CLA: https://ubuntu.com/legal/contributors
-  [.] I have included a comprehensive commit message using the guide below
- [.] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [.] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [.] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e doc``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix: prevent traceback in util.get_hostname_fqdn when hostname is numeric

Catch the AttributeError thrown in util.get_hostname_fqdn and return empty hostname and fqdn to prevent cloud-init from crashing due to bad schema and log a warning instead.

Fixes GH-7006

```

## Additional Context
Reproduced the error using QEMU and the following user-data file 
```
#cloud-config
hostname: 123456
password: password
chpasswd:
  expire: False
```

Fixes [#7007](https://github.com/canonical/cloud-init/issues/7006)

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

```
tox -e py3
```
## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
