### PR TITLE
fix(cloudstack): avoid UnboundLocalError for primary_nic on NoDHCPLeaseError

### DIFF
--- a/cloudinit/sources/DataSourceCloudStack.py
+++ b/cloudinit/sources/DataSourceCloudStack.py
@@ -216,6 +216,7 @@ class DataSourceCloudStack(sources.DataSource):
             self.metadata = seed_ret["meta-data"]
             LOG.debug("Using seeded cloudstack data from: %s", self.seed_dir)
             return True
+        primary_nic = None
         if self.perform_dhcp_setup:
             primary_nic = net.find_fallback_nic()
             LOG.debug("Attempting DHCP on: %s", primary_nic)

--- a/tests/unittests/sources/test_cloudstack.py
+++ b/tests/unittests/sources/test_cloudstack.py
@@ -782,4 +782,3 @@ class TestDataSourceCloudStackLocal:
         ds = DataSourceCloudStack({}, distro, paths)
         ds.perform_dhcp_setup = False
         assert ds._get_data() is False
-

--- a/tests/unittests/sources/test_cloudstack.py
+++ b/tests/unittests/sources/test_cloudstack.py
@@ -778,9 +778,7 @@ class TestDataSourceCloudStackLocal:
         tmpdir,
     ):
         distro = MockDistro()
-        ds = DataSourceCloudStack(
-            {}, distro, helpers.Paths({"run_dir": tmpdir})
-        )
+        ds = DataSourceCloudStack({}, distro, helpers.Paths({"run_dir": tmpdir}))
         ds.perform_dhcp_setup = False
         assert ds._get_data() is False
 

--- a/tests/unittests/sources/test_cloudstack.py
+++ b/tests/unittests/sources/test_cloudstack.py
@@ -778,7 +778,8 @@ class TestDataSourceCloudStackLocal:
         tmpdir,
     ):
         distro = MockDistro()
-        ds = DataSourceCloudStack({}, distro, helpers.Paths({"run_dir": tmpdir}))
+        paths = helpers.Paths({"run_dir": tmpdir})
+        ds = DataSourceCloudStack({}, distro, paths)
         ds.perform_dhcp_setup = False
         assert ds._get_data() is False
 

--- a/tests/unittests/sources/test_cloudstack.py
+++ b/tests/unittests/sources/test_cloudstack.py
@@ -770,3 +770,17 @@ class TestDataSourceCloudStackLocal:
         assert ds._get_data() is True
         assert ds.userdata_raw == "ud"
         assert ds.metadata == "md"
+
+    @mock.patch(MOD_PATH + ".get_vr_address", side_effect=NoDHCPLeaseError)
+    def test_get_data_no_dhcp_lease_error_without_dhcp_setup(
+        self,
+        m_get_vr_address,
+        tmpdir,
+    ):
+        distro = MockDistro()
+        ds = DataSourceCloudStack(
+            {}, distro, helpers.Paths({"run_dir": tmpdir})
+        )
+        ds.perform_dhcp_setup = False
+        assert ds._get_data() is False
+


### PR DESCRIPTION
## Problem
In `DataSourceCloudStack._get_data`, when `self.perform_dhcp_setup` is `False`, `primary_nic` is never assigned. If `get_vr_address(self.distro)` subsequently raises a `NoDHCPLeaseError`, the exception handler attempts to log:
```python
LOG.warning("Unable to obtain a DHCP lease on %s", primary_nic)
```
which crashes with:
```
UnboundLocalError: cannot access local variable 'primary_nic' where it is not associated with a value
```

## Solution
- Initialized `primary_nic = None` before the DHCP setup branch in `DataSourceCloudStack._get_data`.
- Added unit test `test_get_data_no_dhcp_lease_error_without_dhcp_setup` under `tests/unittests/sources/test_cloudstack.py` to verify that `NoDHCPLeaseError` with `perform_dhcp_setup=False` logs cleanly and returns `False` without raising an `UnboundLocalError`.

Fixes #6838

## Testing
- Verified test failure prior to the fix (`UnboundLocalError` reproduced).
- Verified that all 29 tests in `tests/unittests/sources/test_cloudstack.py` pass with 100% success after the fix.