### PR TITLE
ds-identify: avoid EC2 false-positive detection when sys_vendor is Hetzner

### DIFF
--- a/tests/unittests/test_ds_identify.py
+++ b/tests/unittests/test_ds_identify.py
@@ -727,6 +727,11 @@ class TestDsIdentify(DsIdentifyBase):
             ),
             # Hetzner cloud is identified in sys_vendor.
             pytest.param("Hetzner", True, id="hetzner_found"),
+            pytest.param(
+                "Hetzner-with-ec2-like-uuid",
+                True,
+                id="hetzner_with_ec2_like_uuid_found",
+            ),
             # CloudCIX cloud is identified in dmi product-name
             pytest.param("CloudCIX", True, id="cloudcix_found"),
             # NWCS is identified in sys_vendor.
@@ -2261,6 +2266,13 @@ VALID_CFG = {
         ],
     },
     "Hetzner": {"ds": "Hetzner", "files": {P_SYS_VENDOR: "Hetzner\n"}},
+    "Hetzner-with-ec2-like-uuid": {
+        "ds": "Hetzner",
+        "files": {
+            P_SYS_VENDOR: "Hetzner\n",
+            P_PRODUCT_UUID: "545f25ec-662d-4691-b311-23cf1794b78c\n",
+        },
+    },
     "Hetzner-kenv": {
         "ds": "Hetzner",
         "mocks": [

--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -1405,6 +1405,10 @@ ec2_identify_platform() {
             _RET="Tilaa"
             return 0
             ;;
+        Hetzner)
+            _RET="$default"
+            return 0
+            ;;
     esac
 
     local product_name="${DI_DMI_PRODUCT_NAME}"


### PR DESCRIPTION
## Problem
On Hetzner VMs where the first octet of `product_uuid` ends in `2[0-9a-fA-F]ec` (e.g. `545f25ec-662d-4691-b311-23cf1794b78c`), `ec2_identify_platform` matched the pattern against AWS Nitro EC2 instance UUIDs, causing `ds-identify` to report both `Ec2` and `Hetzner` as found datasources.

## Solution
- Added an explicit check for the `Hetzner` vendor in `ec2_identify_platform` under `tools/ds-identify`, returning default platform status (`Unknown`).
- Added a regression test case `Hetzner-with-ec2-like-uuid` in `tests/unittests/test_ds_identify.py` verifying that Hetzner instances with matching UUID prefixes are only identified as `Hetzner`.

Fixes #6987

## Testing
- Executed unit tests in `tests/unittests/test_ds_identify.py` (131 passed, 1 xfailed).
- Verified all regression checks pass cleanly.