### PR TITLE
docs: fix module schema property description for object types

### DIFF
--- a/doc/rtd/templates/module_property.tmpl
+++ b/doc/rtd/templates/module_property.tmpl
@@ -14,20 +14,22 @@
 {{prefix ~ '  '}}{{ line }}
 {% endfor -%}
 {%- endmacro -%}
-{% set ns = namespace(is_obj_type=false) -%}
+{% set ns = namespace(is_obj_type=false, is_list_type=false) -%}
 {% for alt_schema in prop_cfg.get("oneOf", []) -%}
   {% if ('properties' in alt_schema or 'patternProperties' in alt_schema) %}{% set ns.is_obj_type = true -%}{% endif -%}
 {% endfor -%}
 {% if ('properties' in prop_cfg or 'patternProperties' in prop_cfg) %}{% set ns.is_obj_type = true -%}{% endif -%}
 {% for key, val in prop_cfg.get('items', {}).items() -%}
-  {% if key in ('properties', 'patternProperties') -%}{% set ns.is_obj_type = true -%}{% endif -%}
+  {% if key in ('properties', 'patternProperties') -%}{% set ns.is_obj_type = true -%}{% set ns.is_list_type = true -%}{% endif -%}
   {% if key == 'oneOf' -%}
     {% for oneOf in val -%}
-      {% if ('properties' in oneOf or 'patternProperties' in oneOf ) -%}{% set ns.is_obj_type = true -%}{% endif -%}
+      {% if ('properties' in oneOf or 'patternProperties' in oneOf ) -%}{% set ns.is_obj_type = true -%}{% set ns.is_list_type = true -%}{% endif -%}
     {% endfor -%}
   {% endif -%}
 {% endfor -%}
-{% if ns.is_obj_type -%}
+{% if ns.is_list_type -%}
 {% set description = description ~ " Each object in **" ~ name ~ "** list supports the following keys:" -%}
+{% elif ns.is_obj_type -%}
+{% set description = description ~ " The **" ~ name ~ "** object supports the following keys:" -%}
 {% endif -%}
 {{ print_prop(name, types, description, deprecated, changed, prefix ) -}}


### PR DESCRIPTION
## Problem
When rendering module configuration schema documentation (such as for `write_files`), `module_property.tmpl` appended "Each object in `<name>` list supports the following keys:" to all properties with nested properties, even when the property is a single object (e.g. `source`), rather than a list of objects.

## Solution
- Updated `doc/rtd/templates/module_property.tmpl` to distinguish between list types (`items` containing properties) and single object types.
- Single object properties now correctly render "The `<name>` object supports the following keys:".

Fixes #7046

## Testing
- Verified template logic for list of object items vs direct object property specifications.