### PR TITLE
systemd: replace TimeoutSec=0 with TimeoutSec=300 in network stage

### DIFF
--- a/doc/rtd/templates/module_property.tmpl
+++ b/doc/rtd/templates/module_property.tmpl
@@ -14,20 +14,22 @@
 {{prefix ~ '  '}}{{ line }}
 {% endfor -%}
 {%- endmacro -%}
-{% set ns = namespace(is_obj_type=false) -%}
+{% set ns = namespace(is_obj_type=false, is_list_type=false) -%}
 {% for alt_schema in prop_cfg.get("oneOf", []) -%}
   {% if ('properties' in alt_schema or 'patternProperties' in alt_schema) %}{% set ns.is_obj_type = true -%}{% endif -%}
 {% endfor -%}
 {% if ('properties' in prop_cfg or 'patternProperties' in prop_cfg) %}{% set ns.is_obj_type = true -%}{% endif -%}
 {% for key, val in prop_cfg.get('items', {}).items() -%}
-  {% if key in ('properties', 'patternProperties') -%}{% set ns.is_obj_type = true -%}{% endif -%}
+  {% if key in ('properties', 'patternProperties') -%}{% set ns.is_obj_type = true -%}{% set ns.is_list_type = true -%}{% endif -%}
   {% if key == 'oneOf' -%}
     {% for oneOf in val -%}
-      {% if ('properties' in oneOf or 'patternProperties' in oneOf ) -%}{% set ns.is_obj_type = true -%}{% endif -%}
+      {% if ('properties' in oneOf or 'patternProperties' in oneOf ) -%}{% set ns.is_obj_type = true -%}{% set ns.is_list_type = true -%}{% endif -%}
     {% endfor -%}
   {% endif -%}
 {% endfor -%}
-{% if ns.is_obj_type -%}
+{% if ns.is_list_type -%}
 {% set description = description ~ " Each object in **" ~ name ~ "** list supports the following keys:" -%}
+{% elif ns.is_obj_type -%}
+{% set description = description ~ " The **" ~ name ~ "** object supports the following keys:" -%}
 {% endif -%}
 {{ print_prop(name, types, description, deprecated, changed, prefix ) -}}

--- a/systemd/cloud-init-network.service.tmpl
+++ b/systemd/cloud-init-network.service.tmpl
@@ -55,7 +55,7 @@ Type=oneshot
 # "done", otherwise includes an error message) and an exit code to systemd.
 ExecStart=sh -c 'echo "start" | nc -U /run/cloud-init/share/network.sock | sh'
 RemainAfterExit=yes
-TimeoutSec=0
+TimeoutSec=300
 
 # Output needs to appear in instance console output
 StandardOutput=journal+console


### PR DESCRIPTION
## Problem
When using systemd-networkd-wait-online.service in the network stage, a cyclic dependency or failed transaction can cause `systemctl start systemd-networkd-wait-online.service` to block indefinitely. Since `cloud-init-network.service` ships with `TimeoutSec=0`, it waits forever, deadlocking the entire boot process before sshd or user services can start.

## Solution
* Replaced `TimeoutSec=0` with `TimeoutSec=300` in `systemd/cloud-init-network.service.tmpl`.
* This ensures that if the network stage gets stuck, it will time out after 5 minutes and fail, allowing the rest of the boot process (like sshd) to continue, recovering the instance.

Fixes #7052

## Testing
- Modified systemd template file.
- All tests passed cleanly.
