### PR TITLE
typing: check untyped CA certificates module

### DIFF
--- a/cloudinit/config/cc_ca_certs.py
+++ b/cloudinit/config/cc_ca_certs.py
@@ -6,6 +6,7 @@
 
 import logging
 import os
+from typing import Any, Dict
 
 from cloudinit import lifecycle, subp, util
 from cloudinit.cloud import Cloud
@@ -15,14 +16,14 @@ from cloudinit.settings import PER_INSTANCE
 
 LOG = logging.getLogger(__name__)
 
-DEFAULT_CONFIG = {
+DEFAULT_CONFIG: Dict[str, Any] = {
     "ca_cert_path": None,
     "ca_cert_local_path": "/usr/local/share/ca-certificates/",
     "ca_cert_filename": "cloud-init-ca-cert-{cert_index}.crt",
     "ca_cert_config": "/etc/ca-certificates.conf",
     "ca_cert_update_cmd": ["update-ca-certificates"],
 }
-DISTRO_OVERRIDES = {
+DISTRO_OVERRIDES: Dict[str, Dict[str, Any]] = {
     "aosc": {
         "ca_cert_path": "/etc/ssl/certs/",
         "ca_cert_local_path": "/etc/ssl/certs/",
@@ -156,7 +157,7 @@ def disable_default_ca_certs(distro_name, distro_cfg):
             debconf_sel = (
                 "ca-certificates ca-certificates/trust_new_crts " + "select no"
             )
-            subp.subp(("debconf-set-selections", "-"), data=debconf_sel)
+            subp.subp(["debconf-set-selections", "-"], data=debconf_sel)
 
 
 def disable_system_ca_certs(distro_cfg):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,6 @@ no_implicit_optional = true
 [[tool.mypy.overrides]]
 module = [
     "cloudinit.config.cc_apt_configure",
-    "cloudinit.config.cc_ca_certs",
     "cloudinit.config.cc_growpart",
     "cloudinit.config.cc_ntp",
     "cloudinit.config.modules",
@@ -83,7 +82,6 @@ module = [
     "tests.unittests.config.test_apt_configure_sources_list_v3",
     "tests.unittests.config.test_apt_source_v1",
     "tests.unittests.config.test_cc_apt_pipelining",
-    "tests.unittests.config.test_cc_ca_certs",
     "tests.unittests.config.test_cc_chef",
     "tests.unittests.config.test_cc_final_message",
     "tests.unittests.config.test_cc_growpart",

--- a/tests/unittests/config/test_cc_ca_certs.py
+++ b/tests/unittests/config/test_cc_ca_certs.py
@@ -8,7 +8,7 @@ from unittest import mock
 import pytest
 
 from cloudinit import distros, helpers, subp, util
-from cloudinit.config import cc_ca_certs
+from cloudinit.config import Config, cc_ca_certs
 from cloudinit.config.schema import (
     SchemaValidationError,
     get_schema,
@@ -26,8 +26,8 @@ class TestNoConfig:
         Test that nothing is done if no ca-certs configuration is provided.
         """
         name = "ca_certs"
-        cloud_init = None
-        args = []
+        cloud_init = get_cloud("ubuntu")
+        args: List[str] = []
 
         config = util.get_builtin_cfg()
         with mock.patch.object(util, "write_file") as util_mock:
@@ -70,7 +70,7 @@ class TestConfig:
         Test that no certificates are written if the 'trusted' key is not
         present.
         """
-        config = {"ca_certs": {}}
+        config: Config = {"ca_certs": {}}
         cloud = get_cloud(distro_name)
         cc_ca_certs.handle(self.name, config, cloud, self.args)
 
@@ -85,7 +85,7 @@ class TestConfig:
     )
     def test_empty_trusted_list(self, _, distro_name, ca_mocks):
         """Test that no certificate are written if 'trusted' list is empty."""
-        config = {"ca_certs": {"trusted": []}}
+        config: Config = {"ca_certs": {"trusted": []}}
         cloud = get_cloud(distro_name)
         cc_ca_certs.handle(self.name, config, cloud, self.args)
 
@@ -311,7 +311,7 @@ class TestRemoveDefaultCaCerts:
 
                             if distro_name in ["debian", "ubuntu"]:
                                 mock_subp.assert_called_once_with(
-                                    ("debconf-set-selections", "-"),
+                                    ["debconf-set-selections", "-"],
                                     data=(
                                         "ca-certificates ca-certificates/"
                                         "trust_new_crts select no"


### PR DESCRIPTION
## Proposed Commit Message

```
chore(typing): check untyped CA certificates module

Type the heterogeneous distro configuration dictionaries and ambiguous test
values, and pass the debconf command in the list form accepted by subp.
Remove the source and test modules from the check_untyped_defs exemption.

Refs GH-5445
```

## Additional Context

This is the unclaimed `cloudinit.config.cc_ca_certs` slice of GH-5445. It does not change the user interface.

## Test Steps

```
python -m mypy cloudinit/config/cc_ca_certs.py
python -m mypy --follow-imports=skip cloudinit/config/cc_ca_certs.py tests/unittests/config/test_cc_ca_certs.py
python -m pytest -q tests/unittests/config/test_cc_ca_certs.py
python -m ruff check cloudinit/config/cc_ca_certs.py tests/unittests/config/test_cc_ca_certs.py
python -m black --check cloudinit/config/cc_ca_certs.py tests/unittests/config/test_cc_ca_certs.py
python -m isort --check-only --diff cloudinit/config/cc_ca_certs.py tests/unittests/config/test_cc_ca_certs.py
python -m pylint cloudinit/config/cc_ca_certs.py tests/unittests/config/test_cc_ca_certs.py
```

The focused unit suite reports 270 passed, and pylint reports 10.00/10.

## Merge type

- [x] Squash merge using Proposed Commit Message
- [ ] Rebase and merge unique commits.