### PR TITLE
fix(vultr): handle metadata and IP edge cases

### DIFF
--- a/cloudinit/sources/helpers/vultr.py
+++ b/cloudinit/sources/helpers/vultr.py
@@ -156,7 +156,7 @@ def read_metadata(
 
     if not response.ok():
         raise RuntimeError(
-            "Failed to connect to %s: Code: %s" % url, response.code
+            f"Failed to connect to {url}: Code: {response.code}"
         )
 
     return response.contents.decode()
@@ -268,8 +268,7 @@ def generate_interface_additional_addresses(
     interface: Mapping[str, Any], netcfg: Dict[str, Any]
 ) -> None:
     # Check for additional IP's
-    additional_count = len(interface["ipv4"]["additional"])
-    if "ipv4" in interface and additional_count > 0:
+    if "ipv4" in interface and interface["ipv4"]["additional"]:
         for additional in interface["ipv4"]["additional"]:
             add = {
                 "type": "static",
@@ -284,8 +283,7 @@ def generate_interface_additional_addresses(
             netcfg["subnets"].append(add)
 
     # Check for additional IPv6's
-    additional_count = len(interface["ipv6"]["additional"])
-    if "ipv6" in interface and additional_count > 0:
+    if "ipv6" in interface and interface["ipv6"]["additional"]:
         for additional in interface["ipv6"]["additional"]:
             add = {
                 "type": "static6",

--- a/tests/unittests/sources/test_vultr.py
+++ b/tests/unittests/sources/test_vultr.py
@@ -307,6 +307,66 @@ class TestDataSourceVultr:
             interf
         )
 
+    @mock.patch("cloudinit.sources.helpers.vultr.url_helper.readurl")
+    def test_read_metadata_failure_includes_url_and_status(self, m_readurl):
+        m_readurl.return_value.ok.return_value = False
+        m_readurl.return_value.code = 503
+
+        with pytest.raises(RuntimeError) as exc_info:
+            vultr.read_metadata(
+                "http://169.254.169.254", 5, 3, 1, "cloud-init"
+            )
+
+        assert exc_info.value.args == (
+            "Failed to connect to http://169.254.169.254/v1.json: Code: 503",
+        )
+
+    @pytest.mark.parametrize(
+        ("interface", "expected_subnet"),
+        (
+            (
+                {
+                    "ipv4": {
+                        "additional": [
+                            {
+                                "address": "192.0.2.10",
+                                "netmask": "255.255.255.0",
+                            }
+                        ]
+                    }
+                },
+                {
+                    "type": "static",
+                    "control": "auto",
+                    "address": "192.0.2.10",
+                    "netmask": "255.255.255.0",
+                },
+            ),
+            (
+                {
+                    "ipv6": {
+                        "additional": [
+                            {"network": "2001:db8::", "prefix": "64"}
+                        ]
+                    }
+                },
+                {
+                    "type": "static6",
+                    "control": "auto",
+                    "address": "2001:db8::/64",
+                },
+            ),
+        ),
+    )
+    def test_additional_addresses_allow_missing_address_family(
+        self, interface, expected_subnet
+    ):
+        netcfg = {"subnets": []}
+
+        vultr.generate_interface_additional_addresses(interface, netcfg)
+
+        assert netcfg["subnets"] == [expected_subnet]
+
     # Test Private Networking config generation
     @mock.patch("cloudinit.net.get_interfaces_by_mac")
     def test_private_network_config(self, mock_netmap):


### PR DESCRIPTION
## Proposed Commit Message

```
fix(vultr): handle metadata and IP edge cases

Construct failed metadata requests with a single formatted error message.
Skip unavailable IP families while adding secondary interface addresses.

Refs GH-7051
```

## Additional Context

This follows up on the two Vultr issues identified during review of #7051.
The error path now raises one useful message containing both the metadata URL
and HTTP status. Additional-address generation now handles interfaces that
omit either the ipv4 or ipv6 section. Runtime behavior is unchanged when both
sections are present.

No documentation update is needed because this corrects internal error and
network metadata handling without changing the user interface.

## Test Steps

```
.tox/py3/bin/pytest -q tests/unittests/sources/test_vultr.py
.tox/mypy/bin/mypy --platform linux cloudinit/
.tox/mypy/bin/ruff check cloudinit/sources/helpers/vultr.py tests/unittests/sources/test_vultr.py
.tox/mypy/bin/black --check cloudinit/sources/helpers/vultr.py tests/unittests/sources/test_vultr.py
.tox/mypy/bin/isort --check-only --diff cloudinit/sources/helpers/vultr.py tests/unittests/sources/test_vultr.py
.tox/mypy/bin/pylint cloudinit/sources/helpers/vultr.py
git diff --check
```

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)