### PR TITLE
doc: clarify required vs optional files for NoCloud datasource

### DIFF
--- a/doc/rtd/reference/datasources/nocloud.rst
+++ b/doc/rtd/reference/datasources/nocloud.rst
@@ -205,25 +205,40 @@ Source files
 ------------
 
 The base path pointed to by the URI in the above sources provides content
-using the following final path components:
+using the following path components:
 
-* ``user-data``
-* ``meta-data``
-* ``vendor-data``
-* ``network-config``
+* **Required files:**
 
-For example, if the ``seedfrom`` value of ``seedfrom`` is
-``https://10.42.42.42/``, then the following files will be fetched from the
-webserver at first boot:
+  * ``meta-data`` (required): Contains cloud-instance information.
+    It is recommended to define a unique ``instance-id``.
+  * ``user-data`` (required): Contains user configuration instructions
+    (can be empty if no configuration is needed).
 
-.. code-block:: sh
+* **Optional files:**
+
+  * ``vendor-data`` (optional): Used for cloud provider defaults.
+  * ``network-config`` (optional): Network configuration if differing
+    from defaults.
+
+.. note::
+
+   Both ``user-data`` and ``meta-data`` must be present. If either of these
+   required files is missing, the NoCloud datasource will treat the seed as
+   invalid and skip it (e.g., logging a warning such as
+   ``device ... with label=cidata not a valid seed``).
+
+For example, if the ``seedfrom`` value is ``https://10.42.42.42/``, then
+the following files will be fetched from the webserver at first boot:
+
+.. code-block:: text
 
     https://10.42.42.42/user-data
-    https://10.42.42.42/vendor-data
     https://10.42.42.42/meta-data
+    https://10.42.42.42/vendor-data
     https://10.42.42.42/network-config
 
-If the required files don't exist, this datasource will be skipped.
+If the required files (``user-data`` and ``meta-data``) do not exist,
+this datasource will be skipped.
 
 .. _line_config_detail:
 

--- a/doc/rtd/reference/datasources/nocloud.rst
+++ b/doc/rtd/reference/datasources/nocloud.rst
@@ -22,29 +22,29 @@ discovery configuration can be delivered to cloud-init in different ways, but
 is different from the configurations that cloud-init uses to configure the
 instance at runtime.
 
-user-data
----------
+user-data (required)
+--------------------
 
 User-data is a :ref:`configuration format<user_data_formats>` that allows a
 user to configure an instance.
 
-meta-data
----------
+meta-data (required)
+--------------------
 
 The ``meta-data`` file is a YAML-formatted file which contains cloud-provided
 information to the instance. This is required to contain an ``instance-id``,
 with other cloud-specific keys available.
 
-vendor-data
------------
+vendor-data (optional)
+----------------------
 
 Vendor-data may be used to provide default cloud-specific configurations which
 may be overridden by user-data. This may be useful, for example, to configure
 an instance with a cloud provider's repository mirror for faster package
 installation.
 
-network-config
---------------
+network-config (optional)
+-------------------------
 
 Network configuration typically comes from the cloud provider to set
 cloud-specific network configurations, or a reasonable default is set by
@@ -209,23 +209,22 @@ using the following path components:
 
 * **Required files:**
 
-  * ``meta-data`` (required): Contains cloud-instance information.
+  * ``meta-data``: Contains cloud-instance information.
     It is recommended to define a unique ``instance-id``.
-  * ``user-data`` (required): Contains user configuration instructions
+  * ``user-data``: Contains user configuration instructions
     (can be empty if no configuration is needed).
 
 * **Optional files:**
 
-  * ``vendor-data`` (optional): Used for cloud provider defaults.
-  * ``network-config`` (optional): Network configuration if differing
+  * ``vendor-data``: Used for cloud provider defaults.
+  * ``network-config``: Network configuration if differing
     from defaults.
 
 .. note::
 
    Both ``user-data`` and ``meta-data`` must be present. If either of these
    required files is missing, the NoCloud datasource will treat the seed as
-   invalid and skip it (e.g., logging a warning such as
-   ``device ... with label=cidata not a valid seed``).
+   invalid and skip it while logging a warning.
 
 For example, if the ``seedfrom`` value is ``https://10.42.42.42/``, then
 the following files will be fetched from the webserver at first boot:


### PR DESCRIPTION
## Summary of changes
This PR updates the NoCloud documentation in `doc/rtd/reference/datasources/nocloud.rst`:
- Explicitly lists `meta-data` and `user-data` as **Required files** and `vendor-data` and `network-config` as **Optional files**.
- Adds an explanatory note clarifying that if either `user-data` or `meta-data` is missing, the NoCloud datasource treats the seed as invalid and skips it (which often manifests as `device ... with label=cidata not a valid seed`).

Fixes #5858

## Testing done
Ran pytest unit tests locally:
```bash
pytest tests/unittests
```
All tests passed.