### PR TITLE
chore: add type annotations to cloudinit.config.modules

### DIFF
--- a/cloudinit/config/modules.py
+++ b/cloudinit/config/modules.py
@@ -342,8 +342,6 @@ class Modules:
         active_mods = []
         for module_details in mostly_mods:
             mod, name, _freq, _args = module_details
-            if mod is None:
-                continue
             worked_distros = mod.meta["distros"]
             if not _is_active(module_details, self.cfg):
                 inapplicable_mods.append(name)
@@ -359,7 +357,7 @@ class Modules:
                         skipped.append(name)
                         continue
                     forced.append(name)
-            active_mods.append([mod, name, _freq, _args])
+            active_mods.append(module_details)
 
         if inapplicable_mods:
             LOG.info(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,6 @@ module = [
     "cloudinit.config.cc_apt_configure",
     "cloudinit.config.cc_growpart",
     "cloudinit.config.cc_ntp",
-    "cloudinit.config.modules",
     "cloudinit.distros.alpine",
     "cloudinit.distros.azurelinux",
     "cloudinit.distros.bsd",

--- a/tests/unittests/config/test_modules.py
+++ b/tests/unittests/config/test_modules.py
@@ -134,7 +134,7 @@ class TestModules:
         assert mods.run_section("not_matter")
         if active:
             assert [
-                mock.call([list(module_details)])
+                mock.call([module_details])
             ] == m_run_modules.call_args_list
             assert not caplog.text
         else:
@@ -171,9 +171,7 @@ class TestModules:
         mocker.patch.object(module, "handle")
         m_run_modules = mocker.patch.object(mods, "_run_modules")
         assert mods.run_section("not_matter")
-        assert [
-            mock.call([list(module_details)])
-        ] == m_run_modules.call_args_list
+        assert [mock.call([module_details])] == m_run_modules.call_args_list
         assert "Skipping" not in caplog.text
 
     @mock.patch(M_PATH + "signature")


### PR DESCRIPTION
## Proposed Commit Message
```
chore: add type annotations to cloudinit.config.modules

run_section rebuilt each ModuleDetails as a plain list before handing
it to _run_modules, which is annotated List[ModuleDetails]. Append the
NamedTuple itself instead; _run_modules unpacks the same four values
either way. The unit test asserted the list shape, so update it to
match.

ModuleDetails.module is a ModuleType, and _fixup_modules only builds
one from importer.import_module, which raises rather than returning
None. The "if mod is None" guard is therefore unreachable, so drop it.

Drop cloudinit.config.modules from the mypy override list in
pyproject.toml.

Refs GH-5445
```

## Additional Context

Refs GH-5445. This module is marked as a priority in the issue checklist.

Removing it from the override list surfaces two errors:

```
modules.py:346: Statement is unreachable                        [unreachable]
modules.py:381: Argument 1 to "_run_modules" of "Modules" has incompatible
                type "list[list[object]]"; expected "list[ModuleDetails]"
                                                                  [arg-type]
```

**The arg-type error.** `run_section` unpacks a `ModuleDetails` and then
rebuilds it as a plain list:

```python
mod, name, _freq, _args = module_details
...
active_mods.append([mod, name, _freq, _args])
```

`_run_modules` is annotated `List[ModuleDetails]` and consumes it with
`for mod, name, freq, args in mostly_mods`, so it unpacks the same four
values whichever shape it receives. Appending `module_details` directly makes
the call match its annotation with no behaviour change.

`tests/unittests/config/test_modules.py` asserted the list shape via
`mock.call([list(module_details)])`, which is what had been holding the
mismatch in place, so I updated those two assertions to
`mock.call([module_details])`. That is the only test change.

**The unreachable error.** `ModuleDetails.module` is declared `ModuleType`,
and `_fixup_modules` is the only producer. It builds every entry from
`importer.import_module(...)`, which is annotated `-> ModuleType` and wraps
`importlib.import_module`, so it raises on failure rather than returning
`None`. There is no path that puts `None` in that field, so `if mod is None`
cannot fire and I removed it rather than silencing the check.

I deliberately left `tests.unittests.config.test_modules` in the override
list. It has six unrelated errors of its own, mostly extra keys on the
`MetaSchema` TypedDict, which are a separate piece of work.

## Test Steps

No runtime behaviour change. The existing tests cover both paths, and two
assertions were updated to match the corrected shape.

```
$ python -m pytest tests/unittests/config/test_modules.py -q
28 passed, 2 skipped

$ tox -e py3
5743 passed, 5 skipped, 13 xfailed, 10 warnings in 156.62s

$ tox -e check_format
ruff: All checks passed!
pylint: Your code has been rated at 10.00/10
black: 595 files would be left unchanged.
isort: Skipped 8 files
mypy: Success: no issues found in 591 source files
congratulations :)
```

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
