### PR TITLE
chore: fix format failures from commit 34c74efa

### DIFF
--- a/tests/unittests/net/test_network_manager.py
+++ b/tests/unittests/net/test_network_manager.py
@@ -266,8 +266,7 @@ class TestNetworkManagerRenderNetworkState:
         primary-reselect-policy and transmit-hash-policy used to be
         silently dropped from the rendered bond. See GH-6932.
         """
-        config = textwrap.dedent(
-            """\
+        config = textwrap.dedent("""\
             version: 2
             ethernets:
               eth0:
@@ -286,8 +285,7 @@ class TestNetworkManagerRenderNetworkState:
                   fail-over-mac-policy: active
                   primary-reselect-policy: always
                   transmit-hash-policy: layer3+4
-            """
-        )
+            """)
 
         expected_config = {
             "/etc/NetworkManager/system-connections/cloud-init-bond0.nmconnection": textwrap.dedent(  # noqa: E501


### PR DESCRIPTION
## Proposed commit message
```
chore: fix format failures from commit 34c74efa (#7016)

The formatting changes of 340ac74 caused CI failures once
34c74efa merged.
```

## Test Steps
tox -e do_format # expect success

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
