### PR TITLE
fix(make-mime): preserve non-ASCII attachment filenames

### DIFF
--- a/cloudinit/cmd/devel/make_mime.py
+++ b/cloudinit/cmd/devel/make_mime.py
@@ -28,7 +28,7 @@ def create_mime_message(files):
         contents = fh.read()
         sub_message = MIMEText(contents, format_type, sys.getdefaultencoding())
         sub_message.add_header(
-            "Content-Disposition", 'attachment; filename="%s"' % (filename)
+            "Content-Disposition", "attachment", filename=filename
         )
         content_type = sub_message.get_content_type().lower()
         if content_type not in get_content_types():

--- a/tests/unittests/cmd/devel/test_make_mime.py
+++ b/tests/unittests/cmd/devel/test_make_mime.py
@@ -1,0 +1,43 @@
+# This file is part of cloud-init. See LICENSE file for license information.
+
+from email import message_from_string
+from io import StringIO
+
+import pytest
+
+from cloudinit.cmd.devel.make_mime import create_mime_message
+from cloudinit.user_data import UserDataProcessor
+
+
+@pytest.mark.parametrize(
+    "filename",
+    [
+        "config.yaml",
+        "my config.yaml",
+        'config"prod.yaml',
+        "config\\prod.yaml",
+        "café.yaml",
+        "إعداد.yaml",
+    ],
+)
+@pytest.mark.parametrize("process_user_data", [False, True])
+def test_attachment_filename_round_trip(
+    filename: str, process_user_data: bool, ud_proc: UserDataProcessor
+) -> None:
+    """Preserve attachment filenames when parsing generated MIME user-data."""
+    contents = "#cloud-config\nhostname: example\n"
+    message, errors = create_mime_message(
+        [(StringIO(contents), filename, "cloud-config")]
+    )
+    assert errors == []
+
+    serialized = message.as_string()
+    if process_user_data:
+        parsed = ud_proc.process(serialized)
+    else:
+        parsed = message_from_string(serialized)
+
+    [attachment] = parsed.get_payload()
+    assert attachment.get_filename() == filename
+    assert attachment.get_content_type() == "text/cloud-config"
+    assert attachment.get_payload(decode=True) == contents.encode("utf-8")


### PR DESCRIPTION
## Proposed Commit Message

```text
fix(make-mime): preserve non-ASCII attachment filenames
```

## Additional Context

`make-mime` loses filenames such as `café.yaml` and `إعداد.yaml` when its output is parsed: `get_filename()` returns `None`, and `UserDataProcessor` substitutes `part-001`. The attachment content is preserved.

Pass `filename` separately to `add_header` so Python applies RFC 2231 encoding, matching the existing pattern in `cloudinit/user_data.py`. No CLI options change.

## Test Steps

```sh
tox -e py3 -- tests/unittests/cmd/devel/test_make_mime.py --no-cov
tox -e py3
tox -e check_format
```

- Regression tests: 4 failures before the fix; all 12 cases pass afterward on Python 3.12 and 3.14, covering ASCII and Unicode filenames, content type, and payload.
- Full unit suite (Python 3.14): **5759 passed, 6 skipped, 13 xfailed**.
- Formatting and checks on the changed files pass. Full `check_format` remains unsuccessful locally: Python 3.12 reports Pylint `E1120` in `cloudinit/util.py:2142` (also reproduced on unmodified `main`), while Python 3.14 reports missing `crypt` imports in unchanged files.

<details>
<summary>CLI reproduction</summary>

Run from the checkout after creating the tox test environment. No VM is required.

```sh
.tox/py3/bin/python - <<'PY'
import email
import subprocess
import sys
import tempfile
from pathlib import Path

with tempfile.TemporaryDirectory() as directory:
    path = Path(directory) / "café.yaml"
    path.write_text("#cloud-config\nhostname: example\n", encoding="utf-8")
    result = subprocess.run(
        [sys.executable, "-m", "cloudinit.cmd.devel.make_mime",
         "-a", str(path) + ":cloud-config"],
        capture_output=True, text=True, check=True,
    )
    part = email.message_from_string(result.stdout).get_payload()[0]
    print("Parsed filename:", part.get_filename())
    assert part.get_filename() == str(path)
    assert part.get_payload(decode=True) == path.read_bytes()
PY
```

Before the fix, the filename assertion fails because the parsed filename is `None`. Afterward, both assertions pass. Temporary files are cleaned up automatically.

</details>

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
