### PR TITLE
Ci rename filter tests param

### DIFF
--- a/.github/actions/integration-test/action.yml
+++ b/.github/actions/integration-test/action.yml
@@ -1,0 +1,138 @@
+name: Run cloud-init integration tests
+description: >
+  Shared composite action that runs the cloud-init integration test suite
+  for a given (release, platform, image_type) tuple and publishes the
+  resulting JUnit report. OCI-specific secret validation and credential
+  setup are NOT handled here; OCI callers must assert and write the OCI
+  config/key to ${{ runner.temp }}/oci/ before invoking this action.
+  Repository secrets (PYCLOUDLIB_TOML_B64, SSH_*) must be exposed to this
+  action via the calling job's `env:` mapping; this action MUST NOT be
+  triggered by PR-driven workflows to prevent secret exposure to untrusted
+  code submitted via pull requests.
+
+inputs:
+  release:
+    description: OS release identifier (e.g. jammy, noble, resolute, stonking)
+    required: true
+  platform:
+    description: Cloud-init platform identifier (e.g. lxd_container, lxd_vm, ec2, oci)
+    required: true
+  image_type:
+    description: Image type identifier (e.g. generic, minimal)
+    required: true
+  install_source:
+    description: cloud-init install source (e.g. ppa:cloud-init-dev/daily)
+    required: true
+  filter_tests:
+    description: Optional test filter expression passed through to tox
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Assert required repo secrets are set
+      shell: bash
+      env:
+        CLOUD_INIT_PLATFORM: ${{ inputs.platform }}
+      run: |
+        if [ -z "$REQUIRED_SECRET" ]; then
+           echo "ERROR: Missing required repo secret. Please provide the necessary repo secret at ${{ github.repository }}/settings/secrets/actions."
+           exit 1
+        fi
+        if [ -z "$SSH_PUBLIC_KEY" ]; then
+           echo "ERROR: Missing required repo secret. Please provide SSH_PUBLIC_KEY repo secret at ${{ github.repository }}/settings/secrets/actions."
+           exit 1
+        fi
+        if [ -z "$SSH_PRIVATE_KEY" ]; then
+           echo "ERROR: Missing required repo secret. Please provide SSH_PRIVATE_KEY repo secret at ${{ github.repository }}/settings/secrets/actions."
+           exit 1
+        fi
+    - name: Checkout
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+    - name: Setup LXD
+      # This shared action supports platforms including lxd_vm and
+      # lxd_container. Only install the lxd snap for those platforms; cloud
+      # platforms such as EC2 and OCI do not need it.
+      if: ${{ contains(fromJSON('["lxd_vm", "lxd_container"]'), inputs.platform) }}
+      uses: canonical/setup-lxd@8c6a87bfb56aa48f3fb9b830baa18562d8bfd4ee # v1
+      with:
+        channel: 6/stable
+    - name: Clean workspace
+      shell: bash
+      run: |
+        rm -rf ${{ github.workspace }}/cloud_init_test_logs/
+    - name: Setup SSH
+      shell: bash
+      run: |
+        mkdir -p ~/.ssh
+        sh -c 'printf "%s\n" "$SSH_PUBLIC_KEY" > ~/.ssh/cloudinit_id_rsa.pub'
+        # Dump secret using a subprocess to avoid accidental leaks when using set -x.
+        sh -c 'printf "%s\n" "$SSH_PRIVATE_KEY" | install -m 600 /dev/stdin ~/.ssh/cloudinit_id_rsa'
+    - name: Setup pycloudlib
+      shell: bash
+      env:
+        PYCLOUDLIB_CONFIG: ${{ runner.temp }}/pycloudlib.toml
+      run: |
+        sh -c 'echo "$REQUIRED_SECRET" | base64 -d > "$PYCLOUDLIB_CONFIG"'
+    - name: Install Dependencies
+      shell: bash
+      run: |
+        sudo DEBIAN_FRONTEND=noninteractive apt-get -qy update
+        sudo DEBIAN_FRONTEND=noninteractive apt-get -qy install tox distro-info-data devscripts
+    - name: Run integration Tests
+      shell: bash
+      env:
+        CLOUD_INIT_PLATFORM: ${{ inputs.platform }}
+        CLOUD_INIT_OS_IMAGE: ${{ inputs.release }}
+        CLOUD_INIT_OS_IMAGE_TYPE: ${{ inputs.image_type }}
+        CLOUD_INIT_CLOUD_INIT_SOURCE: ${{ inputs.install_source }}
+        CLOUD_INIT_LOCAL_LOG_PATH: ${{ github.workspace }}/cloud_init_test_logs
+        PYCLOUDLIB_CONFIG: ${{ runner.temp }}/pycloudlib.toml
+        PYCLOUDLIB_OCI_CONFIG_FILE_PATH: ${{ runner.temp }}/oci/config
+        PYCLOUDLIB_OCI_KEY_FILE_PATH: ${{ runner.temp }}/oci/key.pem
+      run: |
+        tox -e integration-tests -- --junitxml="${{ github.workspace }}/junit-report.xml" --color=yes ${{ inputs.filter_tests || 'tests/integration_tests' }}
+    - name: Publish Test Report with Insights
+      if: ${{ always() }}
+      uses: ctrf-io/github-test-reporter@024bc4b64d997ca9da86833c6b9548c55c620e40 # v1.0.26
+      with:
+        report-path: '${{ github.workspace }}/junit-report.xml'
+        title: '${{ inputs.platform }}-${{ inputs.release }}-${{ inputs.image_type }}:${{ inputs.install_source }}'
+        integrations-config: |
+          {
+            "junit-to-ctrf": {
+              "enabled": true,
+              "action": "convert",
+              "options": {
+                "output": "./ctrf-report.json",
+                "toolname": "junit-to-ctrf",
+                "useSuiteName": false,
+                "env": {
+                  "appName": "my-app"
+                }
+              }
+            }
+          }
+        summary-delta-report: true
+        insights-report: true
+        flaky-rate-report: true
+        slowest-report: true
+        upload-artifact: true
+        github-report: true
+        artifact-name: ctrf-report-${{ inputs.platform }}-${{ inputs.release }}
+      env:
+        GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
+    - name: Upload failure artifacts
+      if: ${{ failure() }}
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+      with:
+        name: failure-${{ github.job }}
+        path: ${{ github.workspace }}/cloud_init_test_logs/
+        retention-days: 2
+    - name: Clean pycloudlib
+      if: ${{ always() }}
+      shell: bash
+      run: |
+        rm -f ${{ runner.temp }}/pycloudlib.toml
+        rm -rf ${{ runner.temp }}/oci

--- a/.github/actions/integration-test/action.yml
+++ b/.github/actions/integration-test/action.yml
@@ -4,7 +4,7 @@ description: >
   for a given (release, platform, image_type) tuple and publishes the
   resulting JUnit report. OCI-specific secret validation and credential
   setup are NOT handled here; OCI callers must assert and write the OCI
-  config/key to ${{ runner.temp }}/oci/ before invoking this action.
+  config/key to the runner temp directory (passed via runner_temp) before invoking this action.
   Repository secrets (PYCLOUDLIB_TOML_B64, SSH_*) must be exposed to this
   action via the calling job's `env:` mapping; this action MUST NOT be
   triggered by PR-driven workflows to prevent secret exposure to untrusted
@@ -27,6 +27,12 @@ inputs:
     description: Optional test filter expression passed through to tox
     required: false
     default: ''
+  runner_temp:
+    description: >
+      The runner's temp directory (runner.temp). Passed by the caller
+      because the runner context is not available inside a composite action's
+      runs section at load time.
+    required: true
 
 runs:
   using: composite
@@ -72,7 +78,7 @@ runs:
     - name: Setup pycloudlib
       shell: bash
       env:
-        PYCLOUDLIB_CONFIG: ${{ runner.temp }}/pycloudlib.toml
+        PYCLOUDLIB_CONFIG: ${{ inputs.runner_temp }}/pycloudlib.toml
       run: |
         sh -c 'echo "$REQUIRED_SECRET" | base64 -d > "$PYCLOUDLIB_CONFIG"'
     - name: Install Dependencies
@@ -88,9 +94,9 @@ runs:
         CLOUD_INIT_OS_IMAGE_TYPE: ${{ inputs.image_type }}
         CLOUD_INIT_CLOUD_INIT_SOURCE: ${{ inputs.install_source }}
         CLOUD_INIT_LOCAL_LOG_PATH: ${{ github.workspace }}/cloud_init_test_logs
-        PYCLOUDLIB_CONFIG: ${{ runner.temp }}/pycloudlib.toml
-        PYCLOUDLIB_OCI_CONFIG_FILE_PATH: ${{ runner.temp }}/oci/config
-        PYCLOUDLIB_OCI_KEY_FILE_PATH: ${{ runner.temp }}/oci/key.pem
+        PYCLOUDLIB_CONFIG: ${{ inputs.runner_temp }}/pycloudlib.toml
+        PYCLOUDLIB_OCI_CONFIG_FILE_PATH: ${{ inputs.runner_temp }}/oci/config
+        PYCLOUDLIB_OCI_KEY_FILE_PATH: ${{ inputs.runner_temp }}/oci/key.pem
       run: |
         tox -e integration-tests -- --junitxml="${{ github.workspace }}/junit-report.xml" --color=yes ${{ inputs.filter_tests || 'tests/integration_tests' }}
     - name: Publish Test Report with Insights
@@ -134,5 +140,5 @@ runs:
       if: ${{ always() }}
       shell: bash
       run: |
-        rm -f ${{ runner.temp }}/pycloudlib.toml
-        rm -rf ${{ runner.temp }}/oci
+        rm -f ${{ inputs.runner_temp }}/pycloudlib.toml
+        rm -rf ${{ inputs.runner_temp }}/oci

--- a/.github/actions/integration-test/action.yml
+++ b/.github/actions/integration-test/action.yml
@@ -26,9 +26,8 @@ inputs:
   test_posargs:
     description: >
       Optional extra posargs appended to the `tox -e integration-tests`
-      invocation (after the hardcoded --junitxml/--color flags). Accepts
-      pytest flags and/or positional test paths/node IDs. Defaults to the
-      full `tests/integration_tests` suite.
+      invocation. Accepts pytest flags and/or positional test paths/node IDs.
+      When unspecified, the full `tests/integration_tests` path is provided.
     required: false
     default: ''
   runner_temp:

--- a/.github/actions/integration-test/action.yml
+++ b/.github/actions/integration-test/action.yml
@@ -23,8 +23,12 @@ inputs:
   install_source:
     description: cloud-init install source (e.g. ppa:cloud-init-dev/daily)
     required: true
-  filter_tests:
-    description: Optional test filter expression passed through to tox
+  test_posargs:
+    description: >
+      Optional extra posargs appended to the `tox -e integration-tests`
+      invocation (after the hardcoded --junitxml/--color flags). Accepts
+      pytest flags and/or positional test paths/node IDs. Defaults to the
+      full `tests/integration_tests` suite.
     required: false
     default: ''
   runner_temp:
@@ -98,7 +102,7 @@ runs:
         PYCLOUDLIB_OCI_CONFIG_FILE_PATH: ${{ inputs.runner_temp }}/oci/config
         PYCLOUDLIB_OCI_KEY_FILE_PATH: ${{ inputs.runner_temp }}/oci/key.pem
       run: |
-        tox -e integration-tests -- --junitxml="${{ github.workspace }}/junit-report.xml" --color=yes ${{ inputs.filter_tests || 'tests/integration_tests' }}
+        tox -e integration-tests -- --junitxml="${{ github.workspace }}/junit-report.xml" --color=yes ${{ inputs.test_posargs || 'tests/integration_tests' }}
     - name: Publish Test Report with Insights
       if: ${{ always() }}
       uses: ctrf-io/github-test-reporter@024bc4b64d997ca9da86833c6b9548c55c620e40 # v1.0.26

--- a/.github/actions/integration-test/action.yml
+++ b/.github/actions/integration-test/action.yml
@@ -142,3 +142,4 @@ runs:
       run: |
         rm -f ${{ inputs.runner_temp }}/pycloudlib.toml
         rm -rf ${{ inputs.runner_temp }}/oci
+        rm -rf ~/.ssh

--- a/.github/workflows/100-dispatch-common.yml
+++ b/.github/workflows/100-dispatch-common.yml
@@ -28,6 +28,10 @@ on:
         required: true
       SSH_PUBLIC_KEY:
         required: true
+      PYCLOUDLIB_OCI_CONFIG_B64:
+        required: false
+      PYCLOUDLIB_OCI_KEY_B64:
+        required: false
 
 jobs:
   integration-test:
@@ -38,6 +42,8 @@ jobs:
       REQUIRED_SECRET: ${{ secrets.PYCLOUDLIB_TOML_B64 }}
       SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
       SSH_PUBLIC_KEY: ${{ secrets.SSH_PUBLIC_KEY }}
+      PYCLOUDLIB_OCI_CONFIG_B64: ${{ secrets.PYCLOUDLIB_OCI_CONFIG_B64 }}
+      PYCLOUDLIB_OCI_KEY_B64: ${{ secrets.PYCLOUDLIB_OCI_KEY_B64 }}
       CLOUD_INIT_PLATFORM: ${{ inputs.platform }}
       CLOUD_INIT_OS_IMAGE: ${{ inputs.release }}
       CLOUD_INIT_OS_IMAGE_TYPE: ${{ inputs.image_type }}
@@ -57,6 +63,16 @@ jobs:
           if [ -z "$SSH_PRIVATE_KEY" ]; then
              echo "ERROR: Missing required repo secret. Please provide SSH_PRIVATE_KEY repo secret at ${{ github.repository }}/settings/secrets/actions."
              exit 1
+          fi
+          if [ "$CLOUD_INIT_PLATFORM" = "oci" ]; then
+            if [ -z "$PYCLOUDLIB_OCI_CONFIG_B64" ]; then
+              echo "ERROR: Missing required repo secret. Please provide PYCLOUDLIB_OCI_CONFIG_B64 repo secret at ${{ github.repository }}/settings/secrets/actions."
+              exit 1
+            fi
+            if [ -z "$PYCLOUDLIB_OCI_KEY_B64" ]; then
+              echo "ERROR: Missing required repo secret. Please provide PYCLOUDLIB_OCI_KEY_B64 repo secret at ${{ github.repository }}/settings/secrets/actions."
+              exit 1
+            fi
           fi
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -82,6 +98,15 @@ jobs:
           PYCLOUDLIB_CONFIG: ${{ runner.temp }}/pycloudlib.toml
         run: |
           sh -c 'echo "$REQUIRED_SECRET" | base64 -d > "$PYCLOUDLIB_CONFIG"'
+      - name: Setup OCI credentials
+        if: ${{ env.CLOUD_INIT_PLATFORM == 'oci' }}
+        env:
+          PYCLOUDLIB_OCI_CONFIG_FILE_PATH: ${{ runner.temp }}/oci/config
+          PYCLOUDLIB_OCI_KEY_FILE_PATH: ${{ runner.temp }}/oci/key.pem
+        run: |
+          mkdir -p "$(dirname "$PYCLOUDLIB_OCI_CONFIG_FILE_PATH")"
+          sh -c 'printf "%s\n" "$PYCLOUDLIB_OCI_CONFIG_B64" | base64 -d > "$PYCLOUDLIB_OCI_CONFIG_FILE_PATH"'
+          sh -c 'printf "%s\n" "$PYCLOUDLIB_OCI_KEY_B64" | base64 -d  | install -m 600 /dev/stdin "$PYCLOUDLIB_OCI_KEY_FILE_PATH"'
       - name: Install Dependencies
         run: |
           sudo DEBIAN_FRONTEND=noninteractive apt-get -qy update
@@ -90,6 +115,8 @@ jobs:
         env:
           CLOUD_INIT_LOCAL_LOG_PATH: ${{ github.workspace }}/cloud_init_test_logs
           PYCLOUDLIB_CONFIG: ${{ runner.temp }}/pycloudlib.toml
+          PYCLOUDLIB_OCI_CONFIG_FILE_PATH: ${{ runner.temp }}/oci/config
+          PYCLOUDLIB_OCI_KEY_FILE_PATH: ${{ runner.temp }}/oci/key.pem
         run: |
           tox -e integration-tests -- --junitxml="${{ github.workspace }}/junit-report.xml" --color=yes ${{ inputs.filter_tests || 'tests/integration_tests' }}
       - name: Publish Test Report with Insights
@@ -133,3 +160,4 @@ jobs:
         if: ${{ always() }}
         run: |
           rm -f ${{ runner.temp }}/pycloudlib.toml
+          rm -rf ${{ runner.temp }}/oci

--- a/.github/workflows/100-dispatch-common.yml
+++ b/.github/workflows/100-dispatch-common.yml
@@ -18,7 +18,7 @@ on:
       install_source:
         required: true
         type: string
-      filter_tests:
+      test_posargs:
         required: false
         type: string
     secrets:
@@ -118,7 +118,7 @@ jobs:
           PYCLOUDLIB_OCI_CONFIG_FILE_PATH: ${{ runner.temp }}/oci/config
           PYCLOUDLIB_OCI_KEY_FILE_PATH: ${{ runner.temp }}/oci/key.pem
         run: |
-          tox -e integration-tests -- --junitxml="${{ github.workspace }}/junit-report.xml" --color=yes ${{ inputs.filter_tests || 'tests/integration_tests' }}
+          tox -e integration-tests -- --junitxml="${{ github.workspace }}/junit-report.xml" --color=yes ${{ inputs.test_posargs || 'tests/integration_tests' }}
       - name: Publish Test Report with Insights
         if: ${{ always() }}
         uses: ctrf-io/github-test-reporter@024bc4b64d997ca9da86833c6b9548c55c620e40 # v1.0.26

--- a/.github/workflows/110-daily-integration-22.04-lxd_container.yml
+++ b/.github/workflows/110-daily-integration-22.04-lxd_container.yml
@@ -37,3 +37,4 @@ jobs:
           install_source: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
           image_type: ${{ inputs.image_type || 'generic' }}
           filter_tests: ${{ inputs.filter_tests }}
+          runner_temp: ${{ runner.temp }}

--- a/.github/workflows/110-daily-integration-22.04-lxd_container.yml
+++ b/.github/workflows/110-daily-integration-22.04-lxd_container.yml
@@ -21,14 +21,19 @@ on:
 
 jobs:
   jammy-lxd_container:
-    uses: ./.github/workflows/100-dispatch-common.yml
-    with:
-      release: jammy
-      platform: lxd_container
-      install_source: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
-      image_type: ${{ inputs.image_type || 'generic' }}
-      filter_tests: ${{ inputs.filter_tests }}
-    secrets:
-      PYCLOUDLIB_TOML_B64: ${{ secrets.PYCLOUDLIB_TOML_B64 }}
+    runs-on: ubuntu-latest
+    if: github.repository == 'canonical/cloud-init'
+    env:
+      REQUIRED_SECRET: ${{ secrets.PYCLOUDLIB_TOML_B64 }}
       SSH_PUBLIC_KEY: ${{ secrets.SSH_PUBLIC_KEY }}
       SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Run integration tests
+        uses: ./.github/actions/integration-test
+        with:
+          release: jammy
+          platform: lxd_container
+          install_source: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
+          image_type: ${{ inputs.image_type || 'generic' }}
+          filter_tests: ${{ inputs.filter_tests }}

--- a/.github/workflows/110-daily-integration-22.04-lxd_container.yml
+++ b/.github/workflows/110-daily-integration-22.04-lxd_container.yml
@@ -13,7 +13,7 @@ on:
         options:
         - generic
         - minimal
-      filter_tests:
+      test_posargs:
         required: false
         type: string
   schedule:
@@ -36,5 +36,5 @@ jobs:
           platform: lxd_container
           install_source: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
           image_type: ${{ inputs.image_type || 'generic' }}
-          filter_tests: ${{ inputs.filter_tests }}
+          test_posargs: ${{ inputs.test_posargs }}
           runner_temp: ${{ runner.temp }}

--- a/.github/workflows/111-daily-integration-24.04-lxd_container.yml
+++ b/.github/workflows/111-daily-integration-24.04-lxd_container.yml
@@ -37,3 +37,4 @@ jobs:
           install_source: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
           image_type: ${{ inputs.image_type || 'generic' }}
           filter_tests: ${{ inputs.filter_tests }}
+          runner_temp: ${{ runner.temp }}

--- a/.github/workflows/111-daily-integration-24.04-lxd_container.yml
+++ b/.github/workflows/111-daily-integration-24.04-lxd_container.yml
@@ -21,14 +21,19 @@ on:
 
 jobs:
   noble-lxd_container:
-    uses: ./.github/workflows/100-dispatch-common.yml
-    with:
-      release: noble
-      platform: lxd_container
-      install_source: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
-      image_type: ${{ inputs.image_type || 'generic' }}
-      filter_tests: ${{ inputs.filter_tests }}
-    secrets:
-      PYCLOUDLIB_TOML_B64: ${{ secrets.PYCLOUDLIB_TOML_B64 }}
+    runs-on: ubuntu-latest
+    if: github.repository == 'canonical/cloud-init'
+    env:
+      REQUIRED_SECRET: ${{ secrets.PYCLOUDLIB_TOML_B64 }}
       SSH_PUBLIC_KEY: ${{ secrets.SSH_PUBLIC_KEY }}
       SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Run integration tests
+        uses: ./.github/actions/integration-test
+        with:
+          release: noble
+          platform: lxd_container
+          install_source: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
+          image_type: ${{ inputs.image_type || 'generic' }}
+          filter_tests: ${{ inputs.filter_tests }}

--- a/.github/workflows/111-daily-integration-24.04-lxd_container.yml
+++ b/.github/workflows/111-daily-integration-24.04-lxd_container.yml
@@ -13,7 +13,7 @@ on:
         options:
         - generic
         - minimal
-      filter_tests:
+      test_posargs:
         required: false
         type: string
   schedule:
@@ -36,5 +36,5 @@ jobs:
           platform: lxd_container
           install_source: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
           image_type: ${{ inputs.image_type || 'generic' }}
-          filter_tests: ${{ inputs.filter_tests }}
+          test_posargs: ${{ inputs.test_posargs }}
           runner_temp: ${{ runner.temp }}

--- a/.github/workflows/113-daily-integration-26.04-lxd_container.yml
+++ b/.github/workflows/113-daily-integration-26.04-lxd_container.yml
@@ -37,3 +37,4 @@ jobs:
           install_source: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
           image_type: ${{ inputs.image_type || 'generic' }}
           filter_tests: ${{ inputs.filter_tests }}
+          runner_temp: ${{ runner.temp }}

--- a/.github/workflows/113-daily-integration-26.04-lxd_container.yml
+++ b/.github/workflows/113-daily-integration-26.04-lxd_container.yml
@@ -21,14 +21,19 @@ on:
 
 jobs:
   resolute-lxd_container:
-    uses: ./.github/workflows/100-dispatch-common.yml
-    with:
-      release: resolute
-      platform: lxd_container
-      install_source: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
-      image_type: ${{ inputs.image_type || 'generic' }}
-      filter_tests: ${{ inputs.filter_tests }}
-    secrets:
-      PYCLOUDLIB_TOML_B64: ${{ secrets.PYCLOUDLIB_TOML_B64 }}
+    runs-on: ubuntu-latest
+    if: github.repository == 'canonical/cloud-init'
+    env:
+      REQUIRED_SECRET: ${{ secrets.PYCLOUDLIB_TOML_B64 }}
       SSH_PUBLIC_KEY: ${{ secrets.SSH_PUBLIC_KEY }}
       SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Run integration tests
+        uses: ./.github/actions/integration-test
+        with:
+          release: resolute
+          platform: lxd_container
+          install_source: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
+          image_type: ${{ inputs.image_type || 'generic' }}
+          filter_tests: ${{ inputs.filter_tests }}

--- a/.github/workflows/113-daily-integration-26.04-lxd_container.yml
+++ b/.github/workflows/113-daily-integration-26.04-lxd_container.yml
@@ -13,7 +13,7 @@ on:
         options:
         - generic
         - minimal
-      filter_tests:
+      test_posargs:
         required: false
         type: string
   schedule:
@@ -36,5 +36,5 @@ jobs:
           platform: lxd_container
           install_source: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
           image_type: ${{ inputs.image_type || 'generic' }}
-          filter_tests: ${{ inputs.filter_tests }}
+          test_posargs: ${{ inputs.test_posargs }}
           runner_temp: ${{ runner.temp }}

--- a/.github/workflows/114-daily-integration-26.10-lxd_container.yml
+++ b/.github/workflows/114-daily-integration-26.10-lxd_container.yml
@@ -37,3 +37,4 @@ jobs:
           install_source: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
           image_type: ${{ inputs.image_type || 'generic' }}
           filter_tests: ${{ inputs.filter_tests }}
+          runner_temp: ${{ runner.temp }}

--- a/.github/workflows/114-daily-integration-26.10-lxd_container.yml
+++ b/.github/workflows/114-daily-integration-26.10-lxd_container.yml
@@ -21,14 +21,19 @@ on:
 
 jobs:
   stonking-lxd_container:
-    uses: ./.github/workflows/100-dispatch-common.yml
-    with:
-      release: stonking
-      platform: lxd_container
-      install_source: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
-      image_type: ${{ inputs.image_type || 'generic' }}
-      filter_tests: ${{ inputs.filter_tests }}
-    secrets:
-      PYCLOUDLIB_TOML_B64: ${{ secrets.PYCLOUDLIB_TOML_B64 }}
+    runs-on: ubuntu-latest
+    if: github.repository == 'canonical/cloud-init'
+    env:
+      REQUIRED_SECRET: ${{ secrets.PYCLOUDLIB_TOML_B64 }}
       SSH_PUBLIC_KEY: ${{ secrets.SSH_PUBLIC_KEY }}
       SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Run integration tests
+        uses: ./.github/actions/integration-test
+        with:
+          release: stonking
+          platform: lxd_container
+          install_source: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
+          image_type: ${{ inputs.image_type || 'generic' }}
+          filter_tests: ${{ inputs.filter_tests }}

--- a/.github/workflows/114-daily-integration-26.10-lxd_container.yml
+++ b/.github/workflows/114-daily-integration-26.10-lxd_container.yml
@@ -13,7 +13,7 @@ on:
         options:
         - generic
         - minimal
-      filter_tests:
+      test_posargs:
         required: false
         type: string
   schedule:
@@ -36,5 +36,5 @@ jobs:
           platform: lxd_container
           install_source: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
           image_type: ${{ inputs.image_type || 'generic' }}
-          filter_tests: ${{ inputs.filter_tests }}
+          test_posargs: ${{ inputs.test_posargs }}
           runner_temp: ${{ runner.temp }}

--- a/.github/workflows/120-daily-integration-22.04-lxd_vm.yml
+++ b/.github/workflows/120-daily-integration-22.04-lxd_vm.yml
@@ -37,3 +37,4 @@ jobs:
           install_source: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
           image_type: ${{ inputs.image_type || 'generic' }}
           filter_tests: ${{ inputs.filter_tests }}
+          runner_temp: ${{ runner.temp }}

--- a/.github/workflows/120-daily-integration-22.04-lxd_vm.yml
+++ b/.github/workflows/120-daily-integration-22.04-lxd_vm.yml
@@ -21,14 +21,19 @@ on:
 
 jobs:
   jammy-lxd_vm:
-    uses: ./.github/workflows/100-dispatch-common.yml
-    with:
-      release: jammy
-      platform: lxd_vm
-      install_source: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
-      image_type: ${{ inputs.image_type || 'generic' }}
-      filter_tests: ${{ inputs.filter_tests }}
-    secrets:
-      PYCLOUDLIB_TOML_B64: ${{ secrets.PYCLOUDLIB_TOML_B64 }}
+    runs-on: ubuntu-latest
+    if: github.repository == 'canonical/cloud-init'
+    env:
+      REQUIRED_SECRET: ${{ secrets.PYCLOUDLIB_TOML_B64 }}
       SSH_PUBLIC_KEY: ${{ secrets.SSH_PUBLIC_KEY }}
       SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Run integration tests
+        uses: ./.github/actions/integration-test
+        with:
+          release: jammy
+          platform: lxd_vm
+          install_source: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
+          image_type: ${{ inputs.image_type || 'generic' }}
+          filter_tests: ${{ inputs.filter_tests }}

--- a/.github/workflows/120-daily-integration-22.04-lxd_vm.yml
+++ b/.github/workflows/120-daily-integration-22.04-lxd_vm.yml
@@ -13,7 +13,7 @@ on:
         options:
         - generic
         - minimal
-      filter_tests:
+      test_posargs:
         required: false
         type: string
   schedule:
@@ -36,5 +36,5 @@ jobs:
           platform: lxd_vm
           install_source: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
           image_type: ${{ inputs.image_type || 'generic' }}
-          filter_tests: ${{ inputs.filter_tests }}
+          test_posargs: ${{ inputs.test_posargs }}
           runner_temp: ${{ runner.temp }}

--- a/.github/workflows/121-daily-integration-24.04-lxd_vm.yml
+++ b/.github/workflows/121-daily-integration-24.04-lxd_vm.yml
@@ -37,3 +37,4 @@ jobs:
           install_source: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
           image_type: ${{ inputs.image_type || 'generic' }}
           filter_tests: ${{ inputs.filter_tests }}
+          runner_temp: ${{ runner.temp }}

--- a/.github/workflows/121-daily-integration-24.04-lxd_vm.yml
+++ b/.github/workflows/121-daily-integration-24.04-lxd_vm.yml
@@ -21,14 +21,19 @@ on:
 
 jobs:
   noble-lxd_vm:
-    uses: ./.github/workflows/100-dispatch-common.yml
-    with:
-      release: noble
-      platform: lxd_vm
-      install_source: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
-      image_type: ${{ inputs.image_type || 'generic' }}
-      filter_tests: ${{ inputs.filter_tests }}
-    secrets:
-      PYCLOUDLIB_TOML_B64: ${{ secrets.PYCLOUDLIB_TOML_B64 }}
+    runs-on: ubuntu-latest
+    if: github.repository == 'canonical/cloud-init'
+    env:
+      REQUIRED_SECRET: ${{ secrets.PYCLOUDLIB_TOML_B64 }}
       SSH_PUBLIC_KEY: ${{ secrets.SSH_PUBLIC_KEY }}
       SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Run integration tests
+        uses: ./.github/actions/integration-test
+        with:
+          release: noble
+          platform: lxd_vm
+          install_source: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
+          image_type: ${{ inputs.image_type || 'generic' }}
+          filter_tests: ${{ inputs.filter_tests }}

--- a/.github/workflows/121-daily-integration-24.04-lxd_vm.yml
+++ b/.github/workflows/121-daily-integration-24.04-lxd_vm.yml
@@ -13,7 +13,7 @@ on:
         options:
         - generic
         - minimal
-      filter_tests:
+      test_posargs:
         required: false
         type: string
   schedule:
@@ -36,5 +36,5 @@ jobs:
           platform: lxd_vm
           install_source: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
           image_type: ${{ inputs.image_type || 'generic' }}
-          filter_tests: ${{ inputs.filter_tests }}
+          test_posargs: ${{ inputs.test_posargs }}
           runner_temp: ${{ runner.temp }}

--- a/.github/workflows/123-daily-integration-26.04-lxd_vm.yml
+++ b/.github/workflows/123-daily-integration-26.04-lxd_vm.yml
@@ -37,3 +37,4 @@ jobs:
           install_source: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
           image_type: ${{ inputs.image_type || 'generic' }}
           filter_tests: ${{ inputs.filter_tests }}
+          runner_temp: ${{ runner.temp }}

--- a/.github/workflows/123-daily-integration-26.04-lxd_vm.yml
+++ b/.github/workflows/123-daily-integration-26.04-lxd_vm.yml
@@ -21,14 +21,19 @@ on:
 
 jobs:
   resolute-lxd_vm:
-    uses: ./.github/workflows/100-dispatch-common.yml
-    with:
-      release: resolute
-      platform: lxd_vm
-      install_source: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
-      image_type: ${{ inputs.image_type || 'generic' }}
-      filter_tests: ${{ inputs.filter_tests }}
-    secrets:
-      PYCLOUDLIB_TOML_B64: ${{ secrets.PYCLOUDLIB_TOML_B64 }}
+    runs-on: ubuntu-latest
+    if: github.repository == 'canonical/cloud-init'
+    env:
+      REQUIRED_SECRET: ${{ secrets.PYCLOUDLIB_TOML_B64 }}
       SSH_PUBLIC_KEY: ${{ secrets.SSH_PUBLIC_KEY }}
       SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Run integration tests
+        uses: ./.github/actions/integration-test
+        with:
+          release: resolute
+          platform: lxd_vm
+          install_source: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
+          image_type: ${{ inputs.image_type || 'generic' }}
+          filter_tests: ${{ inputs.filter_tests }}

--- a/.github/workflows/123-daily-integration-26.04-lxd_vm.yml
+++ b/.github/workflows/123-daily-integration-26.04-lxd_vm.yml
@@ -13,7 +13,7 @@ on:
         options:
         - generic
         - minimal
-      filter_tests:
+      test_posargs:
         required: false
         type: string
   schedule:
@@ -36,5 +36,5 @@ jobs:
           platform: lxd_vm
           install_source: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
           image_type: ${{ inputs.image_type || 'generic' }}
-          filter_tests: ${{ inputs.filter_tests }}
+          test_posargs: ${{ inputs.test_posargs }}
           runner_temp: ${{ runner.temp }}

--- a/.github/workflows/124-daily-integration-26.10-lxd_vm.yml
+++ b/.github/workflows/124-daily-integration-26.10-lxd_vm.yml
@@ -37,3 +37,4 @@ jobs:
           install_source: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
           image_type: ${{ inputs.image_type || 'generic' }}
           filter_tests: ${{ inputs.filter_tests }}
+          runner_temp: ${{ runner.temp }}

--- a/.github/workflows/124-daily-integration-26.10-lxd_vm.yml
+++ b/.github/workflows/124-daily-integration-26.10-lxd_vm.yml
@@ -21,14 +21,19 @@ on:
 
 jobs:
   stonking-lxd_vm:
-    uses: ./.github/workflows/100-dispatch-common.yml
-    with:
-      release: stonking
-      platform: lxd_vm
-      install_source: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
-      image_type: ${{ inputs.image_type || 'generic' }}
-      filter_tests: ${{ inputs.filter_tests }}
-    secrets:
-      PYCLOUDLIB_TOML_B64: ${{ secrets.PYCLOUDLIB_TOML_B64 }}
+    runs-on: ubuntu-latest
+    if: github.repository == 'canonical/cloud-init'
+    env:
+      REQUIRED_SECRET: ${{ secrets.PYCLOUDLIB_TOML_B64 }}
       SSH_PUBLIC_KEY: ${{ secrets.SSH_PUBLIC_KEY }}
       SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Run integration tests
+        uses: ./.github/actions/integration-test
+        with:
+          release: stonking
+          platform: lxd_vm
+          install_source: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
+          image_type: ${{ inputs.image_type || 'generic' }}
+          filter_tests: ${{ inputs.filter_tests }}

--- a/.github/workflows/124-daily-integration-26.10-lxd_vm.yml
+++ b/.github/workflows/124-daily-integration-26.10-lxd_vm.yml
@@ -13,7 +13,7 @@ on:
         options:
         - generic
         - minimal
-      filter_tests:
+      test_posargs:
         required: false
         type: string
   schedule:
@@ -36,5 +36,5 @@ jobs:
           platform: lxd_vm
           install_source: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
           image_type: ${{ inputs.image_type || 'generic' }}
-          filter_tests: ${{ inputs.filter_tests }}
+          test_posargs: ${{ inputs.test_posargs }}
           runner_temp: ${{ runner.temp }}

--- a/.github/workflows/130-daily-integration-22.04-ec2.yml
+++ b/.github/workflows/130-daily-integration-22.04-ec2.yml
@@ -38,3 +38,4 @@ jobs:
           install_source: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
           image_type: ${{ inputs.image_type || 'generic' }}
           filter_tests: ${{ inputs.filter_tests }}
+          runner_temp: ${{ runner.temp }}

--- a/.github/workflows/130-daily-integration-22.04-ec2.yml
+++ b/.github/workflows/130-daily-integration-22.04-ec2.yml
@@ -22,14 +22,19 @@ on:
 
 jobs:
   jammy-ec2:
-    uses: ./.github/workflows/100-dispatch-common.yml
-    with:
-      release: jammy
-      platform: ec2
-      install_source: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
-      image_type: ${{ inputs.image_type || 'generic' }}
-      filter_tests: ${{ inputs.filter_tests }}
-    secrets:
-      PYCLOUDLIB_TOML_B64: ${{ secrets.PYCLOUDLIB_TOML_B64 }}
+    runs-on: ubuntu-latest
+    if: github.repository == 'canonical/cloud-init'
+    env:
+      REQUIRED_SECRET: ${{ secrets.PYCLOUDLIB_TOML_B64 }}
       SSH_PUBLIC_KEY: ${{ secrets.SSH_PUBLIC_KEY }}
       SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Run integration tests
+        uses: ./.github/actions/integration-test
+        with:
+          release: jammy
+          platform: ec2
+          install_source: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
+          image_type: ${{ inputs.image_type || 'generic' }}
+          filter_tests: ${{ inputs.filter_tests }}

--- a/.github/workflows/130-daily-integration-22.04-ec2.yml
+++ b/.github/workflows/130-daily-integration-22.04-ec2.yml
@@ -13,7 +13,7 @@ on:
         options:
         - generic
         - minimal
-      filter_tests:
+      test_posargs:
         required: false
         type: string
   schedule:
@@ -37,5 +37,5 @@ jobs:
           platform: ec2
           install_source: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
           image_type: ${{ inputs.image_type || 'generic' }}
-          filter_tests: ${{ inputs.filter_tests }}
+          test_posargs: ${{ inputs.test_posargs }}
           runner_temp: ${{ runner.temp }}

--- a/.github/workflows/131-daily-integration-24.04-ec2.yml
+++ b/.github/workflows/131-daily-integration-24.04-ec2.yml
@@ -38,3 +38,4 @@ jobs:
           install_source: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
           image_type: ${{ inputs.image_type || 'generic' }}
           filter_tests: ${{ inputs.filter_tests }}
+          runner_temp: ${{ runner.temp }}

--- a/.github/workflows/131-daily-integration-24.04-ec2.yml
+++ b/.github/workflows/131-daily-integration-24.04-ec2.yml
@@ -22,14 +22,19 @@ on:
 
 jobs:
   noble-ec2:
-    uses: ./.github/workflows/100-dispatch-common.yml
-    with:
-      release: noble
-      platform: ec2
-      install_source: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
-      image_type: ${{ inputs.image_type || 'generic' }}
-      filter_tests: ${{ inputs.filter_tests }}
-    secrets:
-      PYCLOUDLIB_TOML_B64: ${{ secrets.PYCLOUDLIB_TOML_B64 }}
+    runs-on: ubuntu-latest
+    if: github.repository == 'canonical/cloud-init'
+    env:
+      REQUIRED_SECRET: ${{ secrets.PYCLOUDLIB_TOML_B64 }}
       SSH_PUBLIC_KEY: ${{ secrets.SSH_PUBLIC_KEY }}
       SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Run integration tests
+        uses: ./.github/actions/integration-test
+        with:
+          release: noble
+          platform: ec2
+          install_source: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
+          image_type: ${{ inputs.image_type || 'generic' }}
+          filter_tests: ${{ inputs.filter_tests }}

--- a/.github/workflows/131-daily-integration-24.04-ec2.yml
+++ b/.github/workflows/131-daily-integration-24.04-ec2.yml
@@ -13,7 +13,7 @@ on:
         options:
         - generic
         - minimal
-      filter_tests:
+      test_posargs:
         required: false
         type: string
   schedule:
@@ -37,5 +37,5 @@ jobs:
           platform: ec2
           install_source: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
           image_type: ${{ inputs.image_type || 'generic' }}
-          filter_tests: ${{ inputs.filter_tests }}
+          test_posargs: ${{ inputs.test_posargs }}
           runner_temp: ${{ runner.temp }}

--- a/.github/workflows/133-daily-integration-26.04-ec2.yml
+++ b/.github/workflows/133-daily-integration-26.04-ec2.yml
@@ -22,14 +22,19 @@ on:
 
 jobs:
   resolute-ec2:
-    uses: ./.github/workflows/100-dispatch-common.yml
-    with:
-      release: resolute
-      platform: ec2
-      install_source: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
-      image_type: ${{ inputs.image_type || 'generic' }}
-      filter_tests: ${{ inputs.filter_tests }}
-    secrets:
-      PYCLOUDLIB_TOML_B64: ${{ secrets.PYCLOUDLIB_TOML_B64 }}
+    runs-on: ubuntu-latest
+    if: github.repository == 'canonical/cloud-init'
+    env:
+      REQUIRED_SECRET: ${{ secrets.PYCLOUDLIB_TOML_B64 }}
       SSH_PUBLIC_KEY: ${{ secrets.SSH_PUBLIC_KEY }}
       SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Run integration tests
+        uses: ./.github/actions/integration-test
+        with:
+          release: resolute
+          platform: ec2
+          install_source: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
+          image_type: ${{ inputs.image_type || 'generic' }}
+          filter_tests: ${{ inputs.filter_tests }}

--- a/.github/workflows/133-daily-integration-26.04-ec2.yml
+++ b/.github/workflows/133-daily-integration-26.04-ec2.yml
@@ -38,3 +38,4 @@ jobs:
           install_source: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
           image_type: ${{ inputs.image_type || 'generic' }}
           filter_tests: ${{ inputs.filter_tests }}
+          runner_temp: ${{ runner.temp }}

--- a/.github/workflows/133-daily-integration-26.04-ec2.yml
+++ b/.github/workflows/133-daily-integration-26.04-ec2.yml
@@ -13,7 +13,7 @@ on:
         options:
         - generic
         - minimal
-      filter_tests:
+      test_posargs:
         required: false
         type: string
   schedule:
@@ -37,5 +37,5 @@ jobs:
           platform: ec2
           install_source: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
           image_type: ${{ inputs.image_type || 'generic' }}
-          filter_tests: ${{ inputs.filter_tests }}
+          test_posargs: ${{ inputs.test_posargs }}
           runner_temp: ${{ runner.temp }}

--- a/.github/workflows/134-daily-integration-26.10-ec2.yml
+++ b/.github/workflows/134-daily-integration-26.10-ec2.yml
@@ -38,3 +38,4 @@ jobs:
           install_source: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
           image_type: ${{ inputs.image_type || 'generic' }}
           filter_tests: ${{ inputs.filter_tests }}
+          runner_temp: ${{ runner.temp }}

--- a/.github/workflows/134-daily-integration-26.10-ec2.yml
+++ b/.github/workflows/134-daily-integration-26.10-ec2.yml
@@ -22,14 +22,19 @@ on:
 
 jobs:
   stonking-ec2:
-    uses: ./.github/workflows/100-dispatch-common.yml
-    with:
-      release: stonking
-      platform: ec2
-      install_source: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
-      image_type: ${{ inputs.image_type || 'generic' }}
-      filter_tests: ${{ inputs.filter_tests }}
-    secrets:
-      PYCLOUDLIB_TOML_B64: ${{ secrets.PYCLOUDLIB_TOML_B64 }}
+    runs-on: ubuntu-latest
+    if: github.repository == 'canonical/cloud-init'
+    env:
+      REQUIRED_SECRET: ${{ secrets.PYCLOUDLIB_TOML_B64 }}
       SSH_PUBLIC_KEY: ${{ secrets.SSH_PUBLIC_KEY }}
       SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Run integration tests
+        uses: ./.github/actions/integration-test
+        with:
+          release: stonking
+          platform: ec2
+          install_source: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
+          image_type: ${{ inputs.image_type || 'generic' }}
+          filter_tests: ${{ inputs.filter_tests }}

--- a/.github/workflows/134-daily-integration-26.10-ec2.yml
+++ b/.github/workflows/134-daily-integration-26.10-ec2.yml
@@ -13,7 +13,7 @@ on:
         options:
         - generic
         - minimal
-      filter_tests:
+      test_posargs:
         required: false
         type: string
   schedule:
@@ -37,5 +37,5 @@ jobs:
           platform: ec2
           install_source: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
           image_type: ${{ inputs.image_type || 'generic' }}
-          filter_tests: ${{ inputs.filter_tests }}
+          test_posargs: ${{ inputs.test_posargs }}
           runner_temp: ${{ runner.temp }}

--- a/.github/workflows/140-daily-integration-22.04-azure.yml
+++ b/.github/workflows/140-daily-integration-22.04-azure.yml
@@ -13,7 +13,7 @@ on:
         options:
         - generic
         - minimal
-      filter_tests:
+      test_posargs:
         required: false
         type: string
   schedule:
@@ -28,7 +28,7 @@ jobs:
       platform: azure
       install_source: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
       image_type: ${{ inputs.image_type || 'generic' }}
-      filter_tests: ${{ inputs.filter_tests }}
+      test_posargs: ${{ inputs.test_posargs }}
     secrets:
       PYCLOUDLIB_TOML_B64: ${{ secrets.PYCLOUDLIB_TOML_B64 }}
       SSH_PUBLIC_KEY: ${{ secrets.SSH_PUBLIC_KEY }}

--- a/.github/workflows/141-daily-integration-24.04-azure.yml
+++ b/.github/workflows/141-daily-integration-24.04-azure.yml
@@ -13,7 +13,7 @@ on:
         options:
         - generic
         - minimal
-      filter_tests:
+      test_posargs:
         required: false
         type: string
   schedule:
@@ -28,7 +28,7 @@ jobs:
       platform: azure
       install_source: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
       image_type: ${{ inputs.image_type || 'generic' }}
-      filter_tests: ${{ inputs.filter_tests }}
+      test_posargs: ${{ inputs.test_posargs }}
     secrets:
       PYCLOUDLIB_TOML_B64: ${{ secrets.PYCLOUDLIB_TOML_B64 }}
       SSH_PUBLIC_KEY: ${{ secrets.SSH_PUBLIC_KEY }}

--- a/.github/workflows/143-daily-integration-26.04-azure.yml
+++ b/.github/workflows/143-daily-integration-26.04-azure.yml
@@ -13,7 +13,7 @@ on:
         options:
         - generic
         - minimal
-      filter_tests:
+      test_posargs:
         required: false
         type: string
   schedule:
@@ -28,7 +28,7 @@ jobs:
       platform: azure
       install_source: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
       image_type: ${{ inputs.image_type || 'generic' }}
-      filter_tests: ${{ inputs.filter_tests }}
+      test_posargs: ${{ inputs.test_posargs }}
     secrets:
       PYCLOUDLIB_TOML_B64: ${{ secrets.PYCLOUDLIB_TOML_B64 }}
       SSH_PUBLIC_KEY: ${{ secrets.SSH_PUBLIC_KEY }}

--- a/.github/workflows/144-daily-integration-26.10-azure.yml
+++ b/.github/workflows/144-daily-integration-26.10-azure.yml
@@ -13,7 +13,7 @@ on:
         options:
         - generic
         - minimal
-      filter_tests:
+      test_posargs:
         required: false
         type: string
   schedule:
@@ -28,7 +28,7 @@ jobs:
       platform: azure
       install_source: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
       image_type: ${{ inputs.image_type || 'generic' }}
-      filter_tests: ${{ inputs.filter_tests }}
+      test_posargs: ${{ inputs.test_posargs }}
     secrets:
       PYCLOUDLIB_TOML_B64: ${{ secrets.PYCLOUDLIB_TOML_B64 }}
       SSH_PUBLIC_KEY: ${{ secrets.SSH_PUBLIC_KEY }}

--- a/.github/workflows/150-daily-integration-22.04-oci.yml
+++ b/.github/workflows/150-daily-integration-22.04-oci.yml
@@ -62,3 +62,4 @@ jobs:
           install_source: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
           image_type: ${{ inputs.image_type || 'generic' }}
           filter_tests: ${{ inputs.filter_tests }}
+          runner_temp: ${{ runner.temp }}

--- a/.github/workflows/150-daily-integration-22.04-oci.yml
+++ b/.github/workflows/150-daily-integration-22.04-oci.yml
@@ -32,6 +32,8 @@ jobs:
       PYCLOUDLIB_OCI_CONFIG_B64: ${{ secrets.PYCLOUDLIB_OCI_CONFIG_B64 }}
       PYCLOUDLIB_OCI_KEY_B64: ${{ secrets.PYCLOUDLIB_OCI_KEY_B64 }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Assert OCI repo secrets are set
         shell: bash
         run: |

--- a/.github/workflows/150-daily-integration-22.04-oci.yml
+++ b/.github/workflows/150-daily-integration-22.04-oci.yml
@@ -22,16 +22,41 @@ on:
 
 jobs:
   jammy-oci:
-    uses: ./.github/workflows/100-dispatch-common.yml
-    with:
-      release: jammy
-      platform: oci
-      install_source: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
-      image_type: ${{ inputs.image_type || 'generic' }}
-      filter_tests: ${{ inputs.filter_tests }}
-    secrets:
-      PYCLOUDLIB_TOML_B64: ${{ secrets.PYCLOUDLIB_TOML_B64 }}
+    runs-on: ubuntu-latest
+    if: github.repository == 'canonical/cloud-init'
+    env:
+      REQUIRED_SECRET: ${{ secrets.PYCLOUDLIB_TOML_B64 }}
       SSH_PUBLIC_KEY: ${{ secrets.SSH_PUBLIC_KEY }}
       SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       PYCLOUDLIB_OCI_CONFIG_B64: ${{ secrets.PYCLOUDLIB_OCI_CONFIG_B64 }}
       PYCLOUDLIB_OCI_KEY_B64: ${{ secrets.PYCLOUDLIB_OCI_KEY_B64 }}
+    steps:
+      - name: Assert OCI repo secrets are set
+        shell: bash
+        run: |
+          if [ -z "$PYCLOUDLIB_OCI_CONFIG_B64" ]; then
+             echo "ERROR: Missing required repo secret. Please provide PYCLOUDLIB_OCI_CONFIG_B64 repo secret at ${{ github.repository }}/settings/secrets/actions."
+             exit 1
+          fi
+          if [ -z "$PYCLOUDLIB_OCI_KEY_B64" ]; then
+             echo "ERROR: Missing required repo secret. Please provide PYCLOUDLIB_OCI_KEY_B64 repo secret at ${{ github.repository }}/settings/secrets/actions."
+             exit 1
+          fi
+      - name: Setup OCI credentials
+        shell: bash
+        env:
+          PYCLOUDLIB_OCI_CONFIG_FILE_PATH: ${{ runner.temp }}/oci/config
+          PYCLOUDLIB_OCI_KEY_FILE_PATH: ${{ runner.temp }}/oci/key.pem
+        run: |
+          mkdir -p "$(dirname "$PYCLOUDLIB_OCI_CONFIG_FILE_PATH")"
+          sh -c 'printf "%s\n" "$PYCLOUDLIB_OCI_CONFIG_B64" | base64 -d > "$PYCLOUDLIB_OCI_CONFIG_FILE_PATH"'
+          sh -c 'printf "%s\n" "$PYCLOUDLIB_OCI_KEY_B64" | base64 -d  | install -m 600 /dev/stdin "$PYCLOUDLIB_OCI_KEY_FILE_PATH"'
+      - name: Run integration tests
+        uses: ./.github/actions/integration-test
+        with:
+          release: jammy
+          platform: oci
+          install_source: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
+          image_type: ${{ inputs.image_type || 'generic' }}
+          filter_tests: ${{ inputs.filter_tests }}

--- a/.github/workflows/150-daily-integration-22.04-oci.yml
+++ b/.github/workflows/150-daily-integration-22.04-oci.yml
@@ -13,7 +13,7 @@ on:
         options:
         - generic
         - minimal
-      filter_tests:
+      test_posargs:
         required: false
         type: string
   schedule:
@@ -61,5 +61,5 @@ jobs:
           platform: oci
           install_source: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
           image_type: ${{ inputs.image_type || 'generic' }}
-          filter_tests: ${{ inputs.filter_tests }}
+          test_posargs: ${{ inputs.test_posargs }}
           runner_temp: ${{ runner.temp }}

--- a/.github/workflows/150-daily-integration-22.04-oci.yml
+++ b/.github/workflows/150-daily-integration-22.04-oci.yml
@@ -1,0 +1,37 @@
+name: "Twice weekly 22.04: oci"
+
+on:
+  workflow_dispatch:
+    inputs:
+      install_source:
+        required: false
+        type: string
+        default: 'ppa:cloud-init-dev/daily'
+      image_type:
+        required: true
+        type: choice
+        options:
+        - generic
+        - minimal
+      filter_tests:
+        required: false
+        type: string
+  schedule:
+    # Run Mon & Thurs to reduce additional cost on shared external tokens
+    - cron: '2 22 * * 1,4'
+
+jobs:
+  jammy-oci:
+    uses: ./.github/workflows/100-dispatch-common.yml
+    with:
+      release: jammy
+      platform: oci
+      install_source: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
+      image_type: ${{ inputs.image_type || 'generic' }}
+      filter_tests: ${{ inputs.filter_tests }}
+    secrets:
+      PYCLOUDLIB_TOML_B64: ${{ secrets.PYCLOUDLIB_TOML_B64 }}
+      SSH_PUBLIC_KEY: ${{ secrets.SSH_PUBLIC_KEY }}
+      SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+      PYCLOUDLIB_OCI_CONFIG_B64: ${{ secrets.PYCLOUDLIB_OCI_CONFIG_B64 }}
+      PYCLOUDLIB_OCI_KEY_B64: ${{ secrets.PYCLOUDLIB_OCI_KEY_B64 }}

--- a/.github/workflows/151-daily-integration-24.04-oci.yml
+++ b/.github/workflows/151-daily-integration-24.04-oci.yml
@@ -62,3 +62,4 @@ jobs:
           install_source: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
           image_type: ${{ inputs.image_type || 'generic' }}
           filter_tests: ${{ inputs.filter_tests }}
+          runner_temp: ${{ runner.temp }}

--- a/.github/workflows/151-daily-integration-24.04-oci.yml
+++ b/.github/workflows/151-daily-integration-24.04-oci.yml
@@ -32,6 +32,8 @@ jobs:
       PYCLOUDLIB_OCI_CONFIG_B64: ${{ secrets.PYCLOUDLIB_OCI_CONFIG_B64 }}
       PYCLOUDLIB_OCI_KEY_B64: ${{ secrets.PYCLOUDLIB_OCI_KEY_B64 }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Assert OCI repo secrets are set
         shell: bash
         run: |

--- a/.github/workflows/151-daily-integration-24.04-oci.yml
+++ b/.github/workflows/151-daily-integration-24.04-oci.yml
@@ -22,16 +22,41 @@ on:
 
 jobs:
   noble-oci:
-    uses: ./.github/workflows/100-dispatch-common.yml
-    with:
-      release: noble
-      platform: oci
-      install_source: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
-      image_type: ${{ inputs.image_type || 'generic' }}
-      filter_tests: ${{ inputs.filter_tests }}
-    secrets:
-      PYCLOUDLIB_TOML_B64: ${{ secrets.PYCLOUDLIB_TOML_B64 }}
+    runs-on: ubuntu-latest
+    if: github.repository == 'canonical/cloud-init'
+    env:
+      REQUIRED_SECRET: ${{ secrets.PYCLOUDLIB_TOML_B64 }}
       SSH_PUBLIC_KEY: ${{ secrets.SSH_PUBLIC_KEY }}
       SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       PYCLOUDLIB_OCI_CONFIG_B64: ${{ secrets.PYCLOUDLIB_OCI_CONFIG_B64 }}
       PYCLOUDLIB_OCI_KEY_B64: ${{ secrets.PYCLOUDLIB_OCI_KEY_B64 }}
+    steps:
+      - name: Assert OCI repo secrets are set
+        shell: bash
+        run: |
+          if [ -z "$PYCLOUDLIB_OCI_CONFIG_B64" ]; then
+             echo "ERROR: Missing required repo secret. Please provide PYCLOUDLIB_OCI_CONFIG_B64 repo secret at ${{ github.repository }}/settings/secrets/actions."
+             exit 1
+          fi
+          if [ -z "$PYCLOUDLIB_OCI_KEY_B64" ]; then
+             echo "ERROR: Missing required repo secret. Please provide PYCLOUDLIB_OCI_KEY_B64 repo secret at ${{ github.repository }}/settings/secrets/actions."
+             exit 1
+          fi
+      - name: Setup OCI credentials
+        shell: bash
+        env:
+          PYCLOUDLIB_OCI_CONFIG_FILE_PATH: ${{ runner.temp }}/oci/config
+          PYCLOUDLIB_OCI_KEY_FILE_PATH: ${{ runner.temp }}/oci/key.pem
+        run: |
+          mkdir -p "$(dirname "$PYCLOUDLIB_OCI_CONFIG_FILE_PATH")"
+          sh -c 'printf "%s\n" "$PYCLOUDLIB_OCI_CONFIG_B64" | base64 -d > "$PYCLOUDLIB_OCI_CONFIG_FILE_PATH"'
+          sh -c 'printf "%s\n" "$PYCLOUDLIB_OCI_KEY_B64" | base64 -d  | install -m 600 /dev/stdin "$PYCLOUDLIB_OCI_KEY_FILE_PATH"'
+      - name: Run integration tests
+        uses: ./.github/actions/integration-test
+        with:
+          release: noble
+          platform: oci
+          install_source: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
+          image_type: ${{ inputs.image_type || 'generic' }}
+          filter_tests: ${{ inputs.filter_tests }}

--- a/.github/workflows/151-daily-integration-24.04-oci.yml
+++ b/.github/workflows/151-daily-integration-24.04-oci.yml
@@ -13,7 +13,7 @@ on:
         options:
         - generic
         - minimal
-      filter_tests:
+      test_posargs:
         required: false
         type: string
   schedule:
@@ -61,5 +61,5 @@ jobs:
           platform: oci
           install_source: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
           image_type: ${{ inputs.image_type || 'generic' }}
-          filter_tests: ${{ inputs.filter_tests }}
+          test_posargs: ${{ inputs.test_posargs }}
           runner_temp: ${{ runner.temp }}

--- a/.github/workflows/151-daily-integration-24.04-oci.yml
+++ b/.github/workflows/151-daily-integration-24.04-oci.yml
@@ -1,0 +1,37 @@
+name: "Twice weekly 24.04: oci"
+
+on:
+  workflow_dispatch:
+    inputs:
+      install_source:
+        required: false
+        type: string
+        default: 'ppa:cloud-init-dev/daily'
+      image_type:
+        required: true
+        type: choice
+        options:
+        - generic
+        - minimal
+      filter_tests:
+        required: false
+        type: string
+  schedule:
+    # Run Mon & Thurs to reduce additional cost on shared external tokens
+    - cron: '2 22 * * 1,4'
+
+jobs:
+  noble-oci:
+    uses: ./.github/workflows/100-dispatch-common.yml
+    with:
+      release: noble
+      platform: oci
+      install_source: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
+      image_type: ${{ inputs.image_type || 'generic' }}
+      filter_tests: ${{ inputs.filter_tests }}
+    secrets:
+      PYCLOUDLIB_TOML_B64: ${{ secrets.PYCLOUDLIB_TOML_B64 }}
+      SSH_PUBLIC_KEY: ${{ secrets.SSH_PUBLIC_KEY }}
+      SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+      PYCLOUDLIB_OCI_CONFIG_B64: ${{ secrets.PYCLOUDLIB_OCI_CONFIG_B64 }}
+      PYCLOUDLIB_OCI_KEY_B64: ${{ secrets.PYCLOUDLIB_OCI_KEY_B64 }}

--- a/.github/workflows/153-daily-integration-26.04-oci.yml
+++ b/.github/workflows/153-daily-integration-26.04-oci.yml
@@ -62,3 +62,4 @@ jobs:
           install_source: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
           image_type: ${{ inputs.image_type || 'generic' }}
           filter_tests: ${{ inputs.filter_tests }}
+          runner_temp: ${{ runner.temp }}

--- a/.github/workflows/153-daily-integration-26.04-oci.yml
+++ b/.github/workflows/153-daily-integration-26.04-oci.yml
@@ -32,6 +32,8 @@ jobs:
       PYCLOUDLIB_OCI_CONFIG_B64: ${{ secrets.PYCLOUDLIB_OCI_CONFIG_B64 }}
       PYCLOUDLIB_OCI_KEY_B64: ${{ secrets.PYCLOUDLIB_OCI_KEY_B64 }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Assert OCI repo secrets are set
         shell: bash
         run: |

--- a/.github/workflows/153-daily-integration-26.04-oci.yml
+++ b/.github/workflows/153-daily-integration-26.04-oci.yml
@@ -22,16 +22,41 @@ on:
 
 jobs:
   resolute-oci:
-    uses: ./.github/workflows/100-dispatch-common.yml
-    with:
-      release: resolute
-      platform: oci
-      install_source: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
-      image_type: ${{ inputs.image_type || 'generic' }}
-      filter_tests: ${{ inputs.filter_tests }}
-    secrets:
-      PYCLOUDLIB_TOML_B64: ${{ secrets.PYCLOUDLIB_TOML_B64 }}
+    runs-on: ubuntu-latest
+    if: github.repository == 'canonical/cloud-init'
+    env:
+      REQUIRED_SECRET: ${{ secrets.PYCLOUDLIB_TOML_B64 }}
       SSH_PUBLIC_KEY: ${{ secrets.SSH_PUBLIC_KEY }}
       SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       PYCLOUDLIB_OCI_CONFIG_B64: ${{ secrets.PYCLOUDLIB_OCI_CONFIG_B64 }}
       PYCLOUDLIB_OCI_KEY_B64: ${{ secrets.PYCLOUDLIB_OCI_KEY_B64 }}
+    steps:
+      - name: Assert OCI repo secrets are set
+        shell: bash
+        run: |
+          if [ -z "$PYCLOUDLIB_OCI_CONFIG_B64" ]; then
+             echo "ERROR: Missing required repo secret. Please provide PYCLOUDLIB_OCI_CONFIG_B64 repo secret at ${{ github.repository }}/settings/secrets/actions."
+             exit 1
+          fi
+          if [ -z "$PYCLOUDLIB_OCI_KEY_B64" ]; then
+             echo "ERROR: Missing required repo secret. Please provide PYCLOUDLIB_OCI_KEY_B64 repo secret at ${{ github.repository }}/settings/secrets/actions."
+             exit 1
+          fi
+      - name: Setup OCI credentials
+        shell: bash
+        env:
+          PYCLOUDLIB_OCI_CONFIG_FILE_PATH: ${{ runner.temp }}/oci/config
+          PYCLOUDLIB_OCI_KEY_FILE_PATH: ${{ runner.temp }}/oci/key.pem
+        run: |
+          mkdir -p "$(dirname "$PYCLOUDLIB_OCI_CONFIG_FILE_PATH")"
+          sh -c 'printf "%s\n" "$PYCLOUDLIB_OCI_CONFIG_B64" | base64 -d > "$PYCLOUDLIB_OCI_CONFIG_FILE_PATH"'
+          sh -c 'printf "%s\n" "$PYCLOUDLIB_OCI_KEY_B64" | base64 -d  | install -m 600 /dev/stdin "$PYCLOUDLIB_OCI_KEY_FILE_PATH"'
+      - name: Run integration tests
+        uses: ./.github/actions/integration-test
+        with:
+          release: resolute
+          platform: oci
+          install_source: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
+          image_type: ${{ inputs.image_type || 'generic' }}
+          filter_tests: ${{ inputs.filter_tests }}

--- a/.github/workflows/153-daily-integration-26.04-oci.yml
+++ b/.github/workflows/153-daily-integration-26.04-oci.yml
@@ -1,0 +1,37 @@
+name: "Twice weekly 26.04: oci"
+
+on:
+  workflow_dispatch:
+    inputs:
+      install_source:
+        required: false
+        type: string
+        default: 'ppa:cloud-init-dev/daily'
+      image_type:
+        required: true
+        type: choice
+        options:
+        - generic
+        - minimal
+      filter_tests:
+        required: false
+        type: string
+  schedule:
+    # Run Mon & Thurs to reduce additional cost on shared external tokens
+    - cron: '2 22 * * 1,4'
+
+jobs:
+  resolute-oci:
+    uses: ./.github/workflows/100-dispatch-common.yml
+    with:
+      release: resolute
+      platform: oci
+      install_source: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
+      image_type: ${{ inputs.image_type || 'generic' }}
+      filter_tests: ${{ inputs.filter_tests }}
+    secrets:
+      PYCLOUDLIB_TOML_B64: ${{ secrets.PYCLOUDLIB_TOML_B64 }}
+      SSH_PUBLIC_KEY: ${{ secrets.SSH_PUBLIC_KEY }}
+      SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+      PYCLOUDLIB_OCI_CONFIG_B64: ${{ secrets.PYCLOUDLIB_OCI_CONFIG_B64 }}
+      PYCLOUDLIB_OCI_KEY_B64: ${{ secrets.PYCLOUDLIB_OCI_KEY_B64 }}

--- a/.github/workflows/153-daily-integration-26.04-oci.yml
+++ b/.github/workflows/153-daily-integration-26.04-oci.yml
@@ -13,7 +13,7 @@ on:
         options:
         - generic
         - minimal
-      filter_tests:
+      test_posargs:
         required: false
         type: string
   schedule:
@@ -61,5 +61,5 @@ jobs:
           platform: oci
           install_source: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
           image_type: ${{ inputs.image_type || 'generic' }}
-          filter_tests: ${{ inputs.filter_tests }}
+          test_posargs: ${{ inputs.test_posargs }}
           runner_temp: ${{ runner.temp }}

--- a/.github/workflows/154-daily-integration-26.10-oci.yml
+++ b/.github/workflows/154-daily-integration-26.10-oci.yml
@@ -62,3 +62,4 @@ jobs:
           install_source: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
           image_type: ${{ inputs.image_type || 'generic' }}
           filter_tests: ${{ inputs.filter_tests }}
+          runner_temp: ${{ runner.temp }}

--- a/.github/workflows/154-daily-integration-26.10-oci.yml
+++ b/.github/workflows/154-daily-integration-26.10-oci.yml
@@ -32,6 +32,8 @@ jobs:
       PYCLOUDLIB_OCI_CONFIG_B64: ${{ secrets.PYCLOUDLIB_OCI_CONFIG_B64 }}
       PYCLOUDLIB_OCI_KEY_B64: ${{ secrets.PYCLOUDLIB_OCI_KEY_B64 }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Assert OCI repo secrets are set
         shell: bash
         run: |

--- a/.github/workflows/154-daily-integration-26.10-oci.yml
+++ b/.github/workflows/154-daily-integration-26.10-oci.yml
@@ -22,16 +22,41 @@ on:
 
 jobs:
   stonking-oci:
-    uses: ./.github/workflows/100-dispatch-common.yml
-    with:
-      release: stonking
-      platform: oci
-      install_source: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
-      image_type: ${{ inputs.image_type || 'generic' }}
-      filter_tests: ${{ inputs.filter_tests }}
-    secrets:
-      PYCLOUDLIB_TOML_B64: ${{ secrets.PYCLOUDLIB_TOML_B64 }}
+    runs-on: ubuntu-latest
+    if: github.repository == 'canonical/cloud-init'
+    env:
+      REQUIRED_SECRET: ${{ secrets.PYCLOUDLIB_TOML_B64 }}
       SSH_PUBLIC_KEY: ${{ secrets.SSH_PUBLIC_KEY }}
       SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       PYCLOUDLIB_OCI_CONFIG_B64: ${{ secrets.PYCLOUDLIB_OCI_CONFIG_B64 }}
       PYCLOUDLIB_OCI_KEY_B64: ${{ secrets.PYCLOUDLIB_OCI_KEY_B64 }}
+    steps:
+      - name: Assert OCI repo secrets are set
+        shell: bash
+        run: |
+          if [ -z "$PYCLOUDLIB_OCI_CONFIG_B64" ]; then
+             echo "ERROR: Missing required repo secret. Please provide PYCLOUDLIB_OCI_CONFIG_B64 repo secret at ${{ github.repository }}/settings/secrets/actions."
+             exit 1
+          fi
+          if [ -z "$PYCLOUDLIB_OCI_KEY_B64" ]; then
+             echo "ERROR: Missing required repo secret. Please provide PYCLOUDLIB_OCI_KEY_B64 repo secret at ${{ github.repository }}/settings/secrets/actions."
+             exit 1
+          fi
+      - name: Setup OCI credentials
+        shell: bash
+        env:
+          PYCLOUDLIB_OCI_CONFIG_FILE_PATH: ${{ runner.temp }}/oci/config
+          PYCLOUDLIB_OCI_KEY_FILE_PATH: ${{ runner.temp }}/oci/key.pem
+        run: |
+          mkdir -p "$(dirname "$PYCLOUDLIB_OCI_CONFIG_FILE_PATH")"
+          sh -c 'printf "%s\n" "$PYCLOUDLIB_OCI_CONFIG_B64" | base64 -d > "$PYCLOUDLIB_OCI_CONFIG_FILE_PATH"'
+          sh -c 'printf "%s\n" "$PYCLOUDLIB_OCI_KEY_B64" | base64 -d  | install -m 600 /dev/stdin "$PYCLOUDLIB_OCI_KEY_FILE_PATH"'
+      - name: Run integration tests
+        uses: ./.github/actions/integration-test
+        with:
+          release: stonking
+          platform: oci
+          install_source: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
+          image_type: ${{ inputs.image_type || 'generic' }}
+          filter_tests: ${{ inputs.filter_tests }}

--- a/.github/workflows/154-daily-integration-26.10-oci.yml
+++ b/.github/workflows/154-daily-integration-26.10-oci.yml
@@ -13,7 +13,7 @@ on:
         options:
         - generic
         - minimal
-      filter_tests:
+      test_posargs:
         required: false
         type: string
   schedule:
@@ -61,5 +61,5 @@ jobs:
           platform: oci
           install_source: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
           image_type: ${{ inputs.image_type || 'generic' }}
-          filter_tests: ${{ inputs.filter_tests }}
+          test_posargs: ${{ inputs.test_posargs }}
           runner_temp: ${{ runner.temp }}

--- a/.github/workflows/154-daily-integration-26.10-oci.yml
+++ b/.github/workflows/154-daily-integration-26.10-oci.yml
@@ -1,0 +1,37 @@
+name: "Twice weekly 26.10: oci"
+
+on:
+  workflow_dispatch:
+    inputs:
+      install_source:
+        required: false
+        type: string
+        default: 'ppa:cloud-init-dev/daily'
+      image_type:
+        required: true
+        type: choice
+        options:
+        - generic
+        - minimal
+      filter_tests:
+        required: false
+        type: string
+  schedule:
+    # Run Mon & Thurs to reduce additional cost on shared external tokens
+    - cron: '2 22 * * 1,4'
+
+jobs:
+  stonking-oci:
+    uses: ./.github/workflows/100-dispatch-common.yml
+    with:
+      release: stonking
+      platform: oci
+      install_source: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
+      image_type: ${{ inputs.image_type || 'generic' }}
+      filter_tests: ${{ inputs.filter_tests }}
+    secrets:
+      PYCLOUDLIB_TOML_B64: ${{ secrets.PYCLOUDLIB_TOML_B64 }}
+      SSH_PUBLIC_KEY: ${{ secrets.SSH_PUBLIC_KEY }}
+      SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+      PYCLOUDLIB_OCI_CONFIG_B64: ${{ secrets.PYCLOUDLIB_OCI_CONFIG_B64 }}
+      PYCLOUDLIB_OCI_KEY_B64: ${{ secrets.PYCLOUDLIB_OCI_KEY_B64 }}


### PR DESCRIPTION
Followup to #6969 rename filter_tests -> test_posargs. Blocked by #6969 and now #7070
## Proposed Commit Message
```
refactor(ci): rename filter_tests input to test_posargs

The value is appended as trailing posargs to `tox -e integration-tests --`
(after the hardcoded --junitxml/--color flags), not a pytest -k/-m keyword
or marker filter expression. The old name implied keyword filtering, which
a positional path/node-ID argument is not; callers passing a bare keyword
would get a 'file or directory not found' error.

Rename to test_posargs to reflect tox terminology for arguments forwarded
after `--`, and update the description to document accepted forms (pytest
flags and/or positional test paths/node IDs) plus the full-suite default.

Updates the composite action, the dispatch-common reusable workflow, and all
20 daily integration workflows.
```

## Additional Context
Only topmost commit applicable for review: 41db952314d7517b29e835561eb0252c2515aecd
Await merge of #6969 before landing.

## Test Steps



## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
