### PR TITLE
fix(net): skip v1 physical entries missing name in extract_physdevs

### DIFF
--- a/cloudinit/net/__init__.py
+++ b/cloudinit/net/__init__.py
@@ -356,6 +356,8 @@ def is_vlan(devname):
 
 def device_driver(devname):
     """Return the device driver for net device named 'devname'."""
+    if not devname:
+        return None
     driver = None
     driver_path = sys_dev_path(devname, "device/driver")
     # driver is a symlink to the driver *dir*
@@ -367,6 +369,8 @@ def device_driver(devname):
 
 def device_devid(devname):
     """Return the device id string for net device named 'devname'."""
+    if not devname:
+        return None
     dev_id = read_sys_net_safe(devname, "device/device")
     if dev_id is False:
         return None
@@ -601,6 +605,8 @@ def extract_physdevs(netcfg):
             if not mac:
                 continue
             name = ent.get("name")
+            if not name:
+                continue
             driver = ent.get("params", {}).get("driver")
             device_id = ent.get("params", {}).get("device_id")
             if not driver:

--- a/tests/unittests/net/test_init.py
+++ b/tests/unittests/net/test_init.py
@@ -1351,6 +1351,25 @@ class TestExtractPhysdevs:
         }
         assert sorted(physdevs) == sorted(net.extract_physdevs(netcfg))
 
+    def test_get_v1_type_physical_skips_if_no_name(self):
+        netcfg = {
+            "version": 1,
+            "config": [
+                {
+                    "type": "physical",
+                    "mac_address": "86:00:00:3c:5c:43",
+                    "name": None,
+                    "subnets": [{"type": "dhcp", "ipv4": True}],
+                },
+                {
+                    "type": "physical",
+                    "mac_address": "86:00:00:3c:5c:44",
+                    "subnets": [{"type": "dhcp", "ipv4": True}],
+                },
+            ],
+        }
+        assert [] == net.extract_physdevs(netcfg)
+
     def test_get_v2_type_physical_skips_if_no_set_name(self):
         netcfg = {
             "version": 2,


### PR DESCRIPTION
## Problem
When parsing network-config v1 in `extract_physdevs`, physical entries without a `name` (such as private NICs on Hetzner Cloud that have not hotplugged yet) were not skipped, leading to `device_driver(None)` being called and raising:
```
TypeError: can only concatenate str (not "NoneType") to str
```

## Solution
1. In `extract_physdevs._version_1`, check if `name` is present before looking up device drivers/ids, matching the existing check in `_version_2`.
2. Add defensive `if not devname:` guards in `device_driver()` and `device_devid()` helpers to prevent `TypeError` when empty or `None` values are passed.
3. Added unit tests under `tests/unittests/net/test_init.py` to verify that v1 configs with `name: None` or missing names are safely skipped.

Fixes #6982

## Testing
- Added and executed `test_get_v1_type_physical_skips_if_no_name` under `tests/unittests/net/test_init.py`.
- All 157 net unit tests pass cleanly.