### PR TITLE
chore(netlink): enable untyped function checks

### DIFF
--- a/cloudinit/sources/helpers/netlink.py
+++ b/cloudinit/sources/helpers/netlink.py
@@ -68,7 +68,7 @@ def create_bound_netlink_socket():
             socket.AF_NETLINK, socket.SOCK_RAW, socket.NETLINK_ROUTE
         )
         netlink_socket.bind((os.getpid(), RTMGRP_LINK))
-        netlink_socket.setblocking(0)
+        netlink_socket.setblocking(False)
     except socket.error as e:
         msg = "Exception during netlink socket create: %s" % e
         raise NetlinkCreateSocketError(msg) from e

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,6 @@ module = [
     "cloudinit.sources.DataSourceSmartOS",
     "cloudinit.sources.DataSourceVMware",
     "cloudinit.sources.helpers.azure",
-    "cloudinit.sources.helpers.netlink",
     "cloudinit.sources.helpers.openstack",
     "cloudinit.sources.helpers.vmware.imc.config_file",
     "cloudinit.sources.helpers.vmware.imc.config_nic",


### PR DESCRIPTION
## Proposed Commit Message

```
chore(netlink): enable untyped function checks

Use a boolean when configuring the non-blocking netlink socket so the
function body passes mypy's stricter checking. Remove the module-level
check_untyped_defs exemption.

Refs GH-5445
```

## Additional Context

This is a typing-only cleanup. `False` preserves the behavior of the previous
`0` argument to `socket.setblocking`.

## Test Steps

```
.tox/mypy/bin/python -m mypy --platform linux cloudinit/sources/helpers/netlink.py
.tox/py3/bin/python -m pytest -q tests/unittests/sources/helpers/test_netlink.py
.tox/mypy/bin/python -m ruff check cloudinit/sources/helpers/netlink.py
.tox/mypy/bin/python -m black --check cloudinit/sources/helpers/netlink.py
.tox/mypy/bin/python -m isort --check-only --diff cloudinit/sources/helpers/netlink.py
```

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
