### PR TITLE
fix(vultr): correct read_metadata format string and guard order in additional addresses

### DIFF
--- a/cloudinit/sources/helpers/vultr.py
+++ b/cloudinit/sources/helpers/vultr.py
@@ -156,7 +156,7 @@ def read_metadata(
 
     if not response.ok():
         raise RuntimeError(
-            "Failed to connect to %s: Code: %s" % url, response.code
+            "Failed to connect to %s: Code: %s" % (url, response.code)
         )
 
     return response.contents.decode()
@@ -268,8 +268,7 @@ def generate_interface_additional_addresses(
     interface: Mapping[str, Any], netcfg: Dict[str, Any]
 ) -> None:
     # Check for additional IP's
-    additional_count = len(interface["ipv4"]["additional"])
-    if "ipv4" in interface and additional_count > 0:
+    if "ipv4" in interface and len(interface["ipv4"]["additional"]) > 0:
         for additional in interface["ipv4"]["additional"]:
             add = {
                 "type": "static",
@@ -284,8 +283,7 @@ def generate_interface_additional_addresses(
             netcfg["subnets"].append(add)
 
     # Check for additional IPv6's
-    additional_count = len(interface["ipv6"]["additional"])
-    if "ipv6" in interface and additional_count > 0:
+    if "ipv6" in interface and len(interface["ipv6"]["additional"]) > 0:
         for additional in interface["ipv6"]["additional"]:
             add = {
                 "type": "static6",

--- a/tests/unittests/sources/test_vultr.py
+++ b/tests/unittests/sources/test_vultr.py
@@ -7,6 +7,7 @@
 
 import copy
 import json
+from typing import Any, Dict
 from unittest import mock
 
 import pytest
@@ -361,3 +362,67 @@ class TestDataSourceVultr:
         ds.get_metadata()
 
         assert mock_eph_init.call_args[1]["iface"] == FILTERED_INTERFACES[1]
+
+    @mock.patch("cloudinit.sources.helpers.vultr.url_helper.readurl")
+    def test_read_metadata_runtimeerror_on_connection_failure(self, mock_readurl):
+        response = mock.MagicMock()
+        response.ok.return_value = False
+        response.code = 404
+        mock_readurl.return_value = response
+
+        with pytest.raises(RuntimeError) as exc_info:
+            vultr.read_metadata(
+                "http://169.254.169.254",
+                timeout=1,
+                retries=1,
+                sec_between=1,
+                agent="cloud-init/test",
+            )
+
+        assert "Failed to connect to http://169.254.169.254/v1.json" in str(
+            exc_info.value
+        )
+        assert "404" in str(exc_info.value)
+
+    def test_generate_interface_additional_addresses_missing_ip_keys(self):
+        interface = {"mac": "56:00:03:15:c4:65"}
+        netcfg: Dict[str, Any] = {"subnets": []}
+
+        # Must not raise KeyError: 'ipv4' / 'ipv6'
+        vultr.generate_interface_additional_addresses(interface, netcfg)
+
+        assert netcfg["subnets"] == []
+
+    # Sanity check that the guarded len() still adds addresses when the
+    # "ipv4"/"ipv6" keys are present with non-empty additional lists.
+    def test_generate_interface_additional_addresses_adds_static(self):
+        interface = {
+            "mac": "56:00:03:15:c4:65",
+            "ipv4": {
+                "additional": [
+                    {"address": "10.0.0.10", "netmask": "255.255.255.0"}
+                ],
+            },
+            "ipv6": {
+                "additional": [
+                    {"network": "2001:19f0::", "prefix": "64"},
+                ],
+            },
+        }
+        netcfg: Dict[str, Any] = {"subnets": []}
+
+        vultr.generate_interface_additional_addresses(interface, netcfg)
+
+        assert netcfg["subnets"] == [
+            {
+                "type": "static",
+                "control": "auto",
+                "address": "10.0.0.10",
+                "netmask": "255.255.255.0",
+            },
+            {
+                "type": "static6",
+                "control": "auto",
+                "address": "2001:19f0::/64",
+            },
+        ]


### PR DESCRIPTION
## Proposed Commit Message

```
fix(vultr): correct read_metadata format string and guard order in additional addresses

Avoid TypeError in read_metadata for raised RuntimeError providing 2 required args.

Fix KeyError by performing validation of 'ipv4' and 'ipv6' in interface in
generate_interface_additional_addresses before referencing that key in len()
calculations.
```

## Additional Context

Resolve two pre-existing runtime bugs surfaced during review of #7051 which enabled
untyped-function checks on `cloudinit/sources/helpers/vultr.py`
## Test Steps

```
tox -e mypy -- cloudinit/sources/helpers/vultr.py
```

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
