### PR TITLE
Map ROSA Linux to the fedora variant

### DIFF
--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -627,6 +627,11 @@ def _get_variant(info):
             variant = "ubuntu"
         elif linux_dist == "redhat":
             variant = "rhel"
+        elif linux_dist == "rosa":
+            # ROSA Linux is RPM/dnf-based with NetworkManager; reuse the
+            # Fedora structure: ds-identify under /usr/libexec, NetworkManager
+            # unit ordering and the sysconfig network renderer.
+            variant = "fedora"
         elif linux_dist in (
             "opensuse",
             "opensuse-leap",


### PR DESCRIPTION
ROSA is an RPM/dnf-based distro using NetworkManager, but it is not known to cloud-init, so system_info()["variant"] fell back to the generic "linux". As a result templates were rendered with the Debian layout: the systemd generator looked for ds-identify under /usr/lib/cloud-init instead of /usr/libexec/cloud-init, the service units got Debian-specific systemd ordering and the sysconfig network renderer reported itself unavailable.

Map the "rosa" distro id to the existing "fedora" variant so that ROSA reuses the Fedora structure everywhere.

