### PR TITLE
chore: add type annotations to cloudinit.distros.ug_util

### DIFF
--- a/cloudinit/distros/ug_util.py
+++ b/cloudinit/distros/ug_util.py
@@ -10,6 +10,7 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
 import logging
+from typing import Any, Dict, List
 
 from cloudinit import lifecycle, type_utils, util
 
@@ -26,7 +27,7 @@ def _normalize_groups(grp_cfg):
         grp_cfg = grp_cfg.strip().split(",")
 
     if isinstance(grp_cfg, list):
-        c_grp_cfg = {}
+        c_grp_cfg: Dict[str, List[str]] = {}
         for i in grp_cfg:
             if isinstance(i, dict):
                 for k, v in i.items():
@@ -72,7 +73,7 @@ def _normalize_groups(grp_cfg):
 # marked false.
 def _normalize_users(u_cfg, def_user_cfg=None):
     if isinstance(u_cfg, dict):
-        ad_ucfg = []
+        ad_ucfg: List[Any] = []
         for k, v in u_cfg.items():
             if isinstance(v, (bool, int, float, str)):
                 if util.is_true(v):
@@ -89,7 +90,7 @@ def _normalize_users(u_cfg, def_user_cfg=None):
     elif isinstance(u_cfg, str):
         u_cfg = util.uniq_merge_sorted(u_cfg)
 
-    users = {}
+    users: Dict[str, Dict[str, Any]] = {}
     for user_config in u_cfg:
         if isinstance(user_config, (list, str)):
             for u in util.uniq_merge(user_config):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,6 @@ module = [
     "cloudinit.distros.opensuse",
     "cloudinit.distros.parsers.hostname",
     "cloudinit.distros.parsers.resolv_conf",
-    "cloudinit.distros.ug_util",
     "cloudinit.helpers",
     "cloudinit.net.ephemeral",
     "cloudinit.net.freebsd",


### PR DESCRIPTION
## Proposed Commit Message
```
chore: add type annotations to cloudinit.distros.ug_util

_normalize_groups and _normalize_users seed empty collections before
filling them in the loops below, which mypy cannot infer element
types for once check_untyped_defs is enabled.

Annotate c_grp_cfg as Dict[str, List[str]] and users as
Dict[str, Dict[str, Any]], matching what each loop stores. ad_ucfg
takes both str(k) and the user config dict, so it is List[Any]; that
mismatch is what the arg-type error on its append was pointing at.

Drop cloudinit.distros.ug_util from the mypy override list in
pyproject.toml.

Refs GH-5445
```

## Additional Context

Refs GH-5445. This module is marked as a priority in the issue checklist.

Removing it from the override list surfaces three errors, all of them empty
collections that get filled further down the same function:

```
ug_util.py:29: Need type annotation for "c_grp_cfg"  [var-annotated]
ug_util.py:82: Argument 1 to "append" of "list" has incompatible type
               "dict[Any, Any]"; expected "str"      [arg-type]
ug_util.py:92: Need type annotation for "users"      [var-annotated]
```

The types come from what each loop stores:

- `c_grp_cfg` is keyed by group name and its values are built with
  `setdefault(k, []).extend(v)` and `.append(v)` where `v` has already been
  narrowed to `list` or `str`, so `Dict[str, List[str]]`.
- `users` is keyed by user name and holds either `{}` or the result of
  `util.mergemanydict(...)`, so `Dict[str, Dict[str, Any]]`.
- `ad_ucfg` is the interesting one. mypy infers `List[str]` from the first
  `ad_ucfg.append(str(k))`, then the `elif isinstance(v, dict)` branch appends
  the config dict itself. The list genuinely holds both, and the loop that
  consumes it in `_normalize_users` isinstance-checks for `list`, `str` and
  `dict`, so `List[Any]` reflects what is actually stored. That is the
  arg-type error above, rather than a separate problem.

No signatures change, so there is no effect on callers.

## Test Steps

Annotation only, with no runtime behaviour change, so no new tests.
`tests/unittests/distros/test_user_data_normalize.py` already covers both
`_normalize_groups` and `_normalize_users`, including the dict, list and
string input forms.

```
$ tox -e py3
5743 passed, 5 skipped, 13 xfailed, 10 warnings in 187.59s

$ tox -e check_format
ruff: All checks passed!
pylint: Your code has been rated at 10.00/10
black: 595 files would be left unchanged.
isort: Skipped 8 files
mypy: Success: no issues found in 591 source files
congratulations :)
```

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
