### PR TITLE
ci: skip empty series file in packaging checks

### DIFF
--- a/.github/workflows/30-pr-packaging-patches-upstream.yml
+++ b/.github/workflows/30-pr-packaging-patches-upstream.yml
@@ -52,7 +52,7 @@ jobs:
           for BRANCH in ubuntu/devel ubuntu/resolute ubuntu/noble ubuntu/jammy; do
             # merge - this step is not expected to fail
             git merge "origin/$BRANCH"
-            if [ ! -f debian/patches/series || ! grep '[^[:space:]]' debian/patches/series ]; then
+            if ! grep --quiet --no-messages '[^[:space:]]' debian/patches/series; then
               echo "no patches, skipping $BRANCH"
               # undo merge - this step is not expected to fail
               git reset --hard origin/main

--- a/.github/workflows/30-pr-packaging-patches-upstream.yml
+++ b/.github/workflows/30-pr-packaging-patches-upstream.yml
@@ -52,7 +52,7 @@ jobs:
           for BRANCH in ubuntu/devel ubuntu/resolute ubuntu/noble ubuntu/jammy; do
             # merge - this step is not expected to fail
             git merge "origin/$BRANCH"
-            if [ ! -f debian/patches/series ]; then
+            if [ ! -f debian/patches/series || ! grep '[^[:space:]]' debian/patches/series ]; then
               echo "no patches, skipping $BRANCH"
               # undo merge - this step is not expected to fail
               git reset --hard origin/main

--- a/.github/workflows/44-packaging-downstream.yml
+++ b/.github/workflows/44-packaging-downstream.yml
@@ -32,7 +32,7 @@ jobs:
           # only run it if necessary to save some cycles.
           # GitHub Actions doesn't appear to have a simple mechanism for
           # early exit without failure
-          if [ ! -f debian/patches/series || ! grep '[^[:space:]]' debian/patches/series ]; then
+          if [ ! grep --quiet --no-messages '[^[:space:]]' debian/patches/series ]; then
             echo "no patches, skipping"
             exit 0
           fi
@@ -43,7 +43,7 @@ jobs:
         run: |
           # GitHub Actions doesn't appear to have a simple mechanism for
           # early exit without failure
-          if [ ! -f debian/patches/series || ! grep '[^[:space:]]' debian/patches/series ]; then
+          if [ ! grep --quiet --no-messages '[^[:space:]]' debian/patches/series ]; then
             echo "no patches, skipping"
             exit 0
           fi
@@ -59,7 +59,7 @@ jobs:
         run: |
           # GitHub Actions doesn't appear to have a simple mechanism for
           # early exit without failure
-          if [ ! -f debian/patches/series || ! grep '[^[:space:]]' debian/patches/series ]; then
+          if [ ! grep --quiet --no-messages '[^[:space:]]' debian/patches/series ]; then
             echo "no patches, skipping"
             exit 0
           fi
@@ -70,7 +70,7 @@ jobs:
         run: |
           # GitHub Actions doesn't appear to have a simple mechanism for
           # early exit without failure
-          if [ ! -f debian/patches/series || ! grep '[^[:space:]]' debian/patches/series ]; then
+          if [ grep --quiet --no-messages '[^[:space:]]' debian/patches/series ]; then
             echo "no patches, skipping"
             exit 0
           fi

--- a/.github/workflows/44-packaging-downstream.yml
+++ b/.github/workflows/44-packaging-downstream.yml
@@ -32,7 +32,7 @@ jobs:
           # only run it if necessary to save some cycles.
           # GitHub Actions doesn't appear to have a simple mechanism for
           # early exit without failure
-          if [ ! -f debian/patches/series ]; then
+          if [ ! -f debian/patches/series || ! grep '[^[:space:]]' debian/patches/series ]; then
             echo "no patches, skipping"
             exit 0
           fi
@@ -43,7 +43,7 @@ jobs:
         run: |
           # GitHub Actions doesn't appear to have a simple mechanism for
           # early exit without failure
-          if [ ! -f debian/patches/series ]; then
+          if [ ! -f debian/patches/series || ! grep '[^[:space:]]' debian/patches/series ]; then
             echo "no patches, skipping"
             exit 0
           fi
@@ -59,7 +59,7 @@ jobs:
         run: |
           # GitHub Actions doesn't appear to have a simple mechanism for
           # early exit without failure
-          if [ ! -f debian/patches/series ]; then
+          if [ ! -f debian/patches/series || ! grep '[^[:space:]]' debian/patches/series ]; then
             echo "no patches, skipping"
             exit 0
           fi
@@ -70,7 +70,7 @@ jobs:
         run: |
           # GitHub Actions doesn't appear to have a simple mechanism for
           # early exit without failure
-          if [ ! -f debian/patches/series ]; then
+          if [ ! -f debian/patches/series || ! grep '[^[:space:]]' debian/patches/series ]; then
             echo "no patches, skipping"
             exit 0
           fi


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [ ] I have signed the CLA: https://ubuntu.com/legal/contributors
- [ ] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [ ] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e doc``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
ci: skip empty series file in packaging workflow

The existing code assumes that the existence of a series
file means that patches exist.
```

## Additional Context

https://github.com/canonical/cloud-init/actions/runs/32418269637/job/96584312527?pr=7020

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
