### PR TITLE
doc: document execution frequency for x-shellscript MIME types

### DIFF
--- a/doc/rtd/explanation/format/mime.rst
+++ b/doc/rtd/explanation/format/mime.rst
@@ -58,16 +58,43 @@ The :command:`make-mime` subcommand takes pairs of (filename, "text/" mime
 subtype) separated by a colon (e.g., ``config.yaml:cloud-config``) and emits a
 MIME multipart message to :file:`stdout`.
 
+Frequency-based shell scripts
+-----------------------------
+
+When using MIME multi-part archives, shell scripts can be configured to run
+at different frequencies by setting the appropriate MIME content-type:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 25 40
+
+   * - MIME Content-Type
+     - Execution Frequency
+     - Target Directory
+   * - ``text/x-shellscript-per-boot``
+     - Every boot
+     - :file:`/var/lib/cloud/scripts/per-boot/`
+   * - ``text/x-shellscript-per-instance``
+     - Once per new instance ID
+     - :file:`/var/lib/cloud/scripts/per-instance/`
+   * - ``text/x-shellscript-per-once``
+     - Once for the lifetime of the machine
+     - :file:`/var/lib/cloud/scripts/per-once/`
+
+These scripts are written to their respective directories during the part
+handling stage and executed during cloud-init's final stage by the
+:ref:`cc_scripts_user<mod_cc_scripts_user>` module.
+
 **MIME subcommand Examples**
 
 Create user-data containing both a cloud-config (:file:`config.yaml`)
-and a shell script (:file:`script.sh`)
+and a shell script (:file:`script.sh`):
 
 .. code-block:: shell-session
 
     $ cloud-init devel make-mime -a config.yaml:cloud-config -a script.sh:x-shellscript > user-data.mime
 
-Create user-data containing 3 shell scripts:
+Create user-data containing 3 shell scripts with different frequencies:
 
 - :file:`always.sh` - run every boot
 - :file:`instance.sh` - run once per instance
@@ -75,6 +102,7 @@ Create user-data containing 3 shell scripts:
 
 .. code-block:: shell-session
 
-    $ cloud-init devel make-mime -a always.sh:x-shellscript-per-boot -a instance.sh:x-shellscript-per-instance -a once.sh:x-shellscript-per-once
+    $ cloud-init devel make-mime -a always.sh:x-shellscript-per-boot -a instance.sh:x-shellscript-per-instance -a once.sh:x-shellscript-per-once > user-data.mime
 
 .. _make-mime: https://github.com/canonical/cloud-init/blob/main/cloudinit/cmd/devel/make_mime.py
+

--- a/doc/rtd/explanation/format/user-data-script.rst
+++ b/doc/rtd/explanation/format/user-data-script.rst
@@ -19,6 +19,12 @@ User-data scripts are run relatively late in the boot process, during
 cloud-init's :ref:`final stage<boot-Final>` as part of the
 :ref:`cc_scripts_user<mod_cc_scripts_user>` module.
 
+.. note::
+    To execute scripts on every boot or only once per machine lifetime,
+    use a :ref:`MIME multi-part archive<user_data_formats-mime_archive>`
+    with the frequency-specific MIME types (``text/x-shellscript-per-boot``
+    or ``text/x-shellscript-per-once``).
+
 .. warning::
     Use of ``INSTANCE_ID`` variable within user-data scripts is deprecated.
     Use :ref:`jinja templates<user_data_formats-jinja>` with


### PR DESCRIPTION
## Summary of changes
This PR documents the behavior, execution frequencies, and storage paths for the `text/x-shellscript-*` MIME types in `doc/rtd/explanation/format/mime.rst`:
- Added a reference table mapping `text/x-shellscript-per-boot`, `text/x-shellscript-per-instance`, and `text/x-shellscript-per-once` to their execution frequency and target directories under `/var/lib/cloud/scripts/`.
- Clarified that scripts are executed in the final boot stage by the `cc_scripts_user` module.
- Added a cross-reference note in `doc/rtd/explanation/format/user-data-script.rst`.

Fixes #6283

## Testing done
Ran pytest unit tests locally:
```bash
pytest tests/unittests
```
All unit tests passed.