### PR TITLE
chore: add type annotation to cloudinit.net.netbsd

### DIFF
--- a/cloudinit/net/netbsd.py
+++ b/cloudinit/net/netbsd.py
@@ -1,6 +1,7 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
 import logging
+from typing import Optional
 
 import cloudinit.net.bsd
 from cloudinit import subp, util
@@ -9,10 +10,10 @@ LOG = logging.getLogger(__name__)
 
 
 class Renderer(cloudinit.net.bsd.BSDRenderer):
-    def __init__(self, config=None):
+    def __init__(self, config: Optional[dict] = None) -> None:
         super(Renderer, self).__init__()
 
-    def write_config(self):
+    def write_config(self, target=None) -> None:
         if self.dhcp_interfaces():
             self.set_rc_config_value("dhcpcd", "YES")
             self.set_rc_config_value(
@@ -20,13 +21,13 @@ class Renderer(cloudinit.net.bsd.BSDRenderer):
             )
         for device_name, v in self.interface_configurations.items():
             if isinstance(v, dict):
-                net_config = v.get("address") + " netmask " + v.get("netmask")
+                net_config = v["address"] + " netmask " + v["netmask"]
                 mtu = v.get("mtu")
                 if mtu:
                     net_config += " mtu %d" % mtu
                 self.set_rc_config_value("ifconfig_" + device_name, net_config)
 
-    def start_services(self, run=False):
+    def start_services(self, run: bool = False) -> None:
         if not run:
             LOG.debug("netbsd generate postcmd disabled")
             return
@@ -35,10 +36,10 @@ class Renderer(cloudinit.net.bsd.BSDRenderer):
         if self.dhcp_interfaces():
             subp.subp(["service", "dhcpcd", "restart"], capture=True)
 
-    def set_route(self, network, netmask, gateway):
+    def set_route(self, network: str, netmask: str, gateway: str) -> None:
         if network == "0.0.0.0":
             self.set_rc_config_value("defaultroute", gateway)
 
 
-def available(target=None):
+def available(target: Optional[str] = None) -> bool:
     return util.is_NetBSD()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,6 @@ module = [
     "cloudinit.helpers",
     "cloudinit.net.ephemeral",
     "cloudinit.net.freebsd",
-    "cloudinit.net.netbsd",
     "cloudinit.net.network_manager",
     "cloudinit.net.network_state",
     "cloudinit.net.networkd",


### PR DESCRIPTION
Ref: https://github.com/canonical/cloud-init/issues/5445#issuecomment-5355942409 
chore: Add type annotations to `cloudinit.net.netbsd` module and enable full type checking

- Added type hints to all methods in the `Renderer` class and `available()` function
- Changed dictionary access from `.get()` to direct indexing for required `address` and `netmask` fields in `write_config()`
- Removed `cloudinit.net.netbsd` from mypy's `check_untyped_defs = false` override list
